### PR TITLE
Fix emitsContent checking KtLambdaExpressions for Modifier usages

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
@@ -5,9 +5,9 @@ package io.nlopez.rules.core.util
 import io.nlopez.rules.core.ComposeKtConfig.Companion.config
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 val KtFunction.emitsContent: Boolean
@@ -62,8 +62,8 @@ private val KtCallExpression.containsComposablesWithModifiers: Boolean
 
         // Check if there is any Modifier chain (e.g. `Modifier.fillMaxWidth()`)
         return valueArguments.mapNotNull { it.getArgumentExpression() }
-            .flatMap { it.findChildrenByClass<KtReferenceExpression>() }
-            .any { it.text == "Modifier" }
+            .filterIsInstance<KtDotQualifiedExpression>()
+            .any { it.rootExpression.text == "Modifier" }
     }
 
 /**
@@ -148,7 +148,7 @@ private val ComposableEmittersList by lazy {
     )
 }
 
-val ComposableEmittersListRegex by lazy {
+private val ComposableEmittersListRegex by lazy {
     Regex(
         listOf(
             "Spacer\\d*", // Spacer() + SpacerNUM()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNotUsedAtRootCheckTest.kt
@@ -105,7 +105,33 @@ class ComposeModifierNotUsedAtRootCheckTest {
                         }
                     }
                 }
-
+                @Composable
+                fun Something(
+                  modifier: Modifier = Modifier,
+                  content: @Composable BoxScope.() -> Unit
+                ) {
+                  MaterialTheme(
+                    colorScheme = darkColorScheme()
+                  ) {
+                    Box(
+                      modifier = modifier
+                        .fillMaxSize()
+                        .background(
+                          color = MaterialTheme.colorScheme.background
+                        )
+                    ) {
+                      Card(
+                        modifier = Modifier.fillMaxSize()
+                      ) {
+                        Box(
+                          modifier = Modifier.padding(16.dp)
+                        ) {
+                          content()
+                        }
+                      }
+                    }
+                  }
+                }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNotUsedAtRootCheckTest.kt
@@ -119,7 +119,33 @@ class ComposeModifierNotUsedAtRootCheckTest {
                         }
                     }
                 }
-
+                @Composable
+                fun Something(
+                  modifier: Modifier = Modifier,
+                  content: @Composable BoxScope.() -> Unit
+                ) {
+                  MaterialTheme(
+                    colorScheme = darkColorScheme()
+                  ) {
+                    Box(
+                      modifier = modifier
+                        .fillMaxSize()
+                        .background(
+                          color = MaterialTheme.colorScheme.background
+                        )
+                    ) {
+                      Card(
+                        modifier = Modifier.fillMaxSize()
+                      ) {
+                        Box(
+                          modifier = Modifier.padding(16.dp)
+                        ) {
+                          content()
+                        }
+                      }
+                    }
+                  }
+                }
             """.trimIndent()
         modifierRuleAssertThat(code)
             .withEditorConfigOverride(


### PR DESCRIPTION
The `KtCallExpression.emitsContent` method was returning false positives after the change to check for Modifier usages, due to it not filtering out the types of expressions where a chained `Modifier` would be useful (e.g. only in `KtDotQualifiedExpression`, really). 

This patch makes it so that the fallback for the `valueArguments` check in `emitsContent` only looks into things like `Modifier.fillMaxWidth().whatever(...)` and the like: basically `KtDotQualifiedExpression`s with the root of `Modifier`.

Fixes #84