### PR TITLE
Use spotless with ktlint 0.49.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,7 @@ subprojects {
     spotless {
         kotlin {
             target "**/*.kt"
-            // TODO update when 0.49.x is supported by spotless ktlint(libs.versions.ktlint.get())
-            ktlint("0.48.2")
+            ktlint(libs.versions.ktlint.get())
             licenseHeaderFile rootProject.file('spotless/copyright.txt')
         }
         groovyGradle {


### PR DESCRIPTION
Update the spotless configuration to use the same ktlint version as the one being used in the rest of the project.