### PR TITLE
Update ktlint to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,9 @@ subprojects {
     spotless {
         kotlin {
             target "**/*.kt"
-            ktlint(libs.versions.ktlint.get())
+            // ktlint(libs.versions.ktlint.get())
+            ktlint("0.50.0")
+
             licenseHeaderFile rootProject.file('spotless/copyright.txt')
         }
         groovyGradle {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.9.10"
-ktlint = "0.50.0"
+ktlint = "1.0.0"
 detekt = "1.23.1"
 junit = "5.10.0"
 


### PR DESCRIPTION
Due to the reasons exposed in https://github.com/pinterest/ktlint/pull/2044/, this is not trivial - we need to rewrite the fixes manually or remove them altogether. Not being able to rely on the embedded kotlin compiler plugin for this is less than ideal, I wanted to stay away from ASTNode as much as possible :(

TODO:
- [x] Fix spotless version
- [x] Fix ViewModelInjection autofix
- [x] Fix PreviewPublic autofix