### PR TITLE
Add allowlist of composable names to VMForwarding rule

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
@@ -6,6 +6,8 @@ import java.util.Locale
 
 fun <T> T.runIf(value: Boolean, block: T.() -> T): T = if (value) block() else this
 
+fun <T, R> T.runIfNotNull(value: R?, block: T.(R) -> T): T = value?.let { block(it) } ?: this
+
 fun String?.matchesAnyOf(patterns: Sequence<Regex>): Boolean {
     if (isNullOrEmpty()) return false
     for (regex in patterns) {

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -99,6 +99,8 @@ Compose:
     active: true
     # -- You can optionally add your own ViewModel factories here
     # viewModelFactories: hiltViewModel,potatoViewModel
+    # -- You can optionally add an allowlist for Composable names that won't be affected by this rule
+    # allowedForwarding: .*Content,.*FancyStuff
 ```
 
 ### Disabling a specific rule

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -93,6 +93,16 @@ The `vm-forwarding-check` rule will, by default, design as a state holder any cl
 compose_allowed_state_holder_names = .*ViewModel,.*Presenter,.*Component,.*SomethingElse
 ```
 
+
+### Allowlist for composable names that aren't affected by the ViewModelForwarding rule
+
+The `vm-forwarding-check` will catch VMs/state holder classes that are relayed to other composables. However, in some situations this can be a valid use-case. The rule can be configured so that all the names that matches a list of regexes are exempt to this rule. You can configure this in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_allowed_forwarding = .*Content,.*SomethingElse
+```
+
 ### Configure the visibility of the composables where to check for missing modifiers
 
 The `modifier-missing-check` rule will, by default, only look for missing modifiers for public composables. If you want to lower the visibility threshold to check also internal compoosables, or all composables, you can configure it in your `.editorconfig` file:

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -133,6 +133,25 @@ val allowedStateHolderNames: EditorConfigProperty<String> =
         },
     )
 
+val allowedForwarding: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_allowed_forwarding",
+            "A comma separated list of regexes of composable names where forwarding a " +
+                "state holder / ViewModel / Presenter names is alright to do",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
 val customModifiers: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ViewModelForwardingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ViewModelForwardingCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.rules.core.ktlint.KtlintRule
 class ViewModelForwardingCheck :
     KtlintRule(
         id = "compose:vm-forwarding-check",
-        editorConfigProperties = setOf(allowedStateHolderNames),
+        editorConfigProperties = setOf(allowedStateHolderNames, allowedForwarding),
     ),
     ComposeKtVisitor by ViewModelForwarding()


### PR DESCRIPTION
Creates a new configuration value `allowedForwarding` which will act as an allowlist for composable function names that allow VM forwarding. This is specially useful for Compose MP, where we don't typically have factory functions to acquire VMs, and we might have different requirements for the different platforms (e.g. Android with stuff in a Scaffold, iOS with stuff that is wrapped by native SwiftUI views).

Closes #165.