### PR TITLE
Detect all vm forwarding violations regardless of nesting level

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeViewModelForwarding.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeViewModelForwarding.kt
@@ -5,7 +5,7 @@ package io.nlopez.compose.rules
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.definedInInterface
-import io.nlopez.rules.core.util.findDirectChildrenByClass
+import io.nlopez.rules.core.util.findChildrenByClass
 import io.nlopez.rules.core.util.isActual
 import io.nlopez.rules.core.util.isOverride
 import io.nlopez.rules.core.util.isRestartableEffect
@@ -31,7 +31,7 @@ class ComposeViewModelForwarding : ComposeKtVisitor {
 
         // We want now to see if these parameter names are used in any other calls to functions that start with
         // a capital letter (so, most likely, composables).
-        bodyBlock.findDirectChildrenByClass<KtCallExpression>()
+        bodyBlock.findChildrenByClass<KtCallExpression>()
             .filter { callExpression -> callExpression.calleeExpression?.text?.first()?.isUpperCase() ?: false }
             // Avoid LaunchedEffect/DisposableEffect/etc that can use the VM as a key
             .filterNot { callExpression -> callExpression.isRestartableEffect }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeViewModelForwardingCheckTest.kt
@@ -3,6 +3,7 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import io.nlopez.compose.rules.ComposeViewModelForwarding
@@ -69,10 +70,26 @@ class ComposeViewModelForwardingCheckTest {
             fun MyComposable(viewModel: MyViewModel) {
                 AnotherComposable(viewModel)
             }
+            @Composable
+            fun MyComposable2(viewModel: MyViewModel) {
+                Row {
+                    AnotherComposable(viewModel)
+                }
+            }
+            @Composable
+            fun MyComposable3(viewModel: MyViewModel) {
+                AnotherComposable(vm = viewModel)
+            }
             """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(1).hasStartSourceLocation(3, 5)
-        assertThat(errors.first()).hasMessage(ComposeViewModelForwarding.AvoidViewModelForwarding)
+        assertThat(errors).hasStartSourceLocations(
+            SourceLocation(3, 5),
+            SourceLocation(8, 9),
+            SourceLocation(13, 5),
+        )
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposeViewModelForwarding.AvoidViewModelForwarding)
+        }
     }
 
     @Test

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelForwardingCheckTest.kt
@@ -65,10 +65,30 @@ class ComposeViewModelForwardingCheckTest {
             fun MyComposable(viewModel: MyViewModel) {
                 AnotherComposable(viewModel)
             }
+            @Composable
+            fun MyComposable2(viewModel: MyViewModel) {
+                Row {
+                    AnotherComposable(viewModel)
+                }
+            }
+            @Composable
+            fun MyComposable3(viewModel: MyViewModel) {
+                AnotherComposable(vm = viewModel)
+            }
             """.trimIndent()
         forwardingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
             LintViolation(
                 line = 3,
+                col = 5,
+                detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
+            ),
+            LintViolation(
+                line = 8,
+                col = 9,
+                detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
+            ),
+            LintViolation(
+                line = 13,
                 col = 5,
                 detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
             ),


### PR DESCRIPTION
Honestly I don't remember why this rule was constrained to the top statements in a composable. It makes sense this is done in all levels. 

Now it will also flag things like:

```kotlin
@Composable
fun MyComposable2(viewModel: MyViewModel) {
  Row {
    AnotherComposable(viewModel)
  }
}
```