### PR TITLE
Try fixing mkdocs borked lists

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,3 +43,4 @@ markdown_extensions:
     - pymdownx.superfences
     - pymdownx.tabbed
     - pymdownx.details
+    - mdx_truly_sane_lists


### PR DESCRIPTION
After reading it in a mkdocs project issue, I found that the https://pypi.org/project/mdx-truly-sane-lists/ extension is supposed to help with mkdocs messing up lists. Let's give it a try.
