### PR TITLE
Report all non-public composables unconditionally

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -55,8 +55,6 @@ Compose:
     active: true
   PreviewPublic:
     active: true
-    # You can optionally disable that only previews with @PreviewParameter are flagged
-    # previewPublicOnlyIfParams: false
   RememberMissing:
     active: true
   UnstableCollections:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -66,15 +66,6 @@ For `compositionlocal-allowlist` rule you can define a list of `CompositionLocal
 compose_allowed_composition_locals = LocalSomething,LocalSomethingElse
 ```
 
-### Make it so that all @Preview composables must be not public, no exceptions
-
-In `preview-public-check`, only previews with a `@PreviewParameter` are required to be non-public by default. However, if you want to make it so ALL `@Preview` composables are non-public, you can add this to your `.editorconfig` file:
-
-```editorconfig
-[*.{kt,kts}]
-compose_preview_public_only_if_params = false
-```
-
 ### Allowing matching function names
 
 The `naming-check` rule requires all composables that return a value to be lowercased. If you want to allow certain patterns though, you can configure a comma-separated list of matching regexes in your `.editorconfig` file:

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposePreviewPublic.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposePreviewPublic.kt
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
-import io.nlopez.rules.core.ComposeKtConfig.Companion.config
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.isPreview
-import io.nlopez.rules.core.util.isPreviewParameter
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
@@ -19,13 +17,6 @@ class ComposePreviewPublic : ComposeKtVisitor {
         // We only care about public methods
         if (!function.isPublic) return
 
-        // If the method is public, none of it's params should be tagged as preview
-        // This is configurable by the `previewPublicOnlyIfParams` config value
-        if (function.config().getBoolean("previewPublicOnlyIfParams", true)) {
-            if (function.valueParameters.none { it.isPreviewParameter }) return
-        }
-
-        // If we got here, it's a public method in a @Preview composable with a @PreviewParameter parameter
         emitter.report(function, ComposablesPreviewShouldNotBePublic, true)
         if (autoCorrect) {
             function.addModifier(KtTokens.PRIVATE_KEYWORD)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposePreviewPublicCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposePreviewPublicCheckTest.kt
@@ -4,7 +4,6 @@ package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import io.nlopez.compose.rules.ComposePreviewPublic
@@ -28,7 +27,7 @@ class ComposePreviewPublicCheckTest {
     }
 
     @Test
-    fun `passes for preview public composables that don't have preview params`() {
+    fun `errors for preview public composables`() {
         @Language("kotlin")
         val code =
             """
@@ -38,54 +37,11 @@ class ComposePreviewPublicCheckTest {
             @CombinedPreviews
             @Composable
             fun MyComposable() { }
-            """.trimIndent()
-        val errors = rule.lint(code)
-        assertThat(errors).isEmpty()
-    }
-
-    @Test
-    fun `errors when a public preview composable is used when previewPublicOnlyIfParams is false`() {
-        val config = TestConfig("previewPublicOnlyIfParams" to false)
-        val ruleWithParams = ComposePreviewPublicCheck(config)
-
-        @Language("kotlin")
-        val code =
-            """
-            @Preview
-            @Composable
-            fun MyComposable() { }
-            @CombinedPreviews
-            @Composable
-            fun MyComposable() { }
-            """.trimIndent()
-        val errors = ruleWithParams.lint(code)
-        assertThat(errors).hasStartSourceLocations(
-            SourceLocation(3, 5),
-            SourceLocation(6, 5),
-        )
-        for (error in errors) {
-            assertThat(error).hasMessage(ComposePreviewPublic.ComposablesPreviewShouldNotBePublic)
-        }
-    }
-
-    @Test
-    fun `errors when a public preview composable uses preview params`() {
-        @Language("kotlin")
-        val code =
-            """
-            @Preview
-            @Composable
-            fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
-            @CombinedPreviews
-            @Composable
-            fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).hasStartSourceLocations(
             SourceLocation(3, 5),
-            SourceLocation(7, 5),
+            SourceLocation(6, 5),
         )
         for (error in errors) {
             assertThat(error).hasMessage(ComposePreviewPublic.ComposablesPreviewShouldNotBePublic)
@@ -99,29 +55,11 @@ class ComposePreviewPublicCheckTest {
             """
             @Preview
             @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
+            private fun MyComposable(user: User) {
             }
             @CombinedPreviews
             @Composable
-            internal fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
-            """.trimIndent()
-        val errors = rule.lint(code)
-        assertThat(errors).isEmpty()
-    }
-
-    @Test
-    fun `passes when a private preview composable uses preview params`() {
-        @Language("kotlin")
-        val code =
-            """
-            @Preview
-            @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
-            @CombinedPreviews
-            @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
+            internal fun MyComposable(user: User) {
             }
             """.trimIndent()
         val errors = rule.lint(code)

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposePreviewPublicCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposePreviewPublicCheck.kt
@@ -7,8 +7,5 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
 class ComposePreviewPublicCheck :
-    KtlintRule(
-        id = "compose:preview-public-check",
-        editorConfigProperties = setOf(previewPublicOnlyIfParams),
-    ),
+    KtlintRule("compose:preview-public-check"),
     ComposeKtVisitor by ComposePreviewPublic()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -60,19 +60,6 @@ val compositionLocalAllowlistProperty: EditorConfigProperty<String> =
         },
     )
 
-val previewPublicOnlyIfParams: EditorConfigProperty<Boolean> =
-    EditorConfigProperty(
-        type = PropertyType.LowerCasingPropertyType(
-            "compose_preview_public_only_if_params",
-            "If set to true, it means ",
-            //
-            PropertyValueParser.BOOLEAN_VALUE_PARSER,
-            "true",
-            "false",
-        ),
-        defaultValue = true,
-    )
-
 val allowedComposeNamingNames: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposePreviewPublicCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposePreviewPublicCheckTest.kt
@@ -24,7 +24,7 @@ class ComposePreviewPublicCheckTest {
     }
 
     @Test
-    fun `passes for preview public composables that don't have preview params`() {
+    fun `errors for preview public composables`() {
         @Language("kotlin")
         val code =
             """
@@ -34,23 +34,6 @@ class ComposePreviewPublicCheckTest {
             @CombinedPreviews
             @Composable
             fun MyComposable() { }
-            """.trimIndent()
-        ruleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
-    fun `errors when a public preview composable uses preview params`() {
-        @Language("kotlin")
-        val code =
-            """
-            @Preview
-            @Composable
-            fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
-            @CombinedPreviews
-            @Composable
-            fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
             """.trimIndent()
         ruleAssertThat(code).hasLintViolations(
             LintViolation(
@@ -59,39 +42,11 @@ class ComposePreviewPublicCheckTest {
                 detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic,
             ),
             LintViolation(
-                line = 7,
+                line = 6,
                 col = 5,
                 detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic,
             ),
         )
-    }
-
-    @Test
-    fun `errors when a public preview composable is used when previewPublicOnlyIfParams is false`() {
-        @Language("kotlin")
-        val code =
-            """
-            @Preview
-            @Composable
-            fun MyComposable() { }
-            @CombinedPreviews
-            @Composable
-            fun MyComposable() { }
-            """.trimIndent()
-        ruleAssertThat(code)
-            .withEditorConfigOverride(previewPublicOnlyIfParams to false)
-            .hasLintViolations(
-                LintViolation(
-                    line = 3,
-                    col = 5,
-                    detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic,
-                ),
-                LintViolation(
-                    line = 6,
-                    col = 5,
-                    detail = ComposePreviewPublic.ComposablesPreviewShouldNotBePublic,
-                ),
-            )
     }
 
     @Test
@@ -101,11 +56,11 @@ class ComposePreviewPublicCheckTest {
             """
             @Preview
             @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
+            private fun MyComposable(user: User) {
             }
             @CombinedPreviews
             @Composable
-            internal fun MyComposable(@PreviewParameter(User::class) user: User) {
+            internal fun MyComposable(user: User) {
             }
             """.trimIndent()
         ruleAssertThat(code).hasNoLintViolations()
@@ -117,11 +72,11 @@ class ComposePreviewPublicCheckTest {
         val badCode = """
             @Preview
             @Composable
-            fun MyComposable(@PreviewParameter(User::class) user: User) {
+            fun MyComposable(user: User) {
             }
             @CombinedPreviews
             @Composable
-            fun MyComposable(@PreviewParameter(User::class) user: User) {
+            fun MyComposable(user: User) {
             }
         """.trimIndent()
 
@@ -129,30 +84,13 @@ class ComposePreviewPublicCheckTest {
         val expectedCode = """
             @Preview
             @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
+            private fun MyComposable(user: User) {
             }
             @CombinedPreviews
             @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
+            private fun MyComposable(user: User) {
             }
         """.trimIndent()
         ruleAssertThat(badCode).isFormattedAs(expectedCode)
-    }
-
-    @Test
-    fun `passes when a private preview composable uses preview params`() {
-        @Language("kotlin")
-        val code =
-            """
-            @Preview
-            @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
-            @CombinedPreviews
-            @Composable
-            private fun MyComposable(@PreviewParameter(User::class) user: User) {
-            }
-            """.trimIndent()
-        ruleAssertThat(code).hasNoLintViolations()
     }
 }


### PR DESCRIPTION
Make it so all public composables that are previews are disallowed. Private and internal methods are good to go.

For a bit of context, historically this was gated so that if the public param had a PreviewParameter annotation, we would be sure it's for sure only used for previews, as the Twitter for Android codebase (which was its original test bed) had a bunch of preview composables on public methods, and I just wanted to get out of the way there. But they shouldn't really be public if they are annotated, even if this causes duplication -- just a matter of addressing possible future footguns: if they are really public, it means they can be consumed from other gradle modules, which means it's a public facing API, which means it should NOT be exposing a preview.

Fixes #24, although indirectly, as the behavior with the custom param is no longer there.