### PR TITLE
Add ComposableAnnotationNaming rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -20,6 +20,8 @@ For the rules to be picked up, you will need to enable them in your `detekt.yml`
 
 ```yaml
 Compose:
+  ComposableAnnotationNaming:
+    active: true
   CompositionLocalAllowlist:
     active: true
     # You can optionally define a list of CompositionLocals that are allowed here

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -153,6 +153,12 @@ More information: [Naming Unit @Composable functions as entities](https://github
 
 Related rule: [compose:naming-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/Naming.kt)
 
+### Naming Composable annotations properly
+
+Custom Composable annotations (tagged with [`@ComposableTargetMarker`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/ComposableTargetMarker#description())) should have the `Composable` prefix (for example, `@GoogleMapComposable` or `@MosaicComposable`).
+
+Related rule: [compose:composable-annotation-naming-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableAnnotationNaming.kt)
+
 ### Ordering @Composable parameters properly
 
 When writing Kotlin, it's a good practice to write the parameters for your methods by putting the mandatory parameters first, followed by the optional ones (aka the ones with default values). By doing so, [we minimize the number times we will need to write the name for arguments explicitly](https://kotlinlang.org/docs/functions.html#default-arguments).

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableAnnotationNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableAnnotationNaming.kt
@@ -1,0 +1,34 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtClass
+
+class ComposableAnnotationNaming : ComposeKtVisitor {
+    override fun visitClass(clazz: KtClass, autoCorrect: Boolean, emitter: Emitter) {
+        if (!clazz.isAnnotation()) return
+        if (!clazz.isComposableTargetMarkerAnnotation) return
+
+        val name = clazz.nameAsSafeName.asString()
+        if (!name.endsWith("Composable")) {
+            emitter.report(clazz, ComposableAnnotationDoesNotEndWithComposable)
+        }
+    }
+
+    private val KtAnnotated.isComposableTargetMarkerAnnotation: Boolean
+        get() = annotationEntries.any {
+            it.calleeExpression?.text?.contains("ComposableTargetMarker") == true
+        }
+
+    companion object {
+        val ComposableAnnotationDoesNotEndWithComposable = """
+            Composable annotations (e.g. tagged with `@ComposableTargetMarker`) should have the `Composable` suffix.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-composable-annotations-properly for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposableAnnotationNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposableAnnotationNamingCheck.kt
@@ -1,0 +1,23 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.ComposableAnnotationNaming
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class ComposableAnnotationNamingCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ComposableAnnotationNaming() {
+
+    override val issue: Issue = Issue(
+        id = "ComposableAnnotationNaming",
+        severity = Severity.CodeSmell,
+        description = ComposableAnnotationNaming.ComposableAnnotationDoesNotEndWithComposable,
+        debt = Debt.FIVE_MINS,
+    )
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -12,6 +12,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
     override fun instance(config: Config): RuleSet = RuleSet(
         CustomRuleSetId,
         listOf(
+            ComposableAnnotationNamingCheck(config),
             CompositionLocalAllowlistCheck(config),
             ContentEmitterReturningValuesCheck(config),
             DefaultsVisibilityCheck(config),

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -1,4 +1,6 @@
 Compose:
+  ComposableAnnotationNaming:
+    active: true
   CompositionLocalAllowlist:
     active: true
   ContentEmitterReturningValues:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableAnnotationNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableAnnotationNamingCheckTest.kt
@@ -1,0 +1,62 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ComposableAnnotationNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposableAnnotationNamingCheckTest {
+
+    private val rule = ComposableAnnotationNamingCheck(Config.empty)
+
+    @Test
+    fun `passes for non-composable annotations`() {
+        @Language("kotlin")
+        val code =
+            """
+            annotation class Banana
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes for composable annotations with the proper names`() {
+        @Language("kotlin")
+        val code =
+            """
+            @ComposableTargetMarker
+            annotation class BananaComposable
+            @ComposableTargetMarker
+            annotation class AppleComposable
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `errors when a composable annotation is not correctly named`() {
+        @Language("kotlin")
+        val code =
+            """
+            @ComposableTargetMarker
+            annotation class Banana
+            @ComposableTargetMarker
+            annotation class Apple
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasStartSourceLocations(
+            SourceLocation(2, 18),
+            SourceLocation(4, 18),
+        )
+        for (error in errors) {
+            assertThat(error)
+                .hasMessage(ComposableAnnotationNaming.ComposableAnnotationDoesNotEndWithComposable)
+        }
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableAnnotationNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableAnnotationNamingCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.ComposableAnnotationNaming
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class ComposableAnnotationNamingCheck :
+    KtlintRule("compose:composable-annotation-naming"),
+    ComposeKtVisitor by ComposableAnnotationNaming()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -11,6 +11,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
 ) {
 
     override fun getRuleProviders(): Set<RuleProvider> = setOf(
+        RuleProvider { ComposableAnnotationNamingCheck() },
         RuleProvider { CompositionLocalAllowlistCheck() },
         RuleProvider { ContentEmitterReturningValuesCheck() },
         RuleProvider { DefaultsVisibilityCheck() },

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableAnnotationNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableAnnotationNamingCheckTest.kt
@@ -1,0 +1,61 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ComposableAnnotationNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposableAnnotationNamingCheckTest {
+
+    private val ruleAssertThat = assertThatRule { ComposableAnnotationNamingCheck() }
+
+    @Test
+    fun `passes for non-composable annotations`() {
+        @Language("kotlin")
+        val code =
+            """
+            annotation class Banana
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes for composable annotations with the proper names`() {
+        @Language("kotlin")
+        val code =
+            """
+            @ComposableTargetMarker
+            annotation class BananaComposable
+            @ComposableTargetMarker
+            annotation class AppleComposable
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `errors when a composable annotation is not correctly named`() {
+        @Language("kotlin")
+        val code =
+            """
+            @ComposableTargetMarker
+            annotation class Banana
+            @ComposableTargetMarker
+            annotation class Apple
+            """.trimIndent()
+        ruleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 18,
+                detail = ComposableAnnotationNaming.ComposableAnnotationDoesNotEndWithComposable,
+            ),
+            LintViolation(
+                line = 4,
+                col = 18,
+                detail = ComposableAnnotationNaming.ComposableAnnotationDoesNotEndWithComposable,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Adds a new rule to make sure all @ComposableTargetMarker annotated annotations (e.g. custom composable annotations) end with `Composable`.