### PR TITLE
Allow ModifierClickableOrder rule to look into multiple modifiers

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -24,54 +24,56 @@ Compose:
     active: true
   ComposableNaming:
     active: true
-    # You can optionally disable the checks in this rule for regex matches against the composable name (e.g. molecule presenters)
+    # -- You can optionally disable the checks in this rule for regex matches against the composable name (e.g. molecule presenters)
     # allowedComposableFunctionNames: .*Presenter,.*MoleculePresenter
   ComposableParamOrder:
     active: true
   CompositionLocalAllowlist:
     active: true
-    # You can optionally define a list of CompositionLocals that are allowed here
+    # -- You can optionally define a list of CompositionLocals that are allowed here
     # allowedCompositionLocals: LocalSomething,LocalSomethingElse
   CompositionLocalNaming:
     active: true
   ContentEmitterReturningValues:
     active: true
-    # You can optionally add your own composables here
+    # -- You can optionally add your own composables here
     # contentEmitters: MyComposable,MyOtherComposable
   DefaultsVisibility:
     active: true
   ModifierClickableOrder:
     active: true
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
   ModifierComposable:
     active: true
-    # You can optionally add your own Modifier types
+    # -- You can optionally add your own Modifier types
     # customModifiers: BananaModifier,PotatoModifier
   ModifierMissing:
     active: true
-    # You can optionally control the visibility of which composables to check for here
-    # Possible values are: `only_public`, `public_and_internal` and `all` (default is `only_public`)
+    # -- You can optionally control the visibility of which composables to check for here
+    # -- Possible values are: `only_public`, `public_and_internal` and `all` (default is `only_public`)
     # checkModifiersForVisibility: only_public
-    # You can optionally add your own Modifier types
+    # -- You can optionally add your own Modifier types
     # customModifiers: BananaModifier,PotatoModifier
   ModifierNaming:
     active: true
-    # You can optionally add your own Modifier types
+    # -- You can optionally add your own Modifier types
     # customModifiers: BananaModifier,PotatoModifier
   ModifierNotUsedAtRoot:
     active: true
-    # You can optionally add your own composables here
+    # -- You can optionally add your own composables here
     # contentEmitters: MyComposable,MyOtherComposable
-    # You can optionally add your own Modifier types
+    # -- You can optionally add your own Modifier types
     # customModifiers: BananaModifier,PotatoModifier
   ModifierReused:
     active: true
-    # You can optionally add your own Modifier types
+    # -- You can optionally add your own Modifier types
     # customModifiers: BananaModifier,PotatoModifier
   ModifierWithoutDefault:
     active: true
   MultipleEmitters:
     active: true
-    # You can optionally add your own composables here
+    # -- You can optionally add your own composables here
     # contentEmitters: MyComposable,MyOtherComposable
   MutableParams:
     active: true
@@ -89,11 +91,11 @@ Compose:
     active: true
   ViewModelForwarding:
     active: true
-      # You can optionally use this rule on things other than types ending in "ViewModel" or "Presenter" (which are the defaults). You can add your own via a regex here:
-      # allowedStateHolderNames: .*ViewModel,.*Presenter
+    # -- You can optionally use this rule on things other than types ending in "ViewModel" or "Presenter" (which are the defaults). You can add your own via a regex here:
+    # allowedStateHolderNames: .*ViewModel,.*Presenter
   ViewModelInjection:
     active: true
-    # You can optionally add your own ViewModel factories here
+    # -- You can optionally add your own ViewModel factories here
     # viewModelFactories: hiltViewModel,potatoViewModel
 ```
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -8,6 +8,7 @@ import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
 import io.nlopez.rules.core.util.argumentsUsingModifiers
 import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.modifierParameters
 import io.nlopez.rules.core.util.obtainAllModifierNames
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
@@ -27,7 +28,8 @@ class ModifierClickableOrder : ComposeKtVisitor {
     ) {
         val code = function.bodyBlockExpression ?: return
 
-        val modifiers = code.obtainAllModifierNames("modifier")
+        val initialModifierNames = with(config) { function.modifierParameters.mapNotNull { it.name } }
+        val modifiers = initialModifierNames.flatMap { code.obtainAllModifierNames(it) }
 
         val suspiciousOrderModifiers = code.findChildrenByClass<KtCallExpression>()
             .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -24,6 +24,8 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
         config: ComposeKtConfig,
     ) {
         val modifier = with(config) { function.modifierParameter } ?: return
+
+        // We only care about the main modifier for this rule
         if (modifier.name != "modifier") return
         val code = function.bodyBlockExpression ?: return
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
@@ -20,7 +20,7 @@ class ModifierClickableOrderCheckTest {
         val code =
             """
                 @Composable
-                fun Something1(modifier: Modifier = Modifier) {
+                fun Something1(modifier: Modifier = Modifier, bananaModifier: Modifier = Modifier) {
                     Something2(
                         modifier = Modifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
                     )
@@ -36,6 +36,9 @@ class ModifierClickableOrderCheckTest {
                     Something6(
                         modifier.clickable { }.then(if (x) border(TurdShape) else Modifier)
                     )
+                    Something7(
+                        modifier = bananaModifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
+                    )
                 }
             """.trimIndent()
 
@@ -47,6 +50,7 @@ class ModifierClickableOrderCheckTest {
                 SourceLocation(10, 18),
                 SourceLocation(13, 47),
                 SourceLocation(16, 18),
+                SourceLocation(19, 35),
             )
 
         assertThat(errors[0]).hasMessage(ModifierClickableOrder.ModifierChainWithSuspiciousOrder)

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheck.kt
@@ -7,5 +7,8 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
 class ModifierClickableOrderCheck :
-    KtlintRule("compose:modifier-clickable-order"),
+    KtlintRule(
+        id = "compose:modifier-clickable-order",
+        editorConfigProperties = setOf(customModifiers),
+    ),
     ComposeKtVisitor by ModifierClickableOrder()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
@@ -18,7 +18,7 @@ class ModifierClickableOrderCheckTest {
         val code =
             """
                 @Composable
-                fun Something1(modifier: Modifier = Modifier) {
+                fun Something1(modifier: Modifier = Modifier, bananaModifier: Modifier = Modifier) {
                     Something2(
                         modifier = Modifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
                     )
@@ -33,6 +33,9 @@ class ModifierClickableOrderCheckTest {
                     )
                     Something6(
                         modifier.clickable { }.then(if (x) border(TurdShape) else Modifier)
+                    )
+                    Something7(
+                        modifier = bananaModifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
                     )
                 }
             """.trimIndent()
@@ -60,6 +63,11 @@ class ModifierClickableOrderCheckTest {
             LintViolation(
                 line = 16,
                 col = 18,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 19,
+                col = 35,
                 detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
             ),
         )


### PR DESCRIPTION
`ModifierClickableOrder` was only looking into `modifier` named parameters. However this rule could be applied to any type of modifier, so if more than one modifier is used, this PR will make it so it catches those issues as well.