### PR TITLE
Add support to configure custom Modifier types

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.rules.core.util
 
+import io.nlopez.rules.core.ComposeKtConfig
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
@@ -76,17 +77,21 @@ val ModifierNames by lazy(LazyThreadSafetyMode.NONE) {
     )
 }
 
+context(ComposeKtConfig)
 val KtCallableDeclaration.isModifier: Boolean
-    get() = typeReference?.text in ModifierNames
+    get() = typeReference?.text in ModifierNames + getSet("customModifiers", emptySet())
 
+context(ComposeKtConfig)
 val KtCallableDeclaration.isModifierReceiver: Boolean
-    get() = receiverTypeReference?.text in ModifierNames
+    get() = receiverTypeReference?.text in ModifierNames + getSet("customModifiers", emptySet())
 
+context(ComposeKtConfig)
 val KtFunction.modifierParameter: KtParameter?
     get() {
         val modifiers = valueParameters.filter { it.isModifier }
         return modifiers.firstOrNull { it.name == "modifier" } ?: modifiers.firstOrNull()
     }
 
+context(ComposeKtConfig)
 val KtFunction.modifierParameters: List<KtParameter>
     get() = valueParameters.filter { it.isModifier }

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -44,19 +44,29 @@ Compose:
     active: true
   ModifierComposable:
     active: true
+    # You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
   ModifierMissing:
     active: true
     # You can optionally control the visibility of which composables to check for here
     # Possible values are: `only_public`, `public_and_internal` and `all` (default is `only_public`)
     # checkModifiersForVisibility: only_public
+    # You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
   ModifierNaming:
     active: true
+    # You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
   ModifierNotUsedAtRoot:
     active: true
     # You can optionally add your own composables here
     # contentEmitters: MyComposable,MyOtherComposable
+    # You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
   ModifierReused:
     active: true
+    # You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
   ModifierWithoutDefault:
     active: true
   MultipleEmitters:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -98,6 +98,15 @@ Possible values are:
 * `public_and_internal`: Will check for missing modifiers in both public and internal composables.
 * `all`: Will check for missing modifiers in all composables.
 
+### Configure custom Modifier names
+
+Most of the modifier-related rules will look for modifiers based their type: either Modifier or GlanceModifier type. Some libraries might add their own flavor of Modifier to the mix, and it might make sense to enforce the same rules we have for the other default modifiers. To support that, you can configure this in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_custom_modifiers = BananaModifier,PotatoModifier
+```
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `compose` tag.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt
@@ -17,7 +17,7 @@ class ModifierComposable : ComposeKtVisitor {
         emitter: Emitter,
         config: ComposeKtConfig,
     ) {
-        if (!function.isModifierReceiver) return
+        if (!with(config) { function.isModifierReceiver }) return
 
         emitter.report(function, ComposableModifier)
     }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierMissing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierMissing.kt
@@ -53,7 +53,7 @@ class ModifierMissing : ComposeKtVisitor {
         if (!shouldCheck) return
 
         // If there is a modifier param, we bail
-        if (function.modifierParameter != null) return
+        if (with(config) { function.modifierParameter } != null) return
 
         // In case we didn't find any `modifier` parameters, we check if it emits content and report the error if so.
         if (with(config) { function.emitsContent }) {

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNaming.kt
@@ -18,7 +18,7 @@ class ModifierNaming : ComposeKtVisitor {
         config: ComposeKtConfig,
     ) {
         // If there is a modifier param, we bail
-        val modifiers = function.valueParameters.filter { it.isModifier }
+        val modifiers = function.valueParameters.filter { with(config) { it.isModifier } }
 
         // If there are no modifiers, or more than one, we don't care as much about the naming
         if (modifiers.isEmpty()) return

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -23,7 +23,7 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
         emitter: Emitter,
         config: ComposeKtConfig,
     ) {
-        val modifier = function.modifierParameter ?: return
+        val modifier = with(config) { function.modifierParameter } ?: return
         if (modifier.name != "modifier") return
         val code = function.bodyBlockExpression ?: return
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -26,7 +26,7 @@ class ModifierReused : ComposeKtVisitor {
         with(config) { if (!function.emitsContent) return }
 
         val composableBlockExpression = function.bodyBlockExpression ?: return
-        val initialModifierNames = function.modifierParameters.mapNotNull { it.name }
+        val initialModifierNames = with(config) { function.modifierParameters.mapNotNull { it.name } }
         if (initialModifierNames.isEmpty()) return
 
         initialModifierNames

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierWithoutDefault.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierWithoutDefault.kt
@@ -25,7 +25,7 @@ class ModifierWithoutDefault : ComposeKtVisitor {
         if (function.definedInInterface || function.isActual || function.isOverride || function.isAbstract) return
 
         // Look for modifier params in the composable signature, and if any without a default value is found, error out.
-        function.valueParameters.filter { it.isModifier }
+        function.valueParameters.filter { with(config) { it.isModifier } }
             .filterNot { it.hasDefaultValue() }
             .forEach { modifierParameter ->
                 emitter.report(modifierParameter, MissingModifierDefaultParam, true)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
@@ -46,7 +46,8 @@ class ParameterOrder : ComposeKtVisitor {
         // As ComposeModifierMissingCheck will catch modifiers without a Modifier default, we don't have to care
         // about that case. We will sort the params with defaults so that the modifier(s) go first.
         val sortedWithDefaults = withDefaults.sortedWith(
-            compareByDescending<KtParameter> { it.isModifier }.thenByDescending { it.name == "modifier" },
+            compareByDescending<KtParameter> { with(config) { it.isModifier } }
+                .thenByDescending { it.name == "modifier" },
         )
 
         // We create our ideal ordering of params for the ideal composable.

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheckTest.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.detekt
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -13,7 +12,10 @@ import org.junit.jupiter.api.Test
 
 class ModifierMissingCheckTest {
 
-    private val rule = ModifierMissingCheck(Config.empty)
+    private val testConfig = TestConfig(
+        "customModifiers" to listOf("BananaModifier"),
+    )
+    private val rule = ModifierMissingCheck(testConfig)
 
     @Test
     fun `errors when a Composable has a layout inside and it doesn't have a modifier`() {
@@ -50,14 +52,18 @@ class ModifierMissingCheckTest {
                         Text("Hi!")
                     }
                 }
+                @Composable
+                fun Something6() {
+                    Column(modifier = BananaModifier.fillMaxSize()) {
+                    }
+                }
             """.trimIndent()
 
         val errors = rule.lint(code)
-        assertThat(errors).hasTextLocations("Something1", "Something2", "Something3", "Something4")
-        assertThat(errors[0]).hasMessage(ModifierMissing.MissingModifierContentComposable)
-        assertThat(errors[1]).hasMessage(ModifierMissing.MissingModifierContentComposable)
-        assertThat(errors[2]).hasMessage(ModifierMissing.MissingModifierContentComposable)
-        assertThat(errors[3]).hasMessage(ModifierMissing.MissingModifierContentComposable)
+        assertThat(errors).hasTextLocations("Something1", "Something2", "Something3", "Something4", "Something6")
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierMissing.MissingModifierContentComposable)
+        }
     }
 
     @Test

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheckTest.kt
@@ -30,6 +30,9 @@ class ParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
+
+            @Composable
+            fun MyComposable(modifier: Modifier, text1: String, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
         """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -47,7 +47,7 @@ val compositionLocalAllowlistProperty: EditorConfigProperty<String> =
         type = PropertyType.LowerCasingPropertyType(
             "compose_allowed_composition_locals",
             "A comma separated list of allowed CompositionLocals",
-            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),
         ),
         defaultValue = "",
@@ -65,7 +65,7 @@ val allowedComposeNamingNames: EditorConfigProperty<String> =
         type = PropertyType.LowerCasingPropertyType(
             "compose_allowed_composable_function_names",
             "A comma separated list of regexes of allowed composable function names",
-            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),
         ),
         defaultValue = "",
@@ -83,7 +83,7 @@ val viewModelFactories: EditorConfigProperty<String> =
         type = PropertyType.LowerCasingPropertyType(
             "compose_view_model_factories",
             "A comma separated list of ViewModel factory methods",
-            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),
         ),
         defaultValue = "",
@@ -101,7 +101,25 @@ val allowedStateHolderNames: EditorConfigProperty<String> =
         type = PropertyType.LowerCasingPropertyType(
             "compose_allowed_state_holder_names",
             "A comma separated list of regexes of valid state holders / ViewModel / Presenter names",
-            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
+val customModifiers: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_custom_modifiers",
+            "A comma separated list of custom Modifier implementations",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),
         ),
         defaultValue = "",

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierComposableCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierComposableCheck.kt
@@ -7,5 +7,8 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
 class ModifierComposableCheck :
-    KtlintRule("compose:modifier-composable-check"),
+    KtlintRule(
+        id = "compose:modifier-composable-check",
+        editorConfigProperties = setOf(customModifiers),
+    ),
     ComposeKtVisitor by ModifierComposable()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.rules.core.ktlint.KtlintRule
 class ModifierMissingCheck :
     KtlintRule(
         id = "compose:modifier-missing-check",
-        editorConfigProperties = setOf(checkModifiersForVisibility, contentEmittersProperty),
+        editorConfigProperties = setOf(checkModifiersForVisibility, contentEmittersProperty, customModifiers),
     ),
     ComposeKtVisitor by ModifierMissing()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierNamingCheck.kt
@@ -7,5 +7,8 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
 class ModifierNamingCheck :
-    KtlintRule("compose:modifier-naming"),
+    KtlintRule(
+        id = "compose:modifier-naming",
+        editorConfigProperties = setOf(customModifiers),
+    ),
     ComposeKtVisitor by ModifierNaming()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.rules.core.ktlint.KtlintRule
 class ModifierNotUsedAtRootCheck :
     KtlintRule(
         id = "compose:modifier-not-used-at-root",
-        editorConfigProperties = setOf(contentEmittersProperty),
+        editorConfigProperties = setOf(contentEmittersProperty, customModifiers),
     ),
     ComposeKtVisitor by ModifierNotUsedAtRoot()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.rules.core.ktlint.KtlintRule
 class ModifierReusedCheck :
     KtlintRule(
         id = "compose:modifier-reused-check",
-        editorConfigProperties = setOf(contentEmittersProperty),
+        editorConfigProperties = setOf(contentEmittersProperty, customModifiers),
     ),
     ComposeKtVisitor by ModifierReused()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierWithoutDefaultCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierWithoutDefaultCheck.kt
@@ -7,5 +7,8 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
 class ModifierWithoutDefaultCheck :
-    KtlintRule("compose:modifier-without-default-check"),
+    KtlintRule(
+        id = "compose:modifier-without-default-check",
+        editorConfigProperties = setOf(customModifiers),
+    ),
     ComposeKtVisitor by ModifierWithoutDefault()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheckTest.kt
@@ -47,30 +47,44 @@ class ModifierMissingCheckTest {
                         Text("Hi!")
                     }
                 }
+                @Composable
+                fun Something() {
+                    Column(modifier = BananaModifier.fillMaxSize()) {
+                    }
+                }
             """.trimIndent()
 
-        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ModifierMissing.MissingModifierContentComposable,
-            ),
-            LintViolation(
-                line = 7,
-                col = 5,
-                detail = ModifierMissing.MissingModifierContentComposable,
-            ),
-            LintViolation(
-                line = 12,
-                col = 5,
-                detail = ModifierMissing.MissingModifierContentComposable,
-            ),
-            LintViolation(
-                line = 19,
-                col = 5,
-                detail = ModifierMissing.MissingModifierContentComposable,
-            ),
-        )
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(
+                customModifiers to "BananaModifier",
+            )
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 5,
+                    detail = ModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 5,
+                    detail = ModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 19,
+                    col = 5,
+                    detail = ModifierMissing.MissingModifierContentComposable,
+                ),
+                LintViolation(
+                    line = 32,
+                    col = 5,
+                    detail = ModifierMissing.MissingModifierContentComposable,
+                ),
+            )
     }
 
     @Test

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheckTest.kt
@@ -29,6 +29,9 @@ class ParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
+
+            @Composable
+            fun MyComposable(modifier: Modifier, text1: String, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
         """.trimIndent()
         orderingRuleAssertThat(code).hasNoLintViolations()
     }


### PR DESCRIPTION
Adds the ability to configure custom modifier types. By default, `Modifier` and `GlanceModifier` types are considered modifiers, but some libraries might want to include their own modifier types so it makes sense to open the door to configurability there.

Addresses #141 (at least its last remaining concern).