### PR TITLE
Extract emission to count code to Composables.kt

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -73,8 +73,10 @@ Compose:
     active: true
   MultipleEmitters:
     active: true
-    # -- You can optionally add your own composables here
+    # -- You can optionally add your own composables here that will count as content emitters
     # contentEmitters: MyComposable,MyOtherComposable
+    # -- You can add composables here that you don't want to count as content emitters (e.g. custom dialogs or modals)
+    # contentEmittersDenylist: MyNonEmitterComposable
   MutableParams:
     active: true
   MutableStateParam:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -41,11 +41,20 @@ You can use this same [uber jar from the releases page](https://github.com/mrman
 
 ### Providing custom content emitters
 
-There are some rules (`compose:content-emitter-returning-values-check`, `compose:modifier-not-used-at-root` and `compose:multiple-emitters-check`) that use predefined list of known composables that emit content. But you can add your own too! In your `.editorconfig` file, you'll need to add a `content_emitters` property followed by a list of composable names separated by commas. You would typically want the composables that are part of your custom design system to be in this list.
+There are some rules (`compose:content-emitter-returning-values-check`, `compose:modifier-not-used-at-root` and `compose:multiple-emitters-check`) that use predefined list of known composables that emit content. But you can add your own too! In your `.editorconfig` file, you'll need to add a `compose_content_emitters` property followed by a list of composable names separated by commas. You would typically want the composables that are part of your custom design system to be in this list.
 
 ```editorconfig
 [*.{kt,kts}]
 compose_content_emitters = MyComposable,MyOtherComposable
+```
+
+### Providing exceptions to content emitters
+
+Sometimes we'll want to not count a Composable towards the multiple content emitters (`compose:multiple-emitters-check`) rule. This is useful, for example, if the composable function actually emits content but that content is painted in a different window (like a dialog or a modal). For those cases, we can use a denylist `compose_content_emitters_denyylist` to add those composable names separated by commas.
+
+```editorconfig
+[*.{kt,kts}]
+compose_content_emitters_denylist = MyModalComposable,MyDialogComposable
 ```
 
 ### Providing custom ViewModel factories

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentEmitterReturningValues.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentEmitterReturningValues.kt
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
-import io.nlopez.compose.rules.MultipleContentEmitters.Companion.directUiEmitterCount
-import io.nlopez.compose.rules.MultipleContentEmitters.Companion.indirectUiEmitterCount
 import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.createDirectComposableToEmissionCountMapping
 import io.nlopez.rules.core.util.findChildrenByClass
 import io.nlopez.rules.core.util.hasReceiverType
 import io.nlopez.rules.core.util.isComposable
+import io.nlopez.rules.core.util.refineComposableToEmissionCountMapping
 import io.nlopez.rules.core.util.returnsValue
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
@@ -18,15 +18,16 @@ import org.jetbrains.kotlin.psi.KtFunction
 class ContentEmitterReturningValues : ComposeKtVisitor {
 
     override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
-        val composableToEmissionCount = file.findChildrenByClass<KtFunction>()
+        val composables = file.findChildrenByClass<KtFunction>()
             .filter { it.isComposable }
             // We don't want to analyze composables that are extension functions, as they might be things like
             // BoxScope which are legit, and we want to avoid false positives.
             .filter { it.hasBlockBody() }
             // We want only methods with a body
             .filterNot { it.hasReceiverType }
-            // Now we want to get the count of direct emitters in them: the composables we know for a fact that output UI
-            .associateWith { with(config) { it.directUiEmitterCount } }
+
+        // Now we want to get the count of direct emitters in them: the composables we know for a fact that output UI
+        val composableToEmissionCount = with(config) { composables.createDirectComposableToEmissionCountMapping() }
 
         // Now we can give some extra passes through the list of composables, and try to get a more accurate count.
         // We want to make sure that if these composables are using other composables in this file that emit UI,
@@ -34,22 +35,11 @@ class ContentEmitterReturningValues : ComposeKtVisitor {
         // @Composable fun Comp1() { Text("Hi") }
         // @Composable fun Comp2() { Text("Hola") }
         // @Composable fun Comp3() { Comp1() Comp2() } // This wouldn't be picked up at first, but should after 1 loop
-        var current = composableToEmissionCount
-
-        var shouldMakeAnotherPass = true
-        while (shouldMakeAnotherPass) {
-            val updatedMapping = current.mapValues { (functionNode, _) ->
-                with(config) { functionNode.indirectUiEmitterCount(current) }
-            }
-            when {
-                updatedMapping != current -> current = updatedMapping
-                else -> shouldMakeAnotherPass = false
-            }
-        }
+        val mapping = with(config) { refineComposableToEmissionCountMapping(composableToEmissionCount) }
 
         // Data in currentMapping should have all the # of emissions inferred for each composable in this file,
         // so we want to iterate through all of them
-        current.filterValues { it > 0 }.keys
+        mapping.filterValues { it > 0 }.keys
             // If the function doesn't have a return type or returns Unit explicitly, it's valid. Otherwise, show error.
             .filter { it.returnsValue }
             // In here we will have functions that emit UI and return a type other than Unit, which is no bueno.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/MultipleContentEmitters.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/MultipleContentEmitters.kt
@@ -6,14 +6,12 @@ import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
-import io.nlopez.rules.core.util.emitsContent
+import io.nlopez.rules.core.util.createDirectComposableToEmissionCountMapping
 import io.nlopez.rules.core.util.findChildrenByClass
 import io.nlopez.rules.core.util.hasReceiverType
 import io.nlopez.rules.core.util.isComposable
-import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtCallExpression
+import io.nlopez.rules.core.util.refineComposableToEmissionCountMapping
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtFunction
 
 class MultipleContentEmitters : ComposeKtVisitor {
@@ -32,7 +30,7 @@ class MultipleContentEmitters : ComposeKtVisitor {
             .filterNot { it.hasReceiverType }
 
         // Now we want to get the count of direct emitters in them: the composables we know for a fact that output UI
-        val composableToEmissionCount = composables.associateWith { with(config) { it.directUiEmitterCount } }
+        val composableToEmissionCount = with(config) { composables.createDirectComposableToEmissionCountMapping() }
 
         // We can start showing errors, for composables that emit more than once (from the list of known composables)
         val directEmissionsReported = composableToEmissionCount.filterValues { it > 1 }.keys
@@ -46,18 +44,7 @@ class MultipleContentEmitters : ComposeKtVisitor {
         // @Composable fun Comp1() { Text("Hi") }
         // @Composable fun Comp2() { Text("Hola") }
         // @Composable fun Comp3() { Comp1() Comp2() } // This wouldn't be picked up at first, but should after 1 loop
-        var currentMapping = composableToEmissionCount
-
-        var shouldMakeAnotherPass = true
-        while (shouldMakeAnotherPass) {
-            val updatedMapping = currentMapping.mapValues { (functionNode, _) ->
-                with(config) { functionNode.indirectUiEmitterCount(currentMapping) }
-            }
-            when {
-                updatedMapping != currentMapping -> currentMapping = updatedMapping
-                else -> shouldMakeAnotherPass = false
-            }
-        }
+        val currentMapping = with(config) { refineComposableToEmissionCountMapping(composableToEmissionCount) }
 
         // Here we have the settled data after all the needed passes, so we want to show errors for them,
         // if they were not caught already by the 1st emission loop
@@ -70,49 +57,6 @@ class MultipleContentEmitters : ComposeKtVisitor {
     }
 
     companion object {
-
-        context(ComposeKtConfig)
-        internal val KtFunction.directUiEmitterCount: Int
-            get() = bodyBlockExpression?.let { block ->
-                // If there's content emitted in a for loop, we assume there's at
-                // least two iterations and thus count any emitters in them as multiple
-                val forLoopCount = when {
-                    block.forLoopHasUiEmitters -> 2
-                    else -> 0
-                }
-                block.directUiEmitterCount + forLoopCount
-            } ?: 0
-
-        context(ComposeKtConfig)
-        internal val KtBlockExpression.forLoopHasUiEmitters: Boolean
-            get() = statements.filterIsInstance<KtForExpression>().any {
-                when (val body = it.body) {
-                    is KtBlockExpression -> body.directUiEmitterCount > 0
-                    is KtCallExpression -> body.emitsContent
-                    else -> false
-                }
-            }
-
-        context(ComposeKtConfig)
-        internal val KtBlockExpression.directUiEmitterCount: Int
-            get() = statements.filterIsInstance<KtCallExpression>().count { it.emitsContent }
-
-        context(ComposeKtConfig)
-        internal fun KtFunction.indirectUiEmitterCount(mapping: Map<KtFunction, Int>): Int {
-            val bodyBlock = bodyBlockExpression ?: return 0
-            return bodyBlock.statements
-                .filterIsInstance<KtCallExpression>()
-                .count { callExpression ->
-                    // If it's a direct hit on our list, it should count directly
-                    if (callExpression.emitsContent) return@count true
-
-                    val name = callExpression.calleeExpression?.text ?: return@count false
-                    // If the hit is in the provided mapping, it means it is using a composable that we know emits UI,
-                    // that we inferred from previous passes
-                    val value = mapping.mapKeys { entry -> entry.key.name }.getOrElse(name) { return@count false }
-                    value > 0
-                }
-        }
 
         val MultipleContentEmittersDetected = """
             Composable functions should only be emitting content into the composition from one source at their top level.

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -13,7 +13,8 @@ import org.junit.jupiter.api.Test
 class MultipleContentEmittersCheckTest {
 
     private val testConfig = TestConfig(
-        "contentEmitters" to listOf("Potato", "Banana"),
+        "contentEmitters" to listOf("Potato", "Banana", "Apple"),
+        "contentEmittersDenylist" to listOf("Apple"),
     )
     private val rule = MultipleContentEmittersCheck(testConfig)
 
@@ -49,7 +50,7 @@ class MultipleContentEmittersCheckTest {
                 }
                 @Composable
                 fun RowScope.Something() {
-                    Spacer16()
+                    Spacer()
                     Text("Hola")
                 }
             """.trimIndent()
@@ -71,7 +72,7 @@ class MultipleContentEmittersCheckTest {
                 context(ColumnScope)
                 @Composable
                 fun Something() {
-                    Spacer16()
+                    Spacer()
                     Text("Hola")
                 }
             """.trimIndent()
@@ -91,12 +92,12 @@ class MultipleContentEmittersCheckTest {
                 }
                 @Composable
                 fun Something() {
-                    Spacer16()
+                    Spacer()
                     Text("Hola")
                 }
             """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(2)
+        assertThat(errors)
             .hasStartSourceLocations(
                 SourceLocation(2, 5),
                 SourceLocation(7, 5),
@@ -135,7 +136,7 @@ class MultipleContentEmittersCheckTest {
                 }
             """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(2)
+        assertThat(errors)
             .hasStartSourceLocations(
                 SourceLocation(6, 5),
                 SourceLocation(19, 5),
@@ -162,7 +163,7 @@ class MultipleContentEmittersCheckTest {
                 }
             """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(1)
+        assertThat(errors)
             .hasStartSourceLocation(2, 5)
         assertThat(errors.first()).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
     }
@@ -194,5 +195,20 @@ class MultipleContentEmittersCheckTest {
         for (error in errors) {
             assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
         }
+    }
+
+    @Test
+    fun `passes when the composable is in the denylist`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    Text("Hi")
+                    Apple()
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
     }
 }

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -11,7 +11,26 @@ val contentEmittersProperty: EditorConfigProperty<String> =
         type = PropertyType.LowerCasingPropertyType(
             "compose_content_emitters",
             "A comma separated list of composable functions that emit content (e.g. UI)",
-            PropertyType.PropertyValueParser.IDENTITY_VALUE_PARSER,
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
+val contentEmittersDenylist: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_content_emitters_denylist",
+            "A comma separated list of composable functions that we don't want to take into acccount " +
+                "when assessing if something is a content emitter",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),
         ),
         defaultValue = "",

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.rules.core.ktlint.KtlintRule
 class MultipleContentEmittersCheck :
     KtlintRule(
         id = "compose:multiple-emitters-check",
-        editorConfigProperties = setOf(contentEmittersProperty),
+        editorConfigProperties = setOf(contentEmittersProperty, contentEmittersDenylist),
     ),
     ComposeKtVisitor by MultipleContentEmitters()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -43,7 +43,7 @@ class MultipleContentEmittersCheckTest {
                 }
                 @Composable
                 fun RowScope.Something() {
-                    Spacer16()
+                    Spacer()
                     Text("Hola")
                 }
             """.trimIndent()
@@ -64,7 +64,7 @@ class MultipleContentEmittersCheckTest {
                 context(RowScope)
                 @Composable
                 fun Something() {
-                    Spacer16()
+                    Spacer()
                     Text("Hola")
                 }
             """.trimIndent()
@@ -83,7 +83,7 @@ class MultipleContentEmittersCheckTest {
                 }
                 @Composable
                 fun Something() {
-                    Spacer16()
+                    Spacer()
                     Text("Hola")
                 }
             """.trimIndent()
@@ -202,5 +202,21 @@ class MultipleContentEmittersCheckTest {
                 detail = MultipleContentEmitters.MultipleContentEmittersDetected,
             ),
         )
+    }
+
+    @Test
+    fun `passes when the composable is in the denylist`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    Text("Hi")
+                    Spacer()
+                }
+            """.trimIndent()
+        emittersRuleAssertThat(code)
+            .withEditorConfigOverride(contentEmittersDenylist to "Spacer")
+            .hasNoLintViolations()
     }
 }


### PR DESCRIPTION
Refactor to push up the layers the direct/indirect count emitters. It simplifies the MultipleEmitters and ContentEmitterReturningValues rules, as they had a lot of shared code.
