### PR TITLE
Update @Preview annotation detection

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Previews.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Previews.kt
@@ -9,11 +9,4 @@ val KtAnnotated.isPreview: Boolean
     get() = annotationEntries.any { it.isPreviewAnnotation }
 
 val KtAnnotationEntry.isPreviewAnnotation: Boolean
-    get() = calleeExpression?.text?.let { PreviewNameRegex.matches(it) } == true
-
-val KtAnnotated.isPreviewParameter: Boolean
-    get() = annotationEntries.any { it.calleeExpression?.text == "PreviewParameter" }
-
-val PreviewNameRegex by lazy {
-    Regex(".*Preview[s]*$")
-}
+    get() = calleeExpression?.text?.run { contains("Preview") } == true

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierMissingCheckTest.kt
@@ -279,6 +279,12 @@ class ComposeModifierMissingCheckTest {
                     Row {
                     }
                 }
+                @PreviewScreenSizes
+                @Composable
+                fun Something() {
+                    Row {
+                    }
+                }
                 @Preview
                 @Composable
                 fun Something() {

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierMissingCheckTest.kt
@@ -306,6 +306,12 @@ class ComposeModifierMissingCheckTest {
                     Row {
                     }
                 }
+                @PreviewScreenSizes
+                @Composable
+                fun Something() {
+                    Row {
+                    }
+                }
                 @Preview
                 @Composable
                 fun Something() {


### PR DESCRIPTION
The `@Preview` annotation in a multipreview could be at the beginning. 

Should fix #98 ? 