### PR TITLE
Add treatAsLambda to ParamOrder rule configuration

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -28,6 +28,8 @@ Compose:
     # allowedComposableFunctionNames: .*Presenter,.*MoleculePresenter
   ComposableParamOrder:
     active: true
+    # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsLambda: MyLambdaType
   CompositionLocalAllowlist:
     active: true
     # -- You can optionally define a list of CompositionLocals that are allowed here

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -126,6 +126,15 @@ Most of the modifier-related rules will look for modifiers based their type: eit
 compose_custom_modifiers = BananaModifier,PotatoModifier
 ```
 
+### Configure types to treat as lambdas in ParamOrder check
+
+The `param-order-check` rule will do its best to identify trailing lambdas. However, in cases where a typedef / functional interface is being used, we might want to have this rule to treat them as if they were lambdas: not reporting them if they are the last in a method signature and they don't have a default value. To give ktlint some hints, you can configure this in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_treat_as_lambda = MyLambdaType,MyOtherLambdaType
+```
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `compose` tag.

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheckTest.kt
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.detekt
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import org.intellij.lang.annotations.Language
@@ -11,7 +11,10 @@ import org.junit.jupiter.api.Test
 
 class ParameterOrderCheckTest {
 
-    private val rule = ParameterOrderCheck(Config.empty)
+    private val testConfig = TestConfig(
+        "treatAsLambda" to listOf("LambdaType"),
+    )
+    private val rule = ParameterOrderCheck(testConfig)
 
     @Test
     fun `no errors when ordering is correct`() {
@@ -27,6 +30,12 @@ class ParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: LambdaType) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: LambdaType?) { }
 
             @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -169,3 +169,22 @@ val customModifiers: EditorConfigProperty<String> =
             }
         },
     )
+
+val treatAsLambda: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_treat_as_lambda",
+            "A comma separated list of types that should be treated as lambdas " +
+                "(e.g. typedefs of lambdas, fun interfaces)",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheck.kt
@@ -7,5 +7,8 @@ import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.ktlint.KtlintRule
 
 class ParameterOrderCheck :
-    KtlintRule("compose:param-order-check"),
+    KtlintRule(
+        id = "compose:param-order-check",
+        editorConfigProperties = setOf(treatAsLambda),
+    ),
     ComposeKtVisitor by ParameterOrder()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheckTest.kt
@@ -28,12 +28,20 @@ class ParameterOrderCheckTest {
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit) { }
 
             @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: LambdaType) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: LambdaType?) { }
+
+            @Composable
             fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
 
             @Composable
             fun MyComposable(modifier: Modifier, text1: String, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
         """.trimIndent()
-        orderingRuleAssertThat(code).hasNoLintViolations()
+        orderingRuleAssertThat(code)
+            .withEditorConfigOverride(treatAsLambda to "LambdaType")
+            .hasNoLintViolations()
     }
 
     @Test


### PR DESCRIPTION
Adds `treatAsLambda` as a configuration parameter for the ParameterOrder rule. This allows any arbitrary type to be treated as a lambda, aka not being flagged when not having a default value when being last in a method signature (like what we do for functional types already).

Partially addresses #153.
