### PR TITLE
Take for loops into account for MultipleContentEmitters rule

### DIFF
--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -166,4 +166,33 @@ class MultipleContentEmittersCheckTest {
             .hasStartSourceLocation(2, 5)
         assertThat(errors.first()).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
     }
+
+    @Test
+    fun `for loops are captured`() {
+        @Language("kotlin")
+        val code = """
+            @Composable
+            fun MultipleContent(texts: List<String>, modifier: Modifier = Modifier) {
+                for (text in texts) {
+                    Text(text)
+                }
+            }
+            @Composable
+            fun MultipleContent(otherTexts: List<String>, modifier: Modifier = Modifier) {
+                Text("text 1")
+                for (otherText in otherTexts) {
+                    Text(otherText)
+                }
+            }
+        """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 5),
+                SourceLocation(8, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
+        }
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -171,4 +171,36 @@ class MultipleContentEmittersCheckTest {
             ),
         )
     }
+
+    @Test
+    fun `for loops are captured`() {
+        @Language("kotlin")
+        val code = """
+            @Composable
+            fun MultipleContent(texts: List<String>, modifier: Modifier = Modifier) {
+                for (text in texts) {
+                    Text(text)
+                }
+            }
+            @Composable
+            fun MultipleContent(otherTexts: List<String>, modifier: Modifier = Modifier) {
+                Text("text 1")
+                for (otherText in otherTexts) {
+                    Text(otherText)
+                }
+            }
+        """.trimIndent()
+        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+            ),
+            LintViolation(
+                line = 8,
+                col = 5,
+                detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
Detect for loops (in a best effort way) and have them influence calculations on MultipleContentEmitters, so that we can detect more issues of this ilk.