### PR TITLE
Fix ComposeNaming rule being applied to operators

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtFunctions.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtFunctions.kt
@@ -35,5 +35,8 @@ val KtFunction.isExpect: Boolean
 val KtFunction.isAbstract: Boolean
     get() = hasModifier(KtTokens.ABSTRACT_KEYWORD)
 
+val KtFunction.isOperator: Boolean
+    get() = hasModifier(KtTokens.OPERATOR_KEYWORD)
+
 val KtFunction.definedInInterface: Boolean
     get() = ((parent as? KtClassBody)?.parent as? KtClass)?.isInterface() ?: false

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeCompositionLocalAllowlist.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeCompositionLocalAllowlist.kt
@@ -25,7 +25,7 @@ class ComposeCompositionLocalAllowlist : ComposeKtVisitor {
         for (compositionLocal in notAllowed) {
             emitter.report(
                 compositionLocal,
-                io.nlopez.compose.rules.ComposeCompositionLocalAllowlist.Companion.CompositionLocalNotInAllowlist,
+                CompositionLocalNotInAllowlist,
             )
         }
     }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeNaming.kt
@@ -7,14 +7,19 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
 import io.nlopez.rules.core.util.hasReceiverType
+import io.nlopez.rules.core.util.isOperator
 import io.nlopez.rules.core.util.returnsValue
 import org.jetbrains.kotlin.psi.KtFunction
 
 class ComposeNaming : ComposeKtVisitor {
 
     override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
-        // If it's a block we can't know if there is a return type or not from ktlint
+        // If it's a block we can't know if there is a return type or not
         if (!function.hasBlockBody()) return
+
+        // Operators have fixed names that we can't modify, so this rule is useless in that case
+        if (function.isOperator) return
+
         val functionName = function.name?.takeUnless(String::isEmpty) ?: return
         val firstLetter = functionName.first()
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeNamingCheckTest.kt
@@ -125,4 +125,17 @@ class ComposeNamingCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes when a composable is an operator function even if the naming should be wrong`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                operator fun invoke() { }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeNamingCheckTest.kt
@@ -126,4 +126,16 @@ class ComposeNamingCheckTest {
 
         namingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when a composable is an operator function even if the naming should be wrong`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                operator fun invoke() { }
+            """.trimIndent()
+
+        namingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
ComposeNaming shouldn't be applied if the method is an `operator fun`, as those have fixed names and we can't argue against kotlin itself. Fixes #36.