### PR TITLE
Add support for numeric state types in RememberStateMissing

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtCallableDeclarations.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtCallableDeclarations.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.psi.KtCallableDeclaration
 val KtCallableDeclaration.isTypeMutable: Boolean
     get() = typeReference?.text?.matchesAnyOf(KnownMutableCommonTypesRegex) == true
 
-val KnownMutableCommonTypesRegex = sequenceOf(
+private val KnownMutableCommonTypesRegex = sequenceOf(
     // Set
     "MutableSet<.*>\\??",
     "ArraySet<.*>\\??",

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheckTest.kt
@@ -45,7 +45,7 @@ class RememberStateMissingCheckTest {
                 SourceLocation(6, 45),
             )
         for (error in errors) {
-            assertThat(error).hasMessage(RememberStateMissing.MutableStateOfNotRemembered)
+            assertThat(error).hasMessage(RememberStateMissing.errorMessage("mutableStateOf"))
         }
     }
 
@@ -114,7 +114,7 @@ class RememberStateMissingCheckTest {
                 SourceLocation(6, 45),
             )
         for (error in errors) {
-            assertThat(error).hasMessage(RememberStateMissing.DerivedStateOfNotRemembered)
+            assertThat(error).hasMessage(RememberStateMissing.errorMessage("derivedStateOf"))
         }
     }
 

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberStateMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberStateMissingCheckTest.kt
@@ -39,12 +39,12 @@ class RememberStateMissingCheckTest {
             LintViolation(
                 line = 3,
                 col = 21,
-                detail = RememberStateMissing.MutableStateOfNotRemembered,
+                detail = RememberStateMissing.errorMessage("mutableStateOf"),
             ),
             LintViolation(
                 line = 6,
                 col = 45,
-                detail = RememberStateMissing.MutableStateOfNotRemembered,
+                detail = RememberStateMissing.errorMessage("mutableStateOf"),
             ),
         )
     }
@@ -108,12 +108,12 @@ class RememberStateMissingCheckTest {
             LintViolation(
                 line = 3,
                 col = 21,
-                detail = RememberStateMissing.DerivedStateOfNotRemembered,
+                detail = RememberStateMissing.errorMessage("derivedStateOf"),
             ),
             LintViolation(
                 line = 6,
                 col = 45,
-                detail = RememberStateMissing.DerivedStateOfNotRemembered,
+                detail = RememberStateMissing.errorMessage("derivedStateOf"),
             ),
         )
     }


### PR DESCRIPTION
Adds support for `mutableIntStateOf`, `mutableFloatStateOf`, `mutableDoubleStateOf` and `mutableLongStateOf` in RememberStateMissing rule.