### PR TITLE
Allow custom configuration of ViewModel factories

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -65,6 +65,8 @@ Compose:
     active: true
   ViewModelInjection:
     active: true
+    # You can optionally add your own ViewModel factories here
+    # viewModelFactories: hiltViewModel,potatoViewModel
 ```
 
 ### Disabling a specific rule

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -48,6 +48,15 @@ There are some rules (`compose:content-emitter-returning-values-check` and `comp
 compose_content_emitters = MyComposable,MyOtherComposable
 ```
 
+### Providing custom ViewModel factories
+
+The `vm-injection-check` rule will check against common ViewModel factories (eg `viewModel` from AAC, `weaverViewModel` from Weaver, `hiltViewModel` from Hilt + Compose, etc), but you can configure your `.editorconfig` file to add your own, as a list of comma-separated strings:
+
+```editorconfig
+[*.{kt,kts}]
+compose_view_model_factories = myViewModel,potatoViewModel
+```
+
 ### Providing a list of allowed `CompositionLocal`s
 
 For `compositionlocal-allowlist` rule you can define a list of `CompositionLocal`s that are allowed in your codebase.
@@ -68,7 +77,7 @@ compose_preview_public_only_if_params = false
 
 ### Allowing matching function names
 
-The `compose:naming-check` rule requires all composables that return a value to be lowercased. If you want to allow certain patterns though, you can configure a comma-separated list of matching regexes in your `.editorconfig` file:
+The `naming-check` rule requires all composables that return a value to be lowercased. If you want to allow certain patterns though, you can configure a comma-separated list of matching regexes in your `.editorconfig` file:
 
 ```editorconfig
 [*.{kt,kts}]
@@ -77,7 +86,7 @@ compose_allowed_composable_function_names = .*Presenter,.*SomethingElse
 
 ### Configure the visibility of the composables where to check for missing modifiers
 
-The `compose:modifier-missing-check` rule will, by default, only look for missing modifiers for public composables. If you want to lower the visibility threshold to check also internal compoosables, or all composables, you can configure it in your `.editorconfig` file:
+The `modifier-missing-check` rule will, by default, only look for missing modifiers for public composables. If you want to lower the visibility threshold to check also internal compoosables, or all composables, you can configure it in your `.editorconfig` file:
 
 ```editorconfig
 [*.{kt,kts}]
@@ -85,18 +94,18 @@ compose_check_modifiers_for_visibility = only_public
 ```
 
 Possible values are:
-- `only_public`: (default) Will check for missing modifiers only for public composables.
-- `public_and_internal`: Will check for missing modifiers in both public and internal composables.
-- `all`: Will check for missing modifiers in all composables.
+* `only_public`: (default) Will check for missing modifiers only for public composables.
+* `public_and_internal`: Will check for missing modifiers in both public and internal composables.
+* `all`: Will check for missing modifiers in all composables.
 
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `compose` tag.
 
-For example, to disable `compose-naming-check`, the tag you'll need to disable is `compose:compose-naming-check`.
+For example, to disable the `naming-check` rule, the tag you'll need to disable is `compose:naming-check`.
 
 ```kotlin
-    /* ktlint-disable compose:compose-naming-check */
+    /* ktlint-disable compose:naming-check */
     ... your code here
-    /* ktlint-enable compose:compose-naming-check */
+    /* ktlint-enable compose:naming-check */
 ```

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeViewModelInjectionCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeViewModelInjectionCheckTest.kt
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.detekt
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import io.nlopez.compose.rules.ComposeViewModelInjection
@@ -12,11 +12,13 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class ComposeViewModelInjectionCheckTest {
-
-    private val rule = ComposeViewModelInjectionCheck(Config.empty)
+    private val testConfig = TestConfig(
+        "viewModelFactories" to listOf("bananaViewModel", "potatoViewModel"),
+    )
+    private val rule = ComposeViewModelInjectionCheck(testConfig)
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `passes when a weaverViewModel is used as a default param`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -33,7 +35,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `overridden functions are ignored`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -48,7 +50,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `errors when a weaverViewModel is used at the beginning of a Composable`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -79,7 +81,7 @@ class ComposeViewModelInjectionCheckTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `errors when a weaverViewModel is used in different branches`(viewModel: String) {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -90,3 +90,21 @@ val allowedComposeNamingNames: EditorConfigProperty<String> =
             }
         },
     )
+
+val viewModelFactories: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_view_model_factories",
+            "A comma separated list of ViewModel factory methods",
+            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelInjectionCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelInjectionCheckTest.kt
@@ -14,7 +14,7 @@ class ComposeViewModelInjectionCheckTest {
     private val injectionRuleAssertThat = assertThatRule { ComposeViewModelInjectionCheck() }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `passes when a weaverViewModel is used as a default param`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -26,11 +26,13 @@ class ComposeViewModelInjectionCheckTest {
                 viewModel2: MyVM = $viewModel(),
             ) { }
             """.trimIndent()
-        injectionRuleAssertThat(code).hasNoLintViolations()
+        injectionRuleAssertThat(code)
+            .withEditorConfigOverride(viewModelFactories to "bananaViewModel,potatoViewModel")
+            .hasNoLintViolations()
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `overridden functions are ignored`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -40,11 +42,13 @@ class ComposeViewModelInjectionCheckTest {
                 val viewModel = $viewModel<MyVM>()
             }
             """.trimIndent()
-        injectionRuleAssertThat(code).hasNoLintViolations()
+        injectionRuleAssertThat(code)
+            .withEditorConfigOverride(viewModelFactories to "bananaViewModel,potatoViewModel")
+            .hasNoLintViolations()
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `errors when a weaverViewModel is used at the beginning of a Composable`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -62,27 +66,29 @@ class ComposeViewModelInjectionCheckTest {
                 val viewModel: MyVM = $viewModel()
             }
             """.trimIndent()
-        injectionRuleAssertThat(code).hasLintViolations(
-            LintViolation(
-                line = 3,
-                col = 9,
-                detail = ComposeViewModelInjection.errorMessage(viewModel),
-            ),
-            LintViolation(
-                line = 7,
-                col = 9,
-                detail = ComposeViewModelInjection.errorMessage(viewModel),
-            ),
-            LintViolation(
-                line = 11,
-                col = 9,
-                detail = ComposeViewModelInjection.errorMessage(viewModel),
-            ),
-        )
+        injectionRuleAssertThat(code)
+            .withEditorConfigOverride(viewModelFactories to "bananaViewModel,potatoViewModel")
+            .hasLintViolations(
+                LintViolation(
+                    line = 3,
+                    col = 9,
+                    detail = ComposeViewModelInjection.errorMessage(viewModel),
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 9,
+                    detail = ComposeViewModelInjection.errorMessage(viewModel),
+                ),
+                LintViolation(
+                    line = 11,
+                    col = 9,
+                    detail = ComposeViewModelInjection.errorMessage(viewModel),
+                ),
+            )
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `errors when a weaverViewModel is used in different branches`(viewModel: String) {
         @Language("kotlin")
         val code =
@@ -96,22 +102,24 @@ class ComposeViewModelInjectionCheckTest {
                 }
             }
             """.trimIndent()
-        injectionRuleAssertThat(code).hasLintViolations(
-            LintViolation(
-                line = 4,
-                col = 13,
-                detail = ComposeViewModelInjection.errorMessage(viewModel),
-            ),
-            LintViolation(
-                line = 6,
-                col = 13,
-                detail = ComposeViewModelInjection.errorMessage(viewModel),
-            ),
-        )
+        injectionRuleAssertThat(code)
+            .withEditorConfigOverride(viewModelFactories to "bananaViewModel,potatoViewModel")
+            .hasLintViolations(
+                LintViolation(
+                    line = 4,
+                    col = 13,
+                    detail = ComposeViewModelInjection.errorMessage(viewModel),
+                ),
+                LintViolation(
+                    line = 6,
+                    col = 13,
+                    detail = ComposeViewModelInjection.errorMessage(viewModel),
+                ),
+            )
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `fix no args composable function adds the code inside the parentheses`(viewModel: String) {
         @Language("kotlin")
         val badCode = """
@@ -135,11 +143,13 @@ class ComposeViewModelInjectionCheckTest {
             }
         """.trimIndent()
 
-        injectionRuleAssertThat(badCode).isFormattedAs(expectedCode)
+        injectionRuleAssertThat(badCode)
+            .withEditorConfigOverride(viewModelFactories to "bananaViewModel,potatoViewModel")
+            .isFormattedAs(expectedCode)
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `fix normal args composable function adds the new code at the end`(viewModel: String) {
         @Language("kotlin")
         val badCode = """
@@ -162,11 +172,13 @@ class ComposeViewModelInjectionCheckTest {
             fun MyComposable(modifier: Modifier = Modifier,viewModel: MyVM = $viewModel(),) {
             }
         """.trimIndent()
-        injectionRuleAssertThat(badCode).isFormattedAs(expectedCode)
+        injectionRuleAssertThat(badCode)
+            .withEditorConfigOverride(viewModelFactories to "bananaViewModel,potatoViewModel")
+            .isFormattedAs(expectedCode)
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel"])
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
     fun `fix trailing lambda args composable function adds the new code before the trailing lambda`(viewModel: String) {
         @Language("kotlin")
         val badCode = """
@@ -202,6 +214,8 @@ class ComposeViewModelInjectionCheckTest {
             ) {
             }
         """.trimIndent()
-        injectionRuleAssertThat(badCode).isFormattedAs(expectedCode)
+        injectionRuleAssertThat(badCode)
+            .withEditorConfigOverride(viewModelFactories to "bananaViewModel,potatoViewModel")
+            .isFormattedAs(expectedCode)
     }
 }


### PR DESCRIPTION
Previously, only known ViewModel factories (e.g. "viewModel", "weaverViewModel", "hiltViewModel", "injectedViewModel", "mavericksViewModel") were taking into account when checking for their proper injection in composables.

This patch allows configuration of custom factories in the user codebase. 