### PR TITLE
Fix documentation about composed modifiers

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -332,11 +332,9 @@ Related rule: [compose:modifier-naming](https://github.com/mrmans0n/compose-rule
 
 ### Avoid Modifier extension factory functions
 
-Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use `Modifier.composed` instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use [Modifier.Node](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier.Node) instead. It will allow you to accomplish the same things while being very performant, and not using a `@Composable` unnecessarily.
 
-Composed modifiers may be created outside of composition, shared across elements, and declared as top-level constants, making them more flexible than modifiers that can only be created via a `@Composable` function call, and easier to avoid accidentally sharing state across elements.
-
-More info: [Modifier extensions](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#extension-functions), [Composed modifiers in Jetpack Compose by Jorge Castillo](https://jorgecastillo.dev/composed-modifiers-in-jetpack-compose) and [Composed modifiers in API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md#composed-modifiers)
+More info: [Modifier.Node](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier.Node), [Compose Modifier.Node and where to find it, by Merab Tato Kutalia](https://proandroiddev.com/compose-modifier-node-and-where-to-find-it-merab-tato-kutalia-66f891c0e8) and [Compose modifiers deep dive, with Leland Richardson](https://www.youtube.com/watch?v=BjGX2RftXsU)
 
 Related rule: [compose:modifier-composable-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierComposable.kt)
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierComposable.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposeModifierComposable.kt
@@ -19,7 +19,7 @@ class ComposeModifierComposable : ComposeKtVisitor {
     companion object {
         val ComposableModifier = """
             Using @Composable builder functions for modifiers is not recommended, as they cause unnecessary recompositions.
-            You should use Modifier.composed { ... } instead, as it limits recomposition to just the modifier instance, rather than the whole function tree.
+            You should consider migrating this modifier to be based on Modifier.Node instead.
 
             See https://mrmans0n.github.io/compose-rules/rules/#avoid-modifier-extension-factory-functions for more information.
         """.trimIndent()


### PR DESCRIPTION
Using `composed` for Modifiers is not the recommended practice anymore. Instead, `Modifier.Node` should be used. This commit updates the docs to reflect that.

Fixes #118 