### PR TITLE
Allow nullable types for trailing lambdas in ComposeParameterOrder

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeParameterOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeParameterOrder.kt
@@ -9,6 +9,7 @@ import io.nlopez.rules.core.util.isModifier
 import io.nlopez.rules.core.util.runIf
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtParameter
 
 class ComposeParameterOrder : ComposeKtVisitor {
@@ -52,7 +53,12 @@ class ComposeParameterOrder : ComposeKtVisitor {
     }
 
     private val KtFunction.hasTrailingFunction: Boolean
-        get() = valueParameters.lastOrNull()?.typeReference?.typeElement is KtFunctionType
+        get() =
+            when (val outerType = valueParameters.lastOrNull()?.typeReference?.typeElement) {
+                is KtFunctionType -> true
+                is KtNullableType -> outerType.innerType is KtFunctionType
+                else -> false
+            }
 
     companion object {
         fun createErrorMessage(currentOrder: List<KtParameter>, properOrder: List<KtParameter>): String =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeParameterOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeParameterOrderCheckTest.kt
@@ -27,6 +27,9 @@ class ComposeParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
         """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeParameterOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeParameterOrderCheckTest.kt
@@ -26,6 +26,9 @@ class ComposeParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
         """.trimIndent()
         orderingRuleAssertThat(code).hasNoLintViolations()
     }


### PR DESCRIPTION
Fixes #59 