### PR TITLE
Update detekt to 1.23.0

### DIFF
--- a/core-detekt/src/test/kotlin/io/nlopez/rules/core/detekt/DetektComposeKtConfigTest.kt
+++ b/core-detekt/src/test/kotlin/io/nlopez/rules/core/detekt/DetektComposeKtConfigTest.kt
@@ -7,18 +7,15 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 
 class DetektComposeKtConfigTest {
-
-    private val mapping = mutableMapOf<String, Any>().apply {
-        put("myInt", 10)
-        put("myString", "abcd")
-        put("myList", "a,b,c,a")
-        put("myList2", "a , b , c,a")
-        put("mySet", "a,b,c,a,b,c")
-        put("mySet2", "  a, b,c ,a  , b  ,  c ")
-        put("myBool", true)
-    }
-
-    private val detektConfig = TestConfig(mapping)
+    private val detektConfig = TestConfig(
+        "myInt" to 10,
+        "myString" to "abcd",
+        "myList" to "a,b,c,a",
+        "myList2" to "a , b , c,a",
+        "mySet" to "a,b,c,a,b,c",
+        "mySet2" to "  a, b,c ,a  , b  ,  c ",
+        "myBool" to true,
+    )
     private val config = DetektComposeKtConfig(detektConfig)
 
     @Test
@@ -52,32 +49,5 @@ class DetektComposeKtConfigTest {
     fun `returns booleans from Config, and default values when unset`() {
         assertThat(config.getBoolean("myBool", false)).isTrue()
         assertThat(config.getBoolean("myOtherBool", false)).isFalse()
-    }
-
-    @Test
-    fun `results are memoized`() {
-        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
-        assertThat(config.getString("myString", null)).isEqualTo("abcd")
-        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
-        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
-        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
-        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
-        assertThat(config.getBoolean("myBool", false)).isTrue()
-
-        mapping["myInt"] = 100
-        mapping["myString"] = "XYZ"
-        mapping["myList"] = "z,y,x"
-        mapping["myList2"] = "z,y"
-        mapping["mySet"] = "a"
-        mapping["mySet2"] = "a, b"
-        mapping["myBool"] = false
-
-        assertThat(config.getInt("myInt", 0)).isEqualTo(10)
-        assertThat(config.getString("myString", null)).isEqualTo("abcd")
-        assertThat(config.getList("myList", emptyList())).containsExactly("a", "b", "c", "a")
-        assertThat(config.getList("myList2", emptyList())).containsExactly("a", "b", "c", "a")
-        assertThat(config.getSet("mySet", emptySet())).containsExactly("a", "b", "c")
-        assertThat(config.getSet("mySet2", emptySet())).containsExactly("a", "b", "c")
-        assertThat(config.getBoolean("myBool", false)).isTrue()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.8.21"
 ktlint = "0.49.1"
-detekt = "1.22.0"
+detekt = "1.23.0"
 junit = "5.9.3"
 
 [libraries]


### PR DESCRIPTION
Updates detekt to 1.23.0, and fixes the Detekt config test that failed due to a new deprecation.