### PR TITLE
Add rule to ensure modifiers are used at the top-most composable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ subprojects {
             freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
             // Enable default methods in interfaces
             freeCompilerArgs += "-Xjvm-default=all"
+            // Enable context receivers
+            freeCompilerArgs += "-Xcontext-receivers"
             // Enable K2 compiler
             freeCompilerArgs += "-language-version=2.0"
             freeCompilerArgs += "-Xsuppress-version-warnings"

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
@@ -5,9 +5,7 @@ package io.nlopez.rules.core.util
 import io.nlopez.rules.core.ComposeKtConfig.Companion.config
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
@@ -46,10 +44,9 @@ private val KtCallExpression.emitExplicitlyNoContent: Boolean
 val KtCallExpression.emitsContent: Boolean
     get() {
         val methodName = calleeExpression?.text ?: return false
-        val providedContentEmitters = config().getSet("contentEmitters", emptySet())
         return methodName in ComposableEmittersList ||
             ComposableEmittersListRegex.matches(methodName) ||
-            methodName in providedContentEmitters ||
+            methodName in config().getSet("contentEmitters", emptySet()) ||
             containsComposablesWithModifiers
     }
 
@@ -151,25 +148,6 @@ val ComposableEmittersListRegex by lazy {
         ),
     )
 }
-
-val ModifierNames by lazy(LazyThreadSafetyMode.NONE) {
-    setOf(
-        "Modifier",
-        "GlanceModifier",
-    )
-}
-
-val KtCallableDeclaration.isModifier: Boolean
-    get() = typeReference?.text in ModifierNames
-
-val KtCallableDeclaration.isModifierReceiver: Boolean
-    get() = receiverTypeReference?.text in ModifierNames
-
-val KtFunction.modifierParameter: KtParameter?
-    get() {
-        val modifiers = valueParameters.filter { it.isModifier }
-        return modifiers.firstOrNull { it.name == "modifier" } ?: modifiers.firstOrNull()
-    }
 
 val KtProperty.declaresCompositionLocal: Boolean
     get() = !isVar &&

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtDotQualifiedExpressions.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtDotQualifiedExpressions.kt
@@ -1,0 +1,15 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.rules.core.util
+
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+
+val KtDotQualifiedExpression.rootExpression: KtExpression
+    get() {
+        var current: KtExpression = receiverExpression
+        while (current is KtDotQualifiedExpression) {
+            current = current.receiverExpression
+        }
+        return current
+    }

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
@@ -1,0 +1,87 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.rules.core.util
+
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtValueArgumentName
+
+// Try to get all possible names by iterating on possible name reassignments until it's stable
+/**
+ *  Try to get all possible names by iterating on possible name reassignments until it's stable
+ */
+fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> {
+    var lastSize = 0
+    val tempModifierNames = mutableSetOf(initialName)
+    while (lastSize < tempModifierNames.size) {
+        lastSize = tempModifierNames.size
+        // Find usages in the current block (the original composable)
+        tempModifierNames += findModifierManipulations { tempModifierNames.contains(it) }
+        // Find usages in child composable blocks
+        tempModifierNames += findChildrenByClass<KtBlockExpression>()
+            .flatMap { block -> block.findModifierManipulations { tempModifierNames.contains(it) } }
+    }
+    return tempModifierNames.toList()
+}
+
+/**
+ * Find references to modifier as a property in case they try to modify or reuse the modifier that way
+ * E.g. val modifier2 = if (X) modifier.blah() else modifier.bleh()
+ */
+private fun KtBlockExpression.findModifierManipulations(contains: (String) -> Boolean): List<String> =
+    statements
+        .filterIsInstance<KtProperty>()
+        .flatMap { property ->
+            property.findChildrenByClass<KtReferenceExpression>()
+                .filter { referenceExpression ->
+                    val parent = referenceExpression.parent
+                    parent !is KtCallExpression &&
+                        parent !is KtValueArgumentName &&
+                        contains(referenceExpression.text)
+                }
+                .map { property }
+        }
+        .mapNotNull { it.nameIdentifier?.text }
+
+fun KtCallExpression.isUsingModifiers(modifierNames: List<String>): Boolean =
+    valueArguments.any { argument ->
+        when (val expression = argument.getArgumentExpression()) {
+            // if it's MyComposable(modifier) or similar
+            is KtReferenceExpression -> {
+                modifierNames.contains(expression.text)
+            }
+            // if it's MyComposable(modifier.fillMaxWidth()) or similar
+            is KtDotQualifiedExpression -> {
+                // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
+                // we need to iterate until we find the start of the chain
+                modifierNames.contains(expression.rootExpression.text)
+            }
+
+            else -> false
+        }
+    }
+
+val ModifierNames by lazy(LazyThreadSafetyMode.NONE) {
+    setOf(
+        "Modifier",
+        "GlanceModifier",
+    )
+}
+
+val KtCallableDeclaration.isModifier: Boolean
+    get() = typeReference?.text in ModifierNames
+
+val KtCallableDeclaration.isModifierReceiver: Boolean
+    get() = receiverTypeReference?.text in ModifierNames
+
+val KtFunction.modifierParameter: KtParameter?
+    get() {
+        val modifiers = valueParameters.filter { it.isModifier }
+        return modifiers.firstOrNull { it.name == "modifier" } ?: modifiers.firstOrNull()
+    }

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -39,6 +39,10 @@ Compose:
     # checkModifiersForVisibility: only_public
   ModifierNaming:
     active: true
+  ModifierNotUsedAtRoot:
+    active: true
+    # You can optionally add your own composables here
+    # contentEmitters: MyComposable,MyOtherComposable
   ModifierReused:
     active: true
   ModifierWithoutDefault:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -41,7 +41,7 @@ You can use this same jar in the [ktlint (unofficial) IntelliJ plugin](https://p
 
 ### Providing custom content emitters
 
-There are some rules (`compose:content-emitter-returning-values-check` and `compose:multiple-emitters-check`) that use predefined list of known composables that emit content. But you can add your own too! In your `.editorconfig` file, you'll need to add a `content_emitters` property followed by a list of composable names separated by commas. You would typically want the composables that are part of your custom design system to be in this list.
+There are some rules (`compose:content-emitter-returning-values-check`, `compose:modifier-not-used-at-root` and `compose:multiple-emitters-check`) that use predefined list of known composables that emit content. But you can add your own too! In your `.editorconfig` file, you'll need to add a `content_emitters` property followed by a list of composable names separated by commas. You would typically want the composables that are part of your custom design system to be in this list.
 
 ```editorconfig
 [*.{kt,kts}]

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -228,6 +228,15 @@ More info: [Always provide a Modifier parameter](https://chris.banes.dev/posts/a
 
 Related rule: [compose:modifier-missing-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierMissing.kt)
 
+### Modifiers should be used at the top-most layout of the component
+
+Modifiers should be applied once as a first modifier in the chain to the root-most layout in the component implementation.
+Since modifiers aim to modify the external behaviors and appearance of the component, they must be applied to the top-most layout and be the first modifiers in the hierarchy. It is allowed to chain other modifiers to the modifier passed as a param if needed.
+
+More info: [Compose Component API Guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md#modifier-parameter)
+
+Related rule: [compose:modifier-not-used-at-root](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt)
+
 ### Don't re-use modifiers
 
 Modifiers which are passed in are designed so that they should be used by a single layout node in the composable function. If the provided modifier is used by multiple composables at different levels, unwanted behaviour can happen.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
@@ -1,0 +1,59 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.emitsContent
+import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.isUsingModifiers
+import io.nlopez.rules.core.util.modifierParameter
+import io.nlopez.rules.core.util.obtainAllModifierNames
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+
+class ComposeModifierNotUsedAtRoot : ComposeKtVisitor {
+
+    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        val modifier = function.modifierParameter ?: return
+        if (modifier.name != "modifier") return
+        val code = function.bodyBlockExpression ?: return
+
+        val modifiers = code.obtainAllModifierNames("modifier")
+
+        val callExpressions = code.findChildrenByClass<KtCallExpression>()
+            .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
+            .filter { it.isUsingModifiers(modifiers) }
+            .filter { callExpression ->
+                // we'll need to traverse upwards to the composable root and check if there is any parent that
+                // emits content: if this is the case, the main modifier should be used there instead.
+                callExpression.findFirstAncestorEmittingContent(stopAt = code) != null
+            }
+
+        for (callExpression in callExpressions) {
+            emitter.report(callExpression, ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
+        }
+    }
+
+    private fun KtCallExpression.findFirstAncestorEmittingContent(stopAt: PsiElement): KtCallExpression? {
+        var current: PsiElement = this
+        var result: KtCallExpression? = null
+        while (current != stopAt) {
+            if (current is KtCallExpression && current.emitsContent) {
+                result = current
+            }
+            current = current.parent
+        }
+        return result
+    }
+
+    companion object {
+        val ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace = """
+            The main Modifier of a @Composable should be applied once as a first modifier in the chain to the root-most layout in the component implementation.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
@@ -7,12 +7,15 @@ import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
 import io.nlopez.rules.core.util.emitsContent
 import io.nlopez.rules.core.util.findChildrenByClass
-import io.nlopez.rules.core.util.isUsingModifiers
 import io.nlopez.rules.core.util.modifierParameter
 import io.nlopez.rules.core.util.obtainAllModifierNames
+import io.nlopez.rules.core.util.rootExpression
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
 
 class ComposeModifierNotUsedAtRoot : ComposeKtVisitor {
 
@@ -23,25 +26,48 @@ class ComposeModifierNotUsedAtRoot : ComposeKtVisitor {
 
         val modifiers = code.obtainAllModifierNames("modifier")
 
-        val callExpressions = code.findChildrenByClass<KtCallExpression>()
+        val errors = code.findChildrenByClass<KtCallExpression>()
             .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
-            .filter { it.isUsingModifiers(modifiers) }
-            .filter { callExpression ->
+            .mapNotNull { callExpression ->
+                val usage = callExpression.getModifierUsage(modifiers) ?: return@mapNotNull null
+                callExpression to usage
+            }
+            .filter { (callExpression, _) ->
                 // we'll need to traverse upwards to the composable root and check if there is any parent that
                 // emits content: if this is the case, the main modifier should be used there instead.
                 callExpression.findFirstAncestorEmittingContent(stopAt = code) != null
             }
+            .map { (_, valueArgument) -> valueArgument }
 
-        for (callExpression in callExpressions) {
-            emitter.report(callExpression, ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
+        for (valueArgument in errors) {
+            emitter.report(valueArgument, ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
         }
     }
 
+    private fun KtCallExpression.getModifierUsage(modifierNames: List<String>): KtValueArgument? =
+        valueArguments.firstOrNull { argument ->
+            when (val expression = argument.getArgumentExpression()) {
+                // if it's MyComposable(modifier) or similar
+                is KtReferenceExpression -> {
+                    modifierNames.contains(expression.text)
+                }
+                // if it's MyComposable(modifier.fillMaxWidth()) or similar
+                is KtDotQualifiedExpression -> {
+                    // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
+                    // we need to iterate until we find the start of the chain
+                    modifierNames.contains(expression.rootExpression.text)
+                }
+
+                else -> false
+            }
+        }
+
     private fun KtCallExpression.findFirstAncestorEmittingContent(stopAt: PsiElement): KtCallExpression? {
+        val origin = this
         var current: PsiElement = this
         var result: KtCallExpression? = null
         while (current != stopAt) {
-            if (current is KtCallExpression && current.emitsContent) {
+            if (current != origin && current is KtCallExpression && current.emitsContent) {
                 result = current
             }
             current = current.parent

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
@@ -53,7 +53,9 @@ class ComposeModifierNotUsedAtRoot : ComposeKtVisitor {
         val ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace = """
             The main Modifier of a @Composable should be applied once as a first modifier in the chain to the root-most layout in the component implementation.
 
-            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+            You should move the modifier usage to the appropriate parent Composable.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#modifiers-should-be-used-at-the-top-most-layout-of-the-component for more information.
         """.trimIndent()
     }
 }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierReused.kt
@@ -6,16 +6,12 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.emitsContent
 import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.isUsingModifiers
 import io.nlopez.rules.core.util.modifierParameter
+import io.nlopez.rules.core.util.obtainAllModifierNames
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
-import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtReferenceExpression
-import org.jetbrains.kotlin.psi.KtValueArgumentName
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 class ComposeModifierReused : ComposeKtVisitor {
@@ -66,66 +62,6 @@ class ComposeModifierReused : ComposeKtVisitor {
                 emitter.report(callExpression, ModifierShouldBeUsedOnceOnly, false)
             }
     }
-
-    private fun KtCallExpression.isUsingModifiers(modifierNames: List<String>): Boolean =
-        valueArguments.any { argument ->
-            when (val expression = argument.getArgumentExpression()) {
-                // if it's MyComposable(modifier) or similar
-                is KtReferenceExpression -> {
-                    modifierNames.contains(expression.text)
-                }
-                // if it's MyComposable(modifier.fillMaxWidth()) or similar
-                is KtDotQualifiedExpression -> {
-                    // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
-                    // we need to iterate until we find the start of the chain
-                    modifierNames.contains(expression.rootExpression.text)
-                }
-
-                else -> false
-            }
-        }
-
-    private val KtDotQualifiedExpression.rootExpression: KtExpression
-        get() {
-            var current: KtExpression = receiverExpression
-            while (current is KtDotQualifiedExpression) {
-                current = current.receiverExpression
-            }
-            return current
-        }
-
-    private fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> {
-        var lastSize = 0
-        val tempModifierNames = mutableSetOf(initialName)
-        while (lastSize < tempModifierNames.size) {
-            lastSize = tempModifierNames.size
-            // Find usages in the current block (the original composable)
-            tempModifierNames += findModifierManipulations { tempModifierNames.contains(it) }
-            // Find usages in child composable blocks
-            tempModifierNames += findChildrenByClass<KtBlockExpression>()
-                .flatMap { block -> block.findModifierManipulations { tempModifierNames.contains(it) } }
-        }
-        return tempModifierNames.toList()
-    }
-
-    /**
-     * Find references to modifier as a property in case they try to modify or reuse the modifier that way
-     * E.g. val modifier2 = if (X) modifier.blah() else modifier.bleh()
-     */
-    private fun KtBlockExpression.findModifierManipulations(contains: (String) -> Boolean): List<String> =
-        statements
-            .filterIsInstance<KtProperty>()
-            .flatMap { property ->
-                property.findChildrenByClass<KtReferenceExpression>()
-                    .filter { referenceExpression ->
-                        val parent = referenceExpression.parent
-                        parent !is KtCallExpression &&
-                            parent !is KtValueArgumentName &&
-                            contains(referenceExpression.text)
-                    }
-                    .map { property }
-            }
-            .mapNotNull { it.nameIdentifier?.text }
 
     companion object {
         val ModifierShouldBeUsedOnceOnly = """

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNotUsedAtRootCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNotUsedAtRootCheck.kt
@@ -1,0 +1,22 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.ComposeModifierNotUsedAtRoot
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class ComposeModifierNotUsedAtRootCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ComposeModifierNotUsedAtRoot() {
+    override val issue: Issue = Issue(
+        id = "ModifierNotUsedAtRoot",
+        severity = Severity.Defect,
+        description = ComposeModifierNotUsedAtRoot.ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+        debt = Debt.FIVE_MINS,
+    )
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -18,6 +18,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             ComposeModifierComposableCheck(config),
             ComposeModifierMissingCheck(config),
             ComposeModifierNamingCheck(config),
+            ComposeModifierNotUsedAtRootCheck(config),
             ComposeModifierReusedCheck(config),
             ComposeModifierWithoutDefaultCheck(config),
             ComposeMultipleContentEmittersCheck(config),

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -11,6 +11,8 @@ Compose:
     active: true
   ModifierNaming:
     active: true
+  ModifierNotUsedAtRoot:
+    active: true
   ModifierReused:
     active: true
   ModifierWithoutDefault:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierMissingCheckTest.kt
@@ -38,7 +38,14 @@ class ComposeModifierMissingCheckTest {
                     }
                 }
                 @Composable
-                fun Something4(modifier: Modifier = Modifier) {
+                fun Something4(): Unit {
+                    SomethingElse {
+                        Box(modifier = Modifier.fillMaxSize()) {
+                        }
+                    }
+                }
+                @Composable
+                fun Something5(modifier: Modifier = Modifier) {
                     Row {
                         Text("Hi!")
                     }
@@ -46,10 +53,11 @@ class ComposeModifierMissingCheckTest {
             """.trimIndent()
 
         val errors = rule.lint(code)
-        assertThat(errors).hasTextLocations("Something1", "Something2", "Something3")
+        assertThat(errors).hasTextLocations("Something1", "Something2", "Something3", "Something4")
         assertThat(errors[0]).hasMessage(ComposeModifierMissing.MissingModifierContentComposable)
         assertThat(errors[1]).hasMessage(ComposeModifierMissing.MissingModifierContentComposable)
         assertThat(errors[2]).hasMessage(ComposeModifierMissing.MissingModifierContentComposable)
+        assertThat(errors[3]).hasMessage(ComposeModifierMissing.MissingModifierContentComposable)
     }
 
     @Test

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNotUsedAtRootCheckTest.kt
@@ -1,0 +1,113 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ComposeModifierNotUsedAtRoot.Companion.ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierNotUsedAtRootCheckTest {
+
+    private val testConfig = TestConfig(
+        "contentEmitters" to listOf("Potato", "Banana"),
+    )
+    private val rule = ComposeModifierNotUsedAtRootCheck(testConfig)
+
+    @Test
+    fun `error out when modifier is used in too deep in the hierarchy`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Row {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Potato(Modifier.fillMaxWidth()) {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val poop = if (x) modifier else modifier.fillMaxWidth()
+                    Column {
+                        Text("Hi", modifier = poop)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    if (paella.isWellDone()) {
+                        Column {
+                            Text("Yay", modifier)
+                        }
+                    } else {
+                        Row {
+                            Text("Oh no", modifier)
+                        }
+                    }
+                }
+
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 20),
+                SourceLocation(10, 20),
+                SourceLocation(17, 20),
+                SourceLocation(24, 25),
+                SourceLocation(28, 27),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
+        }
+    }
+
+    @Test
+    fun `passes when modifier is used in the top-most place that emits content`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Row(modifier = modifier) {
+                        Text("Hi")
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Potato(modifier.fillMaxWidth()) {
+                        Text("Hi")
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val poop = if (x) modifier else modifier.fillMaxWidth()
+                    Column(modifier = poop) {
+                        Text("Hi")
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    if (paella.isWellDone()) {
+                        Column(modifier) {
+                            Text("Yay")
+                        }
+                    } else {
+                        Row(modifier) {
+                            Text("Oh no")
+                        }
+                    }
+                }
+
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNotUsedAtRootCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNotUsedAtRootCheck.kt
@@ -1,0 +1,14 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.ComposeModifierNotUsedAtRoot
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class ComposeModifierNotUsedAtRootCheck :
+    KtlintRule(
+        id = "compose:modifier-not-used-at-root",
+        editorConfigProperties = setOf(contentEmittersProperty),
+    ),
+    ComposeKtVisitor by ComposeModifierNotUsedAtRoot()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -17,6 +17,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { ComposeModifierComposableCheck() },
         RuleProvider { ComposeModifierMissingCheck() },
         RuleProvider { ComposeModifierNamingCheck() },
+        RuleProvider { ComposeModifierNotUsedAtRootCheck() },
         RuleProvider { ComposeModifierReusedCheck() },
         RuleProvider { ComposeModifierWithoutDefaultCheck() },
         RuleProvider { ComposeMultipleContentEmittersCheck() },

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierMissingCheckTest.kt
@@ -35,6 +35,13 @@ class ComposeModifierMissingCheckTest {
                     }
                 }
                 @Composable
+                fun Something(): Unit {
+                    SomethingElse {
+                        Box(Modifier.fillMaxSize()) {
+                        }
+                    }
+                }
+                @Composable
                 fun Something(modifier: Modifier = Modifier) {
                     Row {
                         Text("Hi!")
@@ -55,6 +62,11 @@ class ComposeModifierMissingCheckTest {
             ),
             LintViolation(
                 line = 12,
+                col = 5,
+                detail = ComposeModifierMissing.MissingModifierContentComposable,
+            ),
+            LintViolation(
+                line = 19,
                 col = 5,
                 detail = ComposeModifierMissing.MissingModifierContentComposable,
             ),

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNotUsedAtRootCheckTest.kt
@@ -1,0 +1,130 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ComposeModifierNotUsedAtRoot.Companion.ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierNotUsedAtRootCheckTest {
+
+    private val modifierRuleAssertThat = assertThatRule { ComposeModifierNotUsedAtRootCheck() }
+
+    @Test
+    fun `error out when modifier is used in too deep in the hierarchy`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Row {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Potato(Modifier.fillMaxWidth()) {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val poop = if (x) modifier else modifier.fillMaxWidth()
+                    Column {
+                        Text("Hi", modifier = poop)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    if (paella.isWellDone()) {
+                        Column {
+                            Text("Yay", modifier)
+                        }
+                    } else {
+                        Row {
+                            Text("Oh no", modifier)
+                        }
+                    }
+                }
+
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(
+                contentEmittersProperty to "Potato,Banana",
+            )
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 4,
+                    col = 20,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+                LintViolation(
+                    line = 10,
+                    col = 20,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+                LintViolation(
+                    line = 17,
+                    col = 20,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+                LintViolation(
+                    line = 24,
+                    col = 25,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+                LintViolation(
+                    line = 28,
+                    col = 27,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when modifier is used in the top-most place that emits content`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Row(modifier = modifier) {
+                        Text("Hi")
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Potato(modifier.fillMaxWidth()) {
+                        Text("Hi")
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val poop = if (x) modifier else modifier.fillMaxWidth()
+                    Column(modifier = poop) {
+                        Text("Hi")
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    if (paella.isWellDone()) {
+                        Column(modifier) {
+                            Text("Yay")
+                        }
+                    } else {
+                        Row(modifier) {
+                            Text("Oh no")
+                        }
+                    }
+                }
+
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(
+                contentEmittersProperty to "Potato,Banana",
+            )
+            .hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
Modifiers aim to modify the external behaviors and appearance of the component, so they must be applied to the top-most layout and be the first modifiers in the hierarchy. 

This patch makes it so by traversing from the usages of said modifiers, and going upwards in the composable hierarchy to see if there is any other content emitter (by leveraging the already existing code for this).