### PR TITLE
Bring back CompositionLocalNaming check

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -26,6 +26,8 @@ Compose:
     active: true
     # You can optionally define a list of CompositionLocals that are allowed here
     # allowedCompositionLocals: LocalSomething,LocalSomethingElse
+  CompositionLocalNaming:
+    active: true
   ContentEmitterReturningValues:
     active: true
     # You can optionally add your own composables here

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -135,6 +135,14 @@ Related rule: [compose:multiple-emitters-check](https://github.com/mrmans0n/comp
 
 > **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
 
+### Naming CompositionLocals properly
+
+`CompositionLocal`s should be named by using the adjective `Local` as prefix, followed by a descriptive noun that describes the value they hold. This makes it easier to know when a value comes from a `CompositionLocal`. Given that these are implicit dependencies, we should make them obvious.
+
+More information: [Naming CompositionLocals](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-api-guidelines.md#naming-compositionlocals)
+
+Related rule: [compose:compositionlocal-naming](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/composerules/CompositionLocalNaming.kt)
+
 ### Naming multipreview annotations properly
 
 Multipreview annotations should be named by using `Previews` as a prefix. These annotations have to be explicitly named to make sure that they are clearly identifiable as a `@Preview` alternative on its usages.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/CompositionLocalNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/CompositionLocalNaming.kt
@@ -1,0 +1,35 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.declaresCompositionLocal
+import io.nlopez.rules.core.util.findChildrenByClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtProperty
+
+class CompositionLocalNaming : ComposeKtVisitor {
+
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+        val compositionLocals = file.findChildrenByClass<KtProperty>()
+            .filter { it.declaresCompositionLocal }
+
+        if (compositionLocals.none()) return
+
+        val notAllowed = compositionLocals.filterNot { it.nameIdentifier?.text?.startsWith("Local") == true }
+
+        for (compositionLocal in notAllowed) {
+            emitter.report(compositionLocal, CompositionLocalNeedsLocalPrefix)
+        }
+    }
+
+    companion object {
+        val CompositionLocalNeedsLocalPrefix = """
+            CompositionLocals should be named using the `Local` prefix as an adjective, followed by a descriptive noun.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -14,6 +14,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
         listOf(
             ComposableAnnotationNamingCheck(config),
             CompositionLocalAllowlistCheck(config),
+            CompositionLocalNamingCheck(config),
             ContentEmitterReturningValuesCheck(config),
             DefaultsVisibilityCheck(config),
             ModifierClickableOrderCheck(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheck.kt
@@ -1,0 +1,23 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.CompositionLocalNaming
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class CompositionLocalNamingCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by CompositionLocalNaming() {
+
+    override val issue: Issue = Issue(
+        id = "CompositionLocalNaming",
+        severity = Severity.CodeSmell,
+        description = CompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
+        debt = Debt.FIVE_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -3,6 +3,8 @@ Compose:
     active: true
   CompositionLocalAllowlist:
     active: true
+  CompositionLocalNaming:
+    active: true
   ContentEmitterReturningValues:
     active: true
   DefaultsVisibility:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheckTest.kt
@@ -1,0 +1,47 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.CompositionLocalNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class CompositionLocalNamingCheckTest {
+
+    private val rule = CompositionLocalNamingCheck(Config.empty)
+
+    @Test
+    fun `error when a CompositionLocal has a wrong name`() {
+        @Language("kotlin")
+        val code =
+            """
+                val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
+                val Plum: String = staticCompositionLocalOf { "Plum" }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(1, 5),
+                SourceLocation(2, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(CompositionLocalNaming.CompositionLocalNeedsLocalPrefix)
+        }
+    }
+
+    @Test
+    fun `passes when a CompositionLocal is well named`() {
+        @Language("kotlin")
+        val code =
+            """
+                val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
+                val LocalPotato = compositionLocalOf { "Potato" }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -13,6 +13,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
     override fun getRuleProviders(): Set<RuleProvider> = setOf(
         RuleProvider { ComposableAnnotationNamingCheck() },
         RuleProvider { CompositionLocalAllowlistCheck() },
+        RuleProvider { CompositionLocalNamingCheck() },
         RuleProvider { ContentEmitterReturningValuesCheck() },
         RuleProvider { DefaultsVisibilityCheck() },
         RuleProvider { ModifierClickableOrderCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.CompositionLocalNaming
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class CompositionLocalNamingCheck :
+    KtlintRule("compose:compositionlocal-naming"),
+    ComposeKtVisitor by CompositionLocalNaming()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheckTest.kt
@@ -1,0 +1,48 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.CompositionLocalNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class CompositionLocalNamingCheckTest {
+
+    private val ruleAssertThat = assertThatRule { CompositionLocalNamingCheck() }
+
+    @Test
+    fun `error when a CompositionLocal has a wrong name`() {
+        @Language("kotlin")
+        val code =
+            """
+                val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
+                val Plum: String = staticCompositionLocalOf { "Plum" }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 1,
+                    col = 5,
+                    detail = CompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
+                ),
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = CompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when a CompositionLocal is well named`() {
+        @Language("kotlin")
+        val code =
+            """
+                val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
+                val LocalPotato = compositionLocalOf { "Potato" }
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
Initially, this rule was removed in be4ea6fbed61abfef0db68a7ee2f5458ae2b8ca4 because Android lint has a similar rule already. However, having it as part of this ruleset is useful for KMP projects anyway. 