### PR TITLE
Allow configuration of state holder classes

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -69,6 +69,8 @@ Compose:
     active: true
   ViewModelForwarding:
     active: true
+      # You can optionally use this rule on things other than types ending in "ViewModel" or "Presenter" (which are the defaults). You can add your own via a regex here:
+      # allowedStateHolderNames: .*ViewModel,.*Presenter
   ViewModelInjection:
     active: true
     # You can optionally add your own ViewModel factories here

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -75,6 +75,15 @@ The `naming-check` rule requires all composables that return a value to be lower
 compose_allowed_composable_function_names = .*Presenter,.*SomethingElse
 ```
 
+### Allowing custom state holder names
+
+The `vm-forwarding-check` rule will, by default, design as a state holder any class ending on "ViewModel" or "Presenter". You can, however, add new types of names to the mix via a comma-separated list of matching regexes in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_allowed_state_holder_names = .*ViewModel,.*Presenter,.*Component,.*SomethingElse
+```
+
 ### Configure the visibility of the composables where to check for missing modifiers
 
 The `modifier-missing-check` rule will, by default, only look for missing modifiers for public composables. If you want to lower the visibility threshold to check also internal compoosables, or all composables, you can configure it in your `.editorconfig` file:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeViewModelForwardingCheckTest.kt
@@ -4,6 +4,7 @@ package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import io.nlopez.compose.rules.ComposeViewModelForwarding
@@ -12,6 +13,9 @@ import org.junit.jupiter.api.Test
 
 class ComposeViewModelForwardingCheckTest {
 
+    private val testConfig = TestConfig(
+        "stateHolder" to listOf("bananaViewModel", "potatoViewModel"),
+    )
     private val rule = ComposeViewModelForwardingCheck(Config.empty)
 
     @Test

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelForwardingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelForwardingCheck.kt
@@ -7,5 +7,8 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
 class ComposeViewModelForwardingCheck :
-    KtlintRule("compose:vm-forwarding-check"),
+    KtlintRule(
+        id = "compose:vm-forwarding-check",
+        editorConfigProperties = setOf(allowedStateHolderNames),
+    ),
     ComposeKtVisitor by ComposeViewModelForwarding()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -95,3 +95,21 @@ val viewModelFactories: EditorConfigProperty<String> =
             }
         },
     )
+
+val allowedStateHolderNames: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_allowed_state_holder_names",
+            "A comma separated list of regexes of valid state holders / ViewModel / Presenter names",
+            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelForwardingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeViewModelForwardingCheckTest.kt
@@ -76,23 +76,25 @@ class ComposeViewModelForwardingCheckTest {
                 AnotherComposable(vm = viewModel)
             }
             """.trimIndent()
-        forwardingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 3,
-                col = 5,
-                detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
-            ),
-            LintViolation(
-                line = 8,
-                col = 9,
-                detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
-            ),
-            LintViolation(
-                line = 13,
-                col = 5,
-                detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
-            ),
-        )
+        forwardingRuleAssertThat(code)
+            .withEditorConfigOverride(allowedStateHolderNames to ".*Component,.*ViewModel")
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
+                ),
+                LintViolation(
+                    line = 8,
+                    col = 9,
+                    detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
+                ),
+                LintViolation(
+                    line = 13,
+                    col = 5,
+                    detail = ComposeViewModelForwarding.AvoidViewModelForwarding,
+                ),
+            )
     }
 
     @Test


### PR DESCRIPTION
Currently, only classes ending in "ViewModel" were subject to the forwarding rule. This type of check should apply to any state holder, and if you use things other than ViewModels (e.g. presenters, or whatever other type of component I wouldn't think of), this rule now allows you to configure it if you want. It will default to look for types ending in "ViewModel" and "Presenter" but allow further configurations.