### PR TITLE
Add rule to have ComponentDefaults objects matching the visibility of their composables

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtFunctions.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtFunctions.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
 
 val KtFunction.returnsValue: Boolean
@@ -14,13 +15,13 @@ val KtFunction.returnsValue: Boolean
 val KtFunction.hasReceiverType: Boolean
     get() = receiverTypeReference != null
 
-val KtFunction.isPrivate: Boolean
+val KtModifierListOwner.isPrivate: Boolean
     get() = visibilityModifierType() == KtTokens.PRIVATE_KEYWORD
 
-val KtFunction.isProtected: Boolean
+val KtModifierListOwner.isProtected: Boolean
     get() = visibilityModifierType() == KtTokens.PROTECTED_KEYWORD
 
-val KtFunction.isInternal: Boolean
+val KtModifierListOwner.isInternal: Boolean
     get() = visibilityModifierType() == KtTokens.INTERNAL_KEYWORD
 
 val KtFunction.isOverride: Boolean

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -28,6 +28,8 @@ Compose:
     active: true
     # You can optionally add your own composables here
     # contentEmitters: MyComposable,MyOtherComposable
+  DefaultsVisibility:
+    active: true
   ModifierComposable:
     active: true
   ModifierMissing:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -286,3 +286,13 @@ Composed modifiers may be created outside of composition, shared across elements
 More info: [Modifier extensions](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#extension-functions), [Composed modifiers in Jetpack Compose by Jorge Castillo](https://jorgecastillo.dev/composed-modifiers-in-jetpack-compose) and [Composed modifiers in API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#composed-modifiers)
 
 Related rule: [compose:modifier-composable-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierComposable.kt)
+
+## ComponentDefaults
+
+### ComponentDefaults object should match the composable visibility
+
+If your composable has an associated `Defaults` object to contain its default values, this object should have the same visibility as the composable itself. This will allow consumers to be able to interact or build upon the original intended defaults, as opposed to having to maintain their own set of defaults by copy-pasting.
+
+More info: [Compose Component API Guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md#default-expressions)
+
+Related rule: [compose:defaults-visibility](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeDefaultsVisibility.kt)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeDefaultsVisibility.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeDefaultsVisibility.kt
@@ -104,7 +104,7 @@ class ComposeDefaultsVisibility : ComposeKtVisitor {
 
             `$defaultObjectName` is $defaultObjectVisibility but it should be $composableVisibility.
 
-            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+            See https://mrmans0n.github.io/compose-rules/rules/#componentdefaults-object-should-match-the-composable-visibility for more information.
         """.trimIndent()
     }
 }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeDefaultsVisibility.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeDefaultsVisibility.kt
@@ -1,0 +1,64 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.isComposable
+import io.nlopez.rules.core.util.isInternal
+import io.nlopez.rules.core.util.isPrivate
+import io.nlopez.rules.core.util.isProtected
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.psiUtil.isPublic
+
+class ComposeDefaultsVisibility : ComposeKtVisitor {
+
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+
+        val composables = file.findChildrenByClass<KtFunction>()
+            .filter { it.isComposable }
+
+        val composableNamesForDefaults = composables.mapNotNull { it.name }.map { it + "Defaults" }.toSet()
+
+        // Default holders should be the ones named ${composableName}Defaults and defined in the same .kt file as them.
+        val defaultObjects = file.findChildrenByClass<KtClassOrObject>()
+            .filter { it.name in composableNamesForDefaults }
+
+        if (defaultObjects.count() == 0) return
+
+
+        // First we have to make sure the defaults class is used inside of the composable (e.g. in the params
+        // in some way).
+
+        // Now we need to cross-reference our default objects with the composables they match to check if the
+        // visibility matches the most visible composable
+        
+        // If we find a "defaults" object with less visibility than its composable, we report it
+    }
+
+
+    companion object {
+
+        private val KtModifierListOwner.visibilityString: String
+            get() = when {
+                isPublic -> "public"
+                isProtected -> "protected"
+                isInternal -> "internal"
+                isPrivate -> "private"
+                else -> "not supported"
+            }
+
+        fun createMessage(composable: KtFunction, defaultObject: KtClassOrObject): String = """
+            @Composable `Defaults` objects should match visibility of the composables they serve.
+
+            ${defaultObject.name} is ${defaultObject.visibilityString} but it should be ${composable.visibilityString}.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+        """.trimIndent()
+    }
+}
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeDefaultsVisibilityCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeDefaultsVisibilityCheck.kt
@@ -1,0 +1,22 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.ComposeDefaultsVisibility
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class ComposeDefaultsVisibilityCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ComposeDefaultsVisibility() {
+    override val issue: Issue = Issue(
+        id = "DefaultsVisibility",
+        severity = Severity.Defect,
+        description = "@Composable `Defaults` objects should match visibility of the composables they serve.",
+        debt = Debt.TEN_MINS,
+    )
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -14,6 +14,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
         listOf(
             ComposeCompositionLocalAllowlistCheck(config),
             ComposeContentEmitterReturningValuesCheck(config),
+            ComposeDefaultsVisibilityCheck(config),
             ComposeModifierComposableCheck(config),
             ComposeModifierMissingCheck(config),
             ComposeModifierNamingCheck(config),

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -3,6 +3,8 @@ Compose:
     active: true
   ContentEmitterReturningValues:
     active: true
+  DefaultsVisibility:
+    active: true
   ModifierComposable:
     active: true
   ModifierMissing:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeDefaultsVisibilityCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeDefaultsVisibilityCheckTest.kt
@@ -1,0 +1,71 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ComposeDefaultsVisibility.Companion.createMessage
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeDefaultsVisibilityCheckTest {
+
+    private val rule = ComposeDefaultsVisibilityCheck(Config.empty)
+
+    @Test
+    fun `errors when a defaults object has less visibility than the composable that uses it`() {
+        @Language("kotlin")
+        val code =
+            """
+                internal object MyComposableDefaults
+                @Composable
+                fun MyComposable(someParam: Bleh = MyComposableDefaults.someParam) { }
+                private object MyOtherComposableDefaults
+                @Composable
+                internal fun MyOtherComposable() {
+                    val someUsage = MyOtherComposableDefaults.someParam.someMethod()
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(1, 17),
+                SourceLocation(4, 16),
+            )
+        assertThat(errors[0]).hasMessage(
+            createMessage("public", "MyComposableDefaults", "internal"),
+        )
+        assertThat(errors[1]).hasMessage(
+            createMessage("internal", "MyOtherComposableDefaults", "private"),
+        )
+    }
+
+    @Test
+    fun `passes when a defaults object has the same visibility as any of the overloaded composables that match it`() {
+        @Language("kotlin")
+        val code =
+            """
+                object MyComposableDefaults
+                @Composable
+                fun MyComposable(someParam: Bleh = MyComposableDefaults.someParam) { }
+                internal object MyOtherComposableDefaults
+                @Composable
+                internal fun MyOtherComposable() {
+                    val someUsage = MyOtherComposableDefaults.someParam.someMethod()
+                }
+                object MyThirdComposableDefaults
+                @Composable
+                fun MyThirdComposable(a: A) {
+                    val someUsage = MyThirdComposableDefaults.someParam
+                }
+                @Composable
+                internal fun MyThirdComposable(b: B) {
+                    val someUsage = MyThirdComposableDefaults.someParam
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeDefaultsVisibilityCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeDefaultsVisibilityCheck.kt
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.ktlint
 
-import io.nlopez.compose.rules.ComposeModifierNaming
+import io.nlopez.compose.rules.ComposeDefaultsVisibility
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
-class ComposeModifierNamingCheck :
-    KtlintRule("compose:modifier-naming"),
-    ComposeKtVisitor by ComposeModifierNaming()
+class ComposeDefaultsVisibilityCheck :
+    KtlintRule("compose:defaults-visibility"),
+    ComposeKtVisitor by ComposeDefaultsVisibility()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -13,6 +13,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
     override fun getRuleProviders(): Set<RuleProvider> = setOf(
         RuleProvider { ComposeCompositionLocalAllowlistCheck() },
         RuleProvider { ComposeContentEmitterReturningValuesCheck() },
+        RuleProvider { ComposeDefaultsVisibilityCheck() },
         RuleProvider { ComposeModifierComposableCheck() },
         RuleProvider { ComposeModifierMissingCheck() },
         RuleProvider { ComposeModifierNamingCheck() },

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeDefaultsVisibilityCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeDefaultsVisibilityCheckTest.kt
@@ -1,0 +1,68 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ComposeDefaultsVisibility.Companion.createMessage
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeDefaultsVisibilityCheckTest {
+
+    private val modifierRuleAssertThat = assertThatRule { ComposeDefaultsVisibilityCheck() }
+
+    @Test
+    fun `errors when a defaults object has less visibility than the composable that uses it`() {
+        @Language("kotlin")
+        val code =
+            """
+                internal object MyComposableDefaults
+                @Composable
+                fun MyComposable(someParam: Bleh = MyComposableDefaults.someParam) { }
+                private object MyOtherComposableDefaults
+                @Composable
+                internal fun MyOtherComposable() {
+                    val someUsage = MyOtherComposableDefaults.someParam.someMethod()
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 1,
+                col = 17,
+                detail = createMessage("public", "MyComposableDefaults", "internal"),
+            ),
+            LintViolation(
+                line = 4,
+                col = 16,
+                detail = createMessage("internal", "MyOtherComposableDefaults", "private"),
+            ),
+        )
+    }
+
+    @Test
+    fun `passes when a defaults object has the same visibility as any of the overloaded composables that match it`() {
+        @Language("kotlin")
+        val code =
+            """
+                object MyComposableDefaults
+                @Composable
+                fun MyComposable(someParam: Bleh = MyComposableDefaults.someParam) { }
+                internal object MyOtherComposableDefaults
+                @Composable
+                internal fun MyOtherComposable() {
+                    val someUsage = MyOtherComposableDefaults.someParam.someMethod()
+                }
+                object MyThirdComposableDefaults
+                @Composable
+                fun MyThirdComposable(a: A) {
+                    val someUsage = MyThirdComposableDefaults.someParam
+                }
+                @Composable
+                internal fun MyThirdComposable(b: B) {
+                    val someUsage = MyThirdComposableDefaults.someParam
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
If a composable has an associated `Defaults` object to contain its default values, this object should have the same visibility as the composable itself. This will allow consumers to be able to interact or build upon the original intended defaults, as opposed to having to maintain their own set of defaults by copy-pasting.