### PR TITLE
Add configuration to the ModifierMissing rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -32,6 +32,9 @@ Compose:
     active: true
   ModifierMissing:
     active: true
+    # You can optionally control the visibility of which composables to check for here
+    # Possible values are: only_public, public_and_internal_ all (default is only_public)
+    # checkModifiersForVisibility: only_public
   ModifierReused:
     active: true
   ModifierWithoutDefault:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -75,6 +75,20 @@ The `compose:naming-check` rule requires all composables that return a value to 
 compose_allowed_composable_function_names = .*Presenter,.*SomethingElse
 ```
 
+### Configure the visibility of the composables where to check for missing modifiers
+
+The `compose:modifier-missing-check` rule will, by default, only look for missing modifiers for public composables. If you want to lower the visibility threshold to check also internal compoosables, or all composables, you can configure it in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_check_modifiers_for_visibility = only_public
+```
+
+Possible values are:
+- `only_public`: (default) Will check for missing modifiers only for public composables.
+- `public_and_internal`: Will check for missing modifiers in both public and internal composables.
+- `all`: Will check for missing modifiers in all composables.
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `compose` tag.

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -24,6 +24,24 @@ val contentEmittersProperty: EditorConfigProperty<String> =
         },
     )
 
+val checkModifiersForVisibility: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_check_modifiers_for_visibility",
+            "Visibility of the composables where we want to check if a Modifier parameter is missing",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            setOf("only_public", "public_and_internal", "all"),
+        ),
+        defaultValue = "only_public",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> "only_public"
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
 val compositionLocalAllowlistProperty: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeCompositionLocalAllowlistCheckTest.kt
@@ -4,6 +4,7 @@ package io.nlopez.compose.rules.ktlint
 
 import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
 import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ComposeCompositionLocalAllowlist
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
@@ -26,22 +27,22 @@ class ComposeCompositionLocalAllowlistCheckTest {
                 LintViolation(
                     line = 1,
                     col = 13,
-                    detail = io.nlopez.compose.rules.ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
                 ),
                 LintViolation(
                     line = 2,
                     col = 14,
-                    detail = io.nlopez.compose.rules.ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
                 ),
                 LintViolation(
                     line = 3,
                     col = 5,
-                    detail = io.nlopez.compose.rules.ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
                 ),
                 LintViolation(
                     line = 4,
                     col = 13,
-                    detail = io.nlopez.compose.rules.ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
+                    detail = ComposeCompositionLocalAllowlist.CompositionLocalNotInAllowlist,
                 ),
             )
     }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierMissingCheckTest.kt
@@ -95,7 +95,7 @@ class ComposeModifierMissingCheckTest {
     }
 
     @Test
-    fun `non-public visibility Composables are ignored`() {
+    fun `non-public visibility Composables are ignored (by default)`() {
         @Language("kotlin")
         val code =
             """
@@ -123,6 +123,104 @@ class ComposeModifierMissingCheckTest {
                 }
             """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `public and internal visibility Composables are checked for 'public_and_internal' configuration`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    Row {
+                    }
+                }
+                @Composable
+                protected fun Something() {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                    }
+                }
+                @Composable
+                internal fun Something() {
+                    SomethingElse {
+                        Box(modifier = Modifier.fillMaxSize()) {
+                        }
+                    }
+                }
+                @Composable
+                private fun Something() {
+                    Whatever(modifier = Modifier.fillMaxSize()) {
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(checkModifiersForVisibility to "public_and_internal")
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposeModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 14,
+                    detail = ComposeModifierMissing.MissingModifierContentComposable,
+                ),
+            )
+    }
+
+    @Test
+    fun `all Composables are checked for 'all' configuration`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    Row {
+                    }
+                }
+                @Composable
+                protected fun Something() {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                    }
+                }
+                @Composable
+                internal fun Something() {
+                    SomethingElse {
+                        Box(modifier = Modifier.fillMaxSize()) {
+                        }
+                    }
+                }
+                @Composable
+                private fun Something() {
+                    Whatever(modifier = Modifier.fillMaxSize()) {
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(checkModifiersForVisibility to "all")
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposeModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 15,
+                    detail = ComposeModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 14,
+                    detail = ComposeModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 19,
+                    col = 13,
+                    detail = ComposeModifierMissing.MissingModifierContentComposable,
+                ),
+            )
     }
 
     @Test


### PR DESCRIPTION
Adds configurability to the ModifierMissing rule, so that now users can configure whether they want non-public composables to be also subject to this check. The current configuration, where only public composables run this rule, keeps being the default. Values `public_and_internal` and `all` are added.

Fixes #25