### PR TITLE
Update config setting to avoid PsiElement#get/putUserData

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/ComposeKtConfig.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/ComposeKtConfig.kt
@@ -2,36 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.rules.core
 
-import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.openapi.util.Key
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-
 interface ComposeKtConfig {
     fun getInt(key: String, default: Int): Int
     fun getString(key: String, default: String?): String?
     fun getList(key: String, default: List<String>): List<String>
     fun getSet(key: String, default: Set<String>): Set<String>
     fun getBoolean(key: String, default: Boolean): Boolean
-
-    companion object {
-        private val Key: Key<ComposeKtConfig> = Key("compose_rules_config")
-        private val ReturnDefaults = object : ComposeKtConfig {
-            override fun getInt(key: String, default: Int): Int = default
-            override fun getString(key: String, default: String?): String? = default
-            override fun getList(key: String, default: List<String>): List<String> = default
-            override fun getSet(key: String, default: Set<String>) = default
-            override fun getBoolean(key: String, default: Boolean) = default
-        }
-
-        fun PsiElement.config(): ComposeKtConfig = containingFile.getUserData(Key) ?: ReturnDefaults
-
-        fun ASTNode.config(): ComposeKtConfig = psi.config()
-
-        private val PsiElement.hasConfigAttached: Boolean
-            get() = containingFile.getUserData(Key) != null
-
-        fun PsiElement.attach(config: ComposeKtConfig) {
-            if (!hasConfigAttached) containingFile.putUserData(Key, config)
-        }
-    }
 }

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/ComposeKtVisitor.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/ComposeKtVisitor.kt
@@ -7,11 +7,12 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 
 interface ComposeKtVisitor {
-    fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {}
 
-    fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {}
+    fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {}
 
-    fun visitClass(clazz: KtClass, autoCorrect: Boolean, emitter: Emitter) {}
+    fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {}
 
-    fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {}
+    fun visitClass(clazz: KtClass, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {}
+
+    fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {}
 }

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.rules.core.util
 
-import io.nlopez.rules.core.ComposeKtConfig.Companion.config
+import io.nlopez.rules.core.ComposeKtConfig
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
+context(ComposeKtConfig)
 val KtFunction.emitsContent: Boolean
     get() {
         return if (isComposable) {
@@ -42,12 +43,13 @@ val KtFunction.emitsContent: Boolean
 private val KtCallExpression.emitExplicitlyNoContent: Boolean
     get() = calleeExpression?.text in ComposableNonEmittersList
 
+context(ComposeKtConfig)
 val KtCallExpression.emitsContent: Boolean
     get() {
         val methodName = calleeExpression?.text ?: return false
         return methodName in ComposableEmittersList ||
             ComposableEmittersListRegex.matches(methodName) ||
-            methodName in config().getSet("contentEmitters", emptySet()) ||
+            methodName in getSet("contentEmitters", emptySet()) ||
             containsComposablesWithModifiers
     }
 

--- a/core-detekt/src/main/kotlin/io/nlopez/rules/core/detekt/DetektRule.kt
+++ b/core-detekt/src/main/kotlin/io/nlopez/rules/core/detekt/DetektRule.kt
@@ -9,7 +9,6 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.nlopez.rules.core.ComposeKtConfig
-import io.nlopez.rules.core.ComposeKtConfig.Companion.attach
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.isComposable
@@ -51,25 +50,22 @@ abstract class DetektRule(
 
     override fun visit(root: KtFile) {
         super.visit(root)
-        root.attach(config)
-        visitFile(root, autoCorrect, emitter)
+        visitFile(root, autoCorrect, emitter, config)
     }
 
     override fun visitClass(klass: KtClass) {
         super<Rule>.visitClass(klass)
-        klass.attach(config)
-        visitClass(klass, autoCorrect, emitter)
+        visitClass(klass, autoCorrect, emitter, config)
     }
 
     override fun visitKtElement(element: KtElement) {
         super.visitKtElement(element)
-        element.attach(config)
         when (element.node.elementType) {
             KtStubElementTypes.FUNCTION -> {
                 val function = element as KtFunction
-                visitFunction(function, autoCorrect, emitter)
+                visitFunction(function, autoCorrect, emitter, config)
                 if (function.isComposable) {
-                    visitComposable(function, autoCorrect, emitter)
+                    visitComposable(function, autoCorrect, emitter, config)
                 }
             }
         }

--- a/core-ktlint/src/main/kotlin/io/nlopez/rules/core/ktlint/KtlintRule.kt
+++ b/core-ktlint/src/main/kotlin/io/nlopez/rules/core/ktlint/KtlintRule.kt
@@ -7,7 +7,6 @@ import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import io.nlopez.rules.core.ComposeKtConfig
-import io.nlopez.rules.core.ComposeKtConfig.Companion.attach
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.isComposable
@@ -51,17 +50,16 @@ abstract class KtlintRule(
         val psi = node.psi
         when (node.elementType) {
             KtStubElementTypes.FILE -> {
-                psi.attach(config)
-                visitFile(psi as KtFile, autoCorrect, emit.toEmitter())
+                visitFile(psi as KtFile, autoCorrect, emit.toEmitter(), config)
             }
 
-            KtStubElementTypes.CLASS -> visitClass(psi as KtClass, autoCorrect, emit.toEmitter())
+            KtStubElementTypes.CLASS -> visitClass(psi as KtClass, autoCorrect, emit.toEmitter(), config)
             KtStubElementTypes.FUNCTION -> {
                 val function = psi as KtFunction
                 val emitter = emit.toEmitter()
-                visitFunction(function, autoCorrect, emitter)
+                visitFunction(function, autoCorrect, emitter, config)
                 if (function.isComposable) {
-                    visitComposable(function, autoCorrect, emitter)
+                    visitComposable(function, autoCorrect, emitter, config)
                 }
             }
         }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableAnnotationNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableAnnotationNaming.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -9,7 +10,7 @@ import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtClass
 
 class ComposableAnnotationNaming : ComposeKtVisitor {
-    override fun visitClass(clazz: KtClass, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitClass(clazz: KtClass, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
         if (!clazz.isAnnotation()) return
         if (!clazz.isComposableTargetMarkerAnnotation) return
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/CompositionLocalAllowlist.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/CompositionLocalAllowlist.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
-import io.nlopez.rules.core.ComposeKtConfig.Companion.config
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -13,13 +13,13 @@ import org.jetbrains.kotlin.psi.KtProperty
 
 class CompositionLocalAllowlist : ComposeKtVisitor {
 
-    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
         val compositionLocals = file.findChildrenByClass<KtProperty>()
             .filter { it.declaresCompositionLocal }
 
         if (compositionLocals.none()) return
 
-        val allowed = file.config().getSet("allowedCompositionLocals", emptySet())
+        val allowed = config.getSet("allowedCompositionLocals", emptySet())
         val notAllowed = compositionLocals.filterNot { allowed.contains(it.nameIdentifier?.text) }
 
         for (compositionLocal in notAllowed) {

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/CompositionLocalNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/CompositionLocalNaming.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -12,7 +13,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 
 class CompositionLocalNaming : ComposeKtVisitor {
 
-    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
         val compositionLocals = file.findChildrenByClass<KtProperty>()
             .filter { it.declaresCompositionLocal }
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/DefaultsVisibility.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/DefaultsVisibility.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -19,7 +20,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 class DefaultsVisibility : ComposeKtVisitor {
 
-    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
         val composables = file.findChildrenByClass<KtFunction>()
             .filter { it.isComposable }
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -18,7 +19,12 @@ import org.jetbrains.kotlin.psi.KtValueArgument
 
 class ModifierClickableOrder : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         val code = function.bodyBlockExpression ?: return
 
         val modifiers = code.obtainAllModifierNames("modifier")

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -10,7 +11,12 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class ModifierComposable : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         if (!function.isModifierReceiver) return
 
         emitter.report(function, ComposableModifier)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierMissing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierMissing.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
-import io.nlopez.rules.core.ComposeKtConfig.Companion.config
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -18,7 +18,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 class ModifierMissing : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         // We want to find all composable functions that:
         //  - emit content
         //  - are not overridden or part of an interface
@@ -38,7 +43,7 @@ class ModifierMissing : ComposeKtVisitor {
         // - public_and_internal: will check for public and internal composables
         // - all: will check all composables (public, internal, protected, private
         val shouldCheck = when (
-            function.config().getString("checkModifiersForVisibility", "only_public")
+            config.getString("checkModifiersForVisibility", "only_public")
         ) {
             "only_public" -> function.isPublic
             "public_and_internal" -> function.isPublic || function.isInternal
@@ -51,7 +56,7 @@ class ModifierMissing : ComposeKtVisitor {
         if (function.modifierParameter != null) return
 
         // In case we didn't find any `modifier` parameters, we check if it emits content and report the error if so.
-        if (function.emitsContent) {
+        if (with(config) { function.emitsContent }) {
             emitter.report(function, MissingModifierContentComposable)
         }
     }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNaming.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -10,7 +11,12 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class ModifierNaming : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         // If there is a modifier param, we bail
         val modifiers = function.valueParameters.filter { it.isModifier }
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.emitsContent
@@ -16,8 +17,14 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 class ModifierReused : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
-        if (!function.emitsContent) return
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
+        with(config) { if (!function.emitsContent) return }
+
         val composableBlockExpression = function.bodyBlockExpression ?: return
         val initialModifierNames = function.modifierParameters.mapNotNull { it.name }
         if (initialModifierNames.isEmpty()) return

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierWithoutDefault.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierWithoutDefault.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.definedInInterface
@@ -15,7 +16,12 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class ModifierWithoutDefault : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         if (function.definedInInterface || function.isActual || function.isOverride || function.isAbstract) return
 
         // Look for modifier params in the composable signature, and if any without a default value is found, error out.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableParameters.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableParameters.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -10,7 +11,12 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class MutableParameters : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         function.valueParameters
             .filter { it.isTypeMutable }
             .forEach { emitter.report(it, MutableParameterInCompose) }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/Naming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/Naming.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
-import io.nlopez.rules.core.ComposeKtConfig.Companion.config
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -13,7 +13,12 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class Naming : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         // If it's a block we can't know if there is a return type or not
         if (!function.hasBlockBody()) return
 
@@ -27,7 +32,7 @@ class Naming : ComposeKtVisitor {
             // If it returns value, the composable should start with a lowercase letter
             if (firstLetter.isUpperCase()) {
                 // If it's allowed, we don't report it
-                val isAllowed = function.config().getSet("allowedComposableFunctionNames", emptySet())
+                val isAllowed = config.getSet("allowedComposableFunctionNames", emptySet())
                     .any {
                         it.toRegex().matches(functionName)
                     }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -14,7 +15,12 @@ import org.jetbrains.kotlin.psi.KtParameter
 
 class ParameterOrder : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         // We need to make sure the proper order is respected. It should be:
         // 1. params without defaults
         // 2. modifiers

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewAnnotationNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewAnnotationNaming.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -9,7 +10,7 @@ import io.nlopez.rules.core.util.isPreview
 import org.jetbrains.kotlin.psi.KtClass
 
 class PreviewAnnotationNaming : ComposeKtVisitor {
-    override fun visitClass(clazz: KtClass, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitClass(clazz: KtClass, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
         if (!clazz.isAnnotation()) return
         if (!clazz.isPreview) return
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewPublic.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewPublic.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.firstChildLeafOrSelf
@@ -13,7 +14,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 class PreviewPublic : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         // We only want previews
         if (!function.isPreview) return
         // We only care about public methods

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberContentMissing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberContentMissing.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.findChildrenByClass
@@ -11,7 +12,12 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class RememberContentMissing : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         // To keep memory consumption in check, we first traverse down until we see one of our known functions
         // that need remembering
         function.findChildrenByClass<KtCallExpression>()

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberStateMissing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberStateMissing.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.findChildrenByClass
@@ -11,7 +12,12 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class RememberStateMissing : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         // To keep memory consumption in check, we first traverse down until we see one of our known functions
         // that need remembering
         function.findChildrenByClass<KtCallExpression>()

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
@@ -11,7 +12,12 @@ import java.util.*
 
 class UnstableCollections : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         for (param in function.valueParameters.filter { it.isTypeUnstableCollection }) {
             val variableName = param.nameAsSafeName.asString()
             val type = param.typeReference?.text ?: "List/Set/Map"

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelForwarding.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelForwarding.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
-import io.nlopez.rules.core.ComposeKtConfig.Companion.config
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.definedInInterface
@@ -16,7 +16,12 @@ import org.jetbrains.kotlin.psi.KtReferenceExpression
 
 class ViewModelForwarding : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         if (function.isOverride || function.definedInInterface || function.isActual) return
         val bodyBlock = function.bodyBlockExpression ?: return
 
@@ -26,7 +31,7 @@ class ViewModelForwarding : ComposeKtVisitor {
         if (parameters.isEmpty()) return
 
         val stateHolderValidNames = Regex(
-            function.config()
+            config
                 .getList("allowedStateHolderNames", defaultStateHolderNames)
                 .ifEmpty { defaultStateHolderNames }
                 .joinToString(

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelInjection.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelInjection.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
-import io.nlopez.rules.core.ComposeKtConfig.Companion.config
+import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.util.definedInInterface
@@ -23,13 +23,18 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 
 class ViewModelInjection : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, autoCorrect: Boolean, emitter: Emitter) {
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) {
         if (function.isOverride || function.definedInInterface) return
 
         val bodyBlock = function.bodyBlockExpression ?: return
 
         val knownViewModelFactories = DefaultKnownViewModelFactories +
-            function.config().getSet("viewModelFactories", emptySet())
+            config.getSet("viewModelFactories", emptySet())
 
         bodyBlock.findChildrenByClass<KtProperty>()
             .flatMap { property ->


### PR DESCRIPTION
As there are a couple issues with config setting (#109, #142), I want to eliminate a potential (?) source of issues, which is using the UserData dictionaries that are present in PSIElement, and use the config wrappers directly. This should be a more robust solution in theory, and removes somewhere to look at when something's wrong, which is great. 

The annoying part which was being able to use the config in content emitter checks can be worked around by using context receivers easily, so I did that.