### PR TITLE
Add a rule to enforce correct naming of Modifier parameters

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
@@ -47,9 +47,9 @@ val KtCallExpression.emitsContent: Boolean
     get() {
         val methodName = calleeExpression?.text ?: return false
         val providedContentEmitters = config().getSet("contentEmitters", emptySet())
-        return ComposableEmittersList.contains(methodName) ||
+        return methodName in ComposableEmittersList ||
             ComposableEmittersListRegex.matches(methodName) ||
-            providedContentEmitters.contains(methodName) ||
+            methodName in providedContentEmitters ||
             containsComposablesWithModifiers
     }
 
@@ -160,10 +160,10 @@ val ModifierNames by lazy(LazyThreadSafetyMode.NONE) {
 }
 
 val KtCallableDeclaration.isModifier: Boolean
-    get() = ModifierNames.contains(typeReference?.text)
+    get() = typeReference?.text in ModifierNames
 
 val KtCallableDeclaration.isModifierReceiver: Boolean
-    get() = ModifierNames.contains(receiverTypeReference?.text)
+    get() = receiverTypeReference?.text in ModifierNames
 
 val KtFunction.modifierParameter: KtParameter?
     get() {
@@ -175,9 +175,7 @@ val KtProperty.declaresCompositionLocal: Boolean
     get() = !isVar &&
         hasInitializer() &&
         initializer is KtCallExpression &&
-        CompositionLocalReferenceExpressions.contains(
-            (initializer as KtCallExpression).referenceExpression()?.text,
-        )
+        (initializer as KtCallExpression).referenceExpression()?.text in CompositionLocalReferenceExpressions
 
 private val CompositionLocalReferenceExpressions by lazy(LazyThreadSafetyMode.NONE) {
     setOf(
@@ -187,7 +185,7 @@ private val CompositionLocalReferenceExpressions by lazy(LazyThreadSafetyMode.NO
 }
 
 val KtCallExpression.isRestartableEffect: Boolean
-    get() = RestartableEffects.contains(calleeExpression?.text)
+    get() = calleeExpression?.text in RestartableEffects
 
 // From https://developer.android.com/jetpack/compose/side-effects#restarting-effects
 private val RestartableEffects by lazy(LazyThreadSafetyMode.NONE) {

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -36,7 +36,7 @@ Compose:
     # Possible values are: `only_public`, `public_and_internal` and `all` (default is `only_public`)
     # checkModifiersForVisibility: only_public
   ModifierNaming:
-      active: true
+    active: true
   ModifierReused:
     active: true
   ModifierWithoutDefault:

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -35,6 +35,8 @@ Compose:
     # You can optionally control the visibility of which composables to check for here
     # Possible values are: `only_public`, `public_and_internal` and `all` (default is `only_public`)
     # checkModifiersForVisibility: only_public
+  ModifierNaming:
+      active: true
   ModifierReused:
     active: true
   ModifierWithoutDefault:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -267,6 +267,16 @@ More info: [Modifier documentation](https://developer.android.com/reference/kotl
 
 Related rule: [compose:modifier-without-default-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierWithoutDefault.kt)
 
+### Naming modifiers properly
+
+Composables that accept a Modifier as a parameter to be applied to the whole component represented by the composable function should name the parameter `modifier`.
+
+In cases where Composables accept modifiers to be applied to a specific subcomponent should name the parameter `xModifier` (e.g. `fooModifier` for a `Foo` subcomponent) and follow the same guidelines above for default values and behavior.
+
+More info: [Modifier documentation](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier)
+
+Related rule: [compose:modifier-naming](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt)
+
 ### Avoid Modifier extension factory functions
 
 Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use `Modifier.composed` instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
@@ -1,0 +1,37 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.isModifier
+import org.jetbrains.kotlin.psi.KtFunction
+
+class ComposeModifierNaming : ComposeKtVisitor {
+
+    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        // If there is a modifier param, we bail
+        val modifiers = function.valueParameters.filter { it.isModifier }
+
+        // If there are no modifiers, or more than one, we don't care as much about the naming
+        if (modifiers.count() != 1) return
+
+        val modifier = modifiers.first()
+
+        // In case we didn't find any `modifier` parameters, we check if it emits content and report the error if so.
+        if (modifier.name != "modifier") {
+            emitter.report(function, ModifiersAreSupposedToBeCalledLowercaseModifier)
+        }
+    }
+
+    companion object {
+        val ModifiersAreSupposedToBeCalledLowercaseModifier = """
+            This @Composable has a single modifier, and its name is not `modifier`.
+
+            The parameter should be called `modifier` as that is the convention expected for these types of parameters.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
@@ -35,12 +35,12 @@ class ComposeModifierNaming : ComposeKtVisitor {
         val ModifiersAreSupposedToBeCalledModifierWhenAlone = """
             Modifier parameters should be called `modifier`.
 
-            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-modifiers-properly for more information.
         """.trimIndent()
         val ModifiersAreSupposedToEndInModifierWhenMultiple = """
             Modifier parameters should be called `modifier` or end in `Modifier` if there are more than one in the same @Composable.
 
-            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-modifiers-properly for more information.
         """.trimIndent()
     }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheck.kt
@@ -1,0 +1,22 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.ComposeModifierNaming
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class ComposeModifierNamingCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ComposeModifierNaming() {
+    override val issue: Issue = Issue(
+        id = "ModifierNaming",
+        severity = Severity.CodeSmell,
+        description = ComposeModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone,
+        debt = Debt.FIVE_MINS,
+    )
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -16,6 +16,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             ComposeContentEmitterReturningValuesCheck(config),
             ComposeModifierComposableCheck(config),
             ComposeModifierMissingCheck(config),
+            ComposeModifierNamingCheck(config),
             ComposeModifierReusedCheck(config),
             ComposeModifierWithoutDefaultCheck(config),
             ComposeMultipleContentEmittersCheck(config),

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -7,6 +7,8 @@ Compose:
     active: true
   ModifierMissing:
     active: true
+  ModifierNaming:
+    active: true
   ModifierReused:
     active: true
   ModifierWithoutDefault:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheckTest.kt
@@ -1,0 +1,55 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ComposeModifierNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierNamingCheckTest {
+
+    private val rule = ComposeModifierNamingCheck(Config.empty)
+
+    @Test
+    fun `errors when a Composable has a modifier not named modifier`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(m: Modifier) {}
+                @Composable
+                fun Something2(m: Modifier, m2: Modifier) {}
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 16),
+                SourceLocation(4, 16),
+                SourceLocation(4, 29),
+            )
+
+        assertThat(errors[0]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone)
+        assertThat(errors[1]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple)
+        assertThat(errors[2]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple)
+    }
+
+    @Test
+    fun `passes when the modifiers are named correctly`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(modifier: Modifier) {}
+                @Composable
+                fun Something2(modifier: Modifier, otherModifier: Modifier) {}
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
@@ -20,4 +20,16 @@ class ComposeRuleSetProviderTest {
         val ruleClassesInRuleSet = ruleSet.rules.filterIsInstance<DetektRule>().map { it::class.java }.toSet()
         assertThat(ruleClassesInRuleSet).containsExactlyInAnyOrderElementsOf(ruleClassesInPackage)
     }
+
+    @Test
+    fun `ensure all rules in the package are listed in alphabetical order`() {
+        val isOrdered = ruleSet.rules
+            .filterIsInstance<DetektRule>()
+            .asSequence()
+            .map { it::class.java.simpleName }
+            .zipWithNext { a, b -> a <= b }.all { it }
+        assertThat(isOrdered)
+            .describedAs("ComposeRuleSetProvider should have the rules in alphabetical order")
+            .isTrue()
+    }
 }

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.ComposeModifierNaming
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class ComposeModifierNamingCheck :
+    KtlintRule("compose:modifier-naming-check"),
+    ComposeKtVisitor by ComposeModifierNaming()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -1,7 +1,5 @@
 // Copyright 2023 Nacho Lopez
 // SPDX-License-Identifier: Apache-2.0
-@file:Suppress("DEPRECATION")
-
 package io.nlopez.compose.rules.ktlint
 
 import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
@@ -17,6 +15,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { ComposeContentEmitterReturningValuesCheck() },
         RuleProvider { ComposeModifierComposableCheck() },
         RuleProvider { ComposeModifierMissingCheck() },
+        RuleProvider { ComposeModifierNamingCheck() },
         RuleProvider { ComposeModifierReusedCheck() },
         RuleProvider { ComposeModifierWithoutDefaultCheck() },
         RuleProvider { ComposeMultipleContentEmittersCheck() },

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheckTest.kt
@@ -1,0 +1,58 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ComposeModifierNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierNamingCheckTest {
+
+    private val modifierRuleAssertThat = assertThatRule { ComposeModifierNamingCheck() }
+
+    @Test
+    fun `errors when a Composable has a modifier not named modifier`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(m: Modifier) {}
+                @Composable
+                fun Something2(m: Modifier, m2: Modifier) {}
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 16,
+                detail = ComposeModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone,
+            ),
+            LintViolation(
+                line = 4,
+                col = 16,
+                detail = ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple,
+            ),
+            LintViolation(
+                line = 4,
+                col = 29,
+                detail = ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple,
+            ),
+        )
+    }
+
+    @Test
+    fun `passes when the modifiers are named correctly`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(modifier: Modifier) {}
+                @Composable
+                fun Something2(modifier: Modifier, otherModifier: Modifier) {}
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+}

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProviderTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProviderTest.kt
@@ -22,4 +22,17 @@ class ComposeRuleSetProviderTest {
             .toSet()
         assertThat(ruleClassesInRuleSet).containsExactlyInAnyOrderElementsOf(ruleClassesInPackage)
     }
+
+    @Test
+    fun `ensure all rules in the package are listed in alphabetical order`() {
+        val isOrdered = ruleSetProvider.getRuleProviders()
+            .filterIsInstance<KtlintRule>()
+            .asSequence()
+            .map { it::class.java.simpleName }
+            .zipWithNext { a, b -> a <= b }
+            .all { it }
+        assertThat(isOrdered)
+            .describedAs("ComposeRuleSetProvider should have the rules in alphabetical order")
+            .isTrue()
+    }
 }


### PR DESCRIPTION
As per the docs, `Modifier` parameters should either be called `modifier` in most cases, or in cases where there are modifiers for subcomponents, `${subcomponentName}Modifier`.

This rule makes sure this is enforced.