### PR TITLE
Update compose modifier naming rule

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
@@ -19,8 +19,13 @@ class ComposeModifierNaming : ComposeKtVisitor {
 
         val count = modifiers.size
 
-        for (modifier in modifiers) {
-            val valid = modifier.name?.lowercase()?.endsWith("modifier") ?: false
+        modifiers.forEachIndexed { index, modifier ->
+            val isCorrectSingleModifier = modifier.name?.equals("modifier") ?: false
+            val valid = if (index == 0) {
+                isCorrectSingleModifier
+            } else {
+                !isCorrectSingleModifier && modifier.name?.lowercase()?.endsWith("modifier") ?: false
+            }
             when {
                 !valid && count == 1 -> emitter.report(modifier, ModifiersAreSupposedToBeCalledModifierWhenAlone)
                 !valid -> emitter.report(modifier, ModifiersAreSupposedToEndInModifierWhenMultiple)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNaming.kt
@@ -18,19 +18,16 @@ class ComposeModifierNaming : ComposeKtVisitor {
         if (modifiers.isEmpty()) return
 
         val count = modifiers.size
-
-        modifiers.forEachIndexed { index, modifier ->
-            val isCorrectSingleModifier = modifier.name?.equals("modifier") ?: false
-            val valid = if (index == 0) {
-                isCorrectSingleModifier
-            } else {
-                !isCorrectSingleModifier && modifier.name?.lowercase()?.endsWith("modifier") ?: false
+        if (count == 1) {
+            if (modifiers.first().name?.equals("modifier") != true) {
+                emitter.report(modifiers.first(), ModifiersAreSupposedToBeCalledModifierWhenAlone)
+                return
             }
-            when {
-                !valid && count == 1 -> emitter.report(modifier, ModifiersAreSupposedToBeCalledModifierWhenAlone)
-                !valid -> emitter.report(modifier, ModifiersAreSupposedToEndInModifierWhenMultiple)
-                else -> {
-                    // no-op
+        } else {
+            for (modifier in modifiers) {
+                val valid = modifier.name?.lowercase()?.endsWith("modifier") ?: false
+                if (!valid) {
+                    emitter.report(modifier, ModifiersAreSupposedToEndInModifierWhenMultiple)
                 }
             }
         }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheckTest.kt
@@ -67,24 +67,4 @@ class ComposeModifierNamingCheckTest {
 
         assertThat(errors[0]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone)
     }
-
-    @Test
-    fun `errors when a Composable has a non first modifier named exactly modifier`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something1(myModifier: Modifier, modifier: Modifier) {}
-            """.trimIndent()
-
-        val errors = rule.lint(code)
-        assertThat(errors)
-            .hasStartSourceLocations(
-                SourceLocation(2, 16),
-                SourceLocation(2, 38),
-            )
-
-        assertThat(errors[0]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple)
-        assertThat(errors[1]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple)
-    }
 }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierNamingCheckTest.kt
@@ -52,4 +52,39 @@ class ComposeModifierNamingCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `errors when a Composable has a single modifier not named modifier but ends with modifier`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(myModifier: Modifier) {}
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).hasStartSourceLocation(2, 16)
+
+        assertThat(errors[0]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone)
+    }
+
+    @Test
+    fun `errors when a Composable has a non first modifier named exactly modifier`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(myModifier: Modifier, modifier: Modifier) {}
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 16),
+                SourceLocation(2, 38),
+            )
+
+        assertThat(errors[0]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple)
+        assertThat(errors[1]).hasMessage(ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple)
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheckTest.kt
@@ -55,4 +55,43 @@ class ComposeModifierNamingCheckTest {
 
         modifierRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `errors when a Composable has a single modifier not named modifier but ends with modifier`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(myModifier: Modifier) {}
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationWithoutAutoCorrect(
+            line = 2,
+            col = 16,
+            detail = ComposeModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone,
+        )
+    }
+
+    @Test
+    fun `errors when a Composable has a non first modifier named exactly modifier`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(myModifier: Modifier, modifier: Modifier) {}
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 16,
+                detail = ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple,
+            ),
+            LintViolation(
+                line = 2,
+                col = 38,
+                detail = ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple,
+            ),
+        )
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierNamingCheckTest.kt
@@ -71,27 +71,4 @@ class ComposeModifierNamingCheckTest {
             detail = ComposeModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone,
         )
     }
-
-    @Test
-    fun `errors when a Composable has a non first modifier named exactly modifier`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something1(myModifier: Modifier, modifier: Modifier) {}
-            """.trimIndent()
-
-        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 16,
-                detail = ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple,
-            ),
-            LintViolation(
-                line = 2,
-                col = 38,
-                detail = ComposeModifierNaming.ModifiersAreSupposedToEndInModifierWhenMultiple,
-            ),
-        )
-    }
 }


### PR DESCRIPTION
The value of this PR depends on how strict you'd prefer the rule but the PR addresses the Compose Modifier naming rule not currently catching the following cases:

- Composable function with single modifier not named "modifier" but ends with "Modifier":
```
@Composable
fun Something1(myModifier: Modifier) {}
```
- Composable function non-initial modifier named exactly "modifier"
```
@Composable
fun Something1(myModifier: Modifier, modifier: Modifier) {}
```