### PR TITLE
Change warning for ktlint-gradle

### DIFF
--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -12,7 +12,7 @@ buildscript {
 
 ## Using with ktlint-gradle
 
-> **Warning**: This plugin doesn't currently support ktlint versions over 0.46.0, [they are working to support it right now](https://github.com/JLLeitschuh/ktlint-gradle/pull/595).
+> **Note**: You need at least version [11.1.0](https://github.com/JLLeitschuh/ktlint-gradle/releases/tag/v11.1.0) of this plugin.
 
 If using [ktlint-gradle](https://github.com/JLLeitschuh/ktlint-gradle), you can specify the dependency on this set of rules by using the `ktlintRuleset`.
 


### PR DESCRIPTION
Hey together,

we are currently evaluating if these rules can be applied in our project.
We are using the `ktlint-gradle` plugin.
We found the warning for this plugin. It says that ktlint in version 0.46.0 is not support by ktlint-gradle.
Just recently, they added support for this version. See https://github.com/JLLeitschuh/ktlint-gradle/releases/tag/v11.1.0
Therefore I thought it make sense to change the warning to an note 🙃 

Nevertheless, I still don't know **why** it requires a specific ktlint version. Maybe someone can explain this a bit more in detail and I can add more information regarding "a" specific ktlint version?! 🤔 

I have the feeling, because of this, it (ktlint-gradle) now requires to support ktlint 0.48.2 ? 🤔 🤷 

https://github.com/mrmans0n/compose-rules/blob/621eb8a51428ec0ddb99aab9339cf6952c434f41/gradle/libs.versions.toml#L3

Thanks 👍 