### PR TITLE
Add ModifierClickableOrder rule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,11 +37,17 @@ subprojects {
             licenseHeaderFile rootProject.file('spotless/copyright.txt'), '(buildscript|apply|import|plugins)'
         }
     }
+
+    tasks.withType(JavaCompile).configureEach {
+        javaCompiler = javaToolchains.compilerFor {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
+    }
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { compile ->
         kotlinOptions {
             // Treat all Kotlin warnings as errors
             allWarningsAsErrors = true
-            // Set JVM target to 11
+            // Set JVM target to 17
             jvmTarget = JavaVersion.VERSION_11
             // Allow use of @OptIn
             freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentName
 
-// Try to get all possible names by iterating on possible name reassignments until it's stable
 /**
  *  Try to get all possible names by iterating on possible name reassignments until it's stable
  */

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentName
 
 // Try to get all possible names by iterating on possible name reassignments until it's stable
@@ -50,7 +51,10 @@ private fun KtBlockExpression.findModifierManipulations(contains: (String) -> Bo
         .mapNotNull { it.nameIdentifier?.text }
 
 fun KtCallExpression.isUsingModifiers(modifierNames: List<String>): Boolean =
-    valueArguments.any { argument ->
+    argumentsUsingModifiers(modifierNames).isNotEmpty()
+
+fun KtCallExpression.argumentsUsingModifiers(modifierNames: List<String>): List<KtValueArgument> =
+    valueArguments.filter { argument ->
         when (val expression = argument.getArgumentExpression()) {
             // if it's MyComposable(modifier) or similar
             is KtReferenceExpression -> {

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -30,6 +30,8 @@ Compose:
     # contentEmitters: MyComposable,MyOtherComposable
   DefaultsVisibility:
     active: true
+  ModifierClickableOrder:
+    active: true
   ModifierComposable:
     active: true
   ModifierMissing:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -227,6 +227,51 @@ More info: [Always provide a Modifier parameter](https://chris.banes.dev/posts/a
 
 Related rule: [compose:modifier-missing-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierMissing.kt)
 
+### Modifier order matters
+
+The order of modifier functions is very important. Each function makes changes to the Modifierreturned by the previous function, the sequence affects the final result. Let's see an example of this:
+
+```kotlin
+@Composable
+fun MyCard(modifier: Modifier = Modifier) {
+    Column(
+        modifier
+            // Tapping on it does a ripple, the ripple is bound incorrectly to the composable
+            .clickable { /* TODO */ }
+            // Create rounded corners
+            .clip(shape = RoundedCornerShape(8.dp))
+            // Background with rounded corners
+            .background(color = backgroundColor, shape = RoundedCornerShape(8.dp))
+    ) {
+        // rest of the implementation
+    }
+}
+```
+The entire area, including the clipped area and the clipped background, responds to clicks. This means that the ripple will fill it all, even the areas that we wanted to trim from the shape.
+
+We can address this by simply reordering the modifiers.
+
+```kotlin
+@Composable
+fun MyCard(modifier: Modifier = Modifier) {
+    Column(
+        modifier
+            // Create rounded corners
+            .clip(shape = RoundedCornerShape(8.dp))
+            // Background with rounded corners
+            .background(color = backgroundColor, shape = RoundedCornerShape(8.dp))
+            // Tapping on it does a ripple, the ripple is bound incorrectly to the composable
+            .clickable { /* TODO */ }
+    ) {
+        // rest of the implementation
+    }
+}
+```
+
+More info: [Modifier documentation](https://developer.android.com/jetpack/compose/modifiers#order-modifier-matters)
+
+Related rule: [compose:modifier-clickable-order](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierClickableOrder.kt)
+
 ### Modifiers should be used at the top-most layout of the component
 
 Modifiers should be applied once as a first modifier in the chain to the root-most layout in the component implementation.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierClickableOrder.kt
@@ -131,7 +131,6 @@ class ComposeModifierClickableOrder : ComposeKtVisitor {
             "combinedClickable",
         )
 
-        // TODO write the actual error
         val ModifierChainWithSuspiciousOrder = """
             This order of modifiers is likely to cause visual issues. You should have your clickable modifiers after modifiers that use shapes, so that the clickable selected area takes into account the change in shape as well.
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierClickableOrder.kt
@@ -134,7 +134,7 @@ class ComposeModifierClickableOrder : ComposeKtVisitor {
         val ModifierChainWithSuspiciousOrder = """
             This order of modifiers is likely to cause visual issues. You should have your clickable modifiers after modifiers that use shapes, so that the clickable selected area takes into account the change in shape as well.
 
-            See https://mrmans0n.github.io/compose-rules/rules/#TODO for more information.
+            See https://mrmans0n.github.io/compose-rules/rules/#modifier-order-matters for more information.
         """.trimIndent()
     }
 }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierClickableOrder.kt
@@ -1,0 +1,80 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.util.argumentsUsingModifiers
+import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.obtainAllModifierNames
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFunction
+
+class ComposeModifierClickableOrder : ComposeKtVisitor {
+
+    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+        val code = function.bodyBlockExpression ?: return
+
+        val modifiers = code.obtainAllModifierNames("modifier")
+
+        val composables = code.findChildrenByClass<KtCallExpression>()
+            .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
+            .flatMap { callExpression ->
+                callExpression.argumentsUsingModifiers(modifiers + "Modifier")
+                    // We only want chains of more than 1 modifier
+                    .filter { argument -> argument.getArgumentExpression() is KtDotQualifiedExpression }
+                    .map { argument -> callExpression to argument }
+            }
+            .filter { (callExpression, valueArgument) ->
+                // TODO walk around the argument chains
+                true
+            }
+
+    }
+
+    private fun KtDotQualifiedExpression.analyzeChain() {
+        // KtDotQualifiedExpression are resolved from end to beginning, so:
+        // Modifier.a().b().c() -> (2) + CallExpression c ==> 3
+        // Modifier.a().b() -> (1) + CallExpression b ==> 2
+        // Modifier.a() -> (root expression) + CallExpression a ==> 1
+
+        val problematicCallExpressions = mutableListOf<KtCallExpression>()
+        var current: KtExpression = receiverExpression
+        while (current is KtDotQualifiedExpression) {
+            current as KtDotQualifiedExpression
+
+            // TODO is selector alright? double check
+            val selector = current.selectorExpression
+            if (selector is KtCallExpression) {
+                if (selector.name in interactionModifiers) {
+                    problematicCallExpressions.add(selector)
+                }
+            }
+
+            current = current.receiverExpression
+        }
+    }
+
+    companion object {
+        private val interactionModifiers = setOf(
+            "clickable",
+            "selectable",
+            "toggleable",
+            "triStateToggleable",
+            "combinedClickable"
+        )
+
+        val ModifiersAreSupposedToBeCalledModifierWhenAlone = """
+            Modifier parameters should be called `modifier`.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-modifiers-properly for more information.
+        """.trimIndent()
+        val ModifiersAreSupposedToEndInModifierWhenMultiple = """
+            Modifier parameters should be called `modifier` or end in `Modifier` if there are more than one in the same @Composable.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-modifiers-properly for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
@@ -7,15 +7,12 @@ import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
 import io.nlopez.rules.core.util.emitsContent
 import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.argumentsUsingModifiers
 import io.nlopez.rules.core.util.modifierParameter
 import io.nlopez.rules.core.util.obtainAllModifierNames
-import io.nlopez.rules.core.util.rootExpression
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtReferenceExpression
-import org.jetbrains.kotlin.psi.KtValueArgument
 
 class ComposeModifierNotUsedAtRoot : ComposeKtVisitor {
 
@@ -29,7 +26,7 @@ class ComposeModifierNotUsedAtRoot : ComposeKtVisitor {
         val errors = code.findChildrenByClass<KtCallExpression>()
             .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
             .mapNotNull { callExpression ->
-                val usage = callExpression.getModifierUsage(modifiers) ?: return@mapNotNull null
+                val usage = callExpression.argumentsUsingModifiers(modifiers).firstOrNull() ?: return@mapNotNull null
                 callExpression to usage
             }
             .filter { (callExpression, _) ->
@@ -43,24 +40,6 @@ class ComposeModifierNotUsedAtRoot : ComposeKtVisitor {
             emitter.report(valueArgument, ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
         }
     }
-
-    private fun KtCallExpression.getModifierUsage(modifierNames: List<String>): KtValueArgument? =
-        valueArguments.firstOrNull { argument ->
-            when (val expression = argument.getArgumentExpression()) {
-                // if it's MyComposable(modifier) or similar
-                is KtReferenceExpression -> {
-                    modifierNames.contains(expression.text)
-                }
-                // if it's MyComposable(modifier.fillMaxWidth()) or similar
-                is KtDotQualifiedExpression -> {
-                    // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
-                    // we need to iterate until we find the start of the chain
-                    modifierNames.contains(expression.rootExpression.text)
-                }
-
-                else -> false
-            }
-        }
 
     private fun KtCallExpression.findFirstAncestorEmittingContent(stopAt: PsiElement): KtCallExpression? {
         val origin = this

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierNotUsedAtRoot.kt
@@ -5,9 +5,9 @@ package io.nlopez.compose.rules
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.argumentsUsingModifiers
 import io.nlopez.rules.core.util.emitsContent
 import io.nlopez.rules.core.util.findChildrenByClass
-import io.nlopez.rules.core.util.argumentsUsingModifiers
 import io.nlopez.rules.core.util.modifierParameter
 import io.nlopez.rules.core.util.obtainAllModifierNames
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierClickableOrderCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierClickableOrderCheck.kt
@@ -1,0 +1,22 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.ComposeModifierClickableOrder
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class ComposeModifierClickableOrderCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ComposeModifierClickableOrder() {
+    override val issue: Issue = Issue(
+        id = "ModifierClickableOrder",
+        severity = Severity.Defect,
+        description = ComposeModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+        debt = Debt.FIVE_MINS,
+    )
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -5,7 +5,6 @@ package io.nlopez.compose.rules.detekt
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.nlopez.compose.rules.ComposeModifierClickableOrder
 
 class ComposeRuleSetProvider : RuleSetProvider {
     override val ruleSetId: String = CustomRuleSetId

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -5,6 +5,7 @@ package io.nlopez.compose.rules.detekt
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.nlopez.compose.rules.ComposeModifierClickableOrder
 
 class ComposeRuleSetProvider : RuleSetProvider {
     override val ruleSetId: String = CustomRuleSetId
@@ -15,6 +16,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             ComposeCompositionLocalAllowlistCheck(config),
             ComposeContentEmitterReturningValuesCheck(config),
             ComposeDefaultsVisibilityCheck(config),
+            ComposeModifierClickableOrderCheck(config),
             ComposeModifierComposableCheck(config),
             ComposeModifierMissingCheck(config),
             ComposeModifierNamingCheck(config),

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -5,6 +5,8 @@ Compose:
     active: true
   DefaultsVisibility:
     active: true
+  ModifierClickableOrder:
+    active: true
   ModifierComposable:
     active: true
   ModifierMissing:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeModifierClickableOrderCheckTest.kt
@@ -1,0 +1,74 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ComposeModifierClickableOrder
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierClickableOrderCheckTest {
+
+    private val rule = ComposeModifierClickableOrderCheck(Config.empty)
+
+    @Test
+    fun `errors when there is a suspicious chain of modifiers`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(modifier: Modifier = Modifier) {
+                    Something2(
+                        modifier = Modifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
+                    )
+                    Something3(
+                        modifier = modifier.clickable { }.clip(CircleShape())
+                    )
+                    Something4(
+                        Modifier.clickable { }.clip(MyShape)
+                    )
+                    Something5(
+                        modifier = Modifier.clip(CircleShape).clickable { }.background(MyShape)
+                    )
+                    Something6(
+                        modifier.clickable { }.then(if (x) border(TurdShape) else Modifier)
+                    )
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 29),
+                SourceLocation(7, 29),
+                SourceLocation(10, 18),
+                SourceLocation(13, 47),
+                SourceLocation(16, 18),
+            )
+
+        assertThat(errors[0]).hasMessage(ComposeModifierClickableOrder.ModifierChainWithSuspiciousOrder)
+    }
+
+    @Test
+    fun `passes with the correct order of modifiers`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1() {
+                    Something2(
+                        modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(shape = Circle()).clickable { }
+                    )
+                    Something2(
+                        modifier = Modifier.clip(shape = Whatever).background().clickable { }
+                    )
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierClickableOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierClickableOrderCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.ComposeModifierClickableOrder
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class ComposeModifierClickableOrderCheck :
+    KtlintRule("compose:modifier-clickable-order"),
+    ComposeKtVisitor by ComposeModifierClickableOrder()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -14,6 +14,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { ComposeCompositionLocalAllowlistCheck() },
         RuleProvider { ComposeContentEmitterReturningValuesCheck() },
         RuleProvider { ComposeDefaultsVisibilityCheck() },
+        RuleProvider { ComposeModifierClickableOrderCheck() },
         RuleProvider { ComposeModifierComposableCheck() },
         RuleProvider { ComposeModifierMissingCheck() },
         RuleProvider { ComposeModifierNamingCheck() },

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeModifierClickableOrderCheckTest.kt
@@ -1,0 +1,86 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ComposeModifierClickableOrder
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposeModifierClickableOrderCheckTest {
+
+    private val modifierRuleAssertThat = assertThatRule { ComposeModifierClickableOrderCheck() }
+
+    @Test
+    fun `errors when there is a suspicious chain of modifiers`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(modifier: Modifier = Modifier) {
+                    Something2(
+                        modifier = Modifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
+                    )
+                    Something3(
+                        modifier = modifier.clickable { }.clip(CircleShape())
+                    )
+                    Something4(
+                        Modifier.clickable { }.clip(MyShape)
+                    )
+                    Something5(
+                        modifier = Modifier.clip(CircleShape).clickable { }.background(MyShape)
+                    )
+                    Something6(
+                        modifier.clickable { }.then(if (x) border(TurdShape) else Modifier)
+                    )
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 4,
+                col = 29,
+                detail = ComposeModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 7,
+                col = 29,
+                detail = ComposeModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 10,
+                col = 18,
+                detail = ComposeModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 13,
+                col = 47,
+                detail = ComposeModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 16,
+                col = 18,
+                detail = ComposeModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+        )
+    }
+
+    @Test
+    fun `passes with the correct order of modifiers`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1() {
+                    Something2(
+                        modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(shape = Circle()).clickable { }
+                    )
+                    Something2(
+                        modifier = Modifier.clip(shape = Whatever).background().clickable { }
+                    )
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
Add a new rule that detects a suspicious chain of modifiers, e.g. using clipping / background with shapes after a clickable-like modifier will likely result in incorrect UI.

Fixes #90 