### PR TITLE
Infer lambdas from typealias/fun interfaces in ParameterOrder

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
@@ -6,73 +6,93 @@ import io.nlopez.rules.core.ComposeKtConfig
 import io.nlopez.rules.core.ComposeKtVisitor
 import io.nlopez.rules.core.Emitter
 import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.isComposable
 import io.nlopez.rules.core.util.isModifier
 import io.nlopez.rules.core.util.runIf
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.psi.KtTypeElement
 import org.jetbrains.kotlin.psi.KtUserType
 
 class ParameterOrder : ComposeKtVisitor {
 
-    override fun visitComposable(
-        function: KtFunction,
-        autoCorrect: Boolean,
-        emitter: Emitter,
-        config: ComposeKtConfig,
-    ) {
-        // We need to make sure the proper order is respected. It should be:
-        // 1. params without defaults
-        // 2. modifiers
-        // 3. params with defaults
-        // 4. optional: function that might have no default
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
+        val lambdaTypes = mutableSetOf<String>()
+        // Add types defined in the config
+        lambdaTypes += config.getSet("treatAsLambda", emptySet())
 
-        // Let's try to build the ideal ordering first, and compare against that.
-        val currentOrder = function.valueParameters
+        // Add fun interfaces
+        lambdaTypes += file.findChildrenByClass<KtClass>()
+            .filter { it.isInterface() && it.hasModifier(KtTokens.FUN_KEYWORD) }
+            .mapNotNull { it.name }
 
-        // We look in the original params without defaults and see if the last one is a function.
-        val hasTrailingFunction = with(config) { function.hasTrailingFunction }
-        val trailingLambda = if (hasTrailingFunction) {
-            listOf(function.valueParameters.last())
-        } else {
-            emptyList()
-        }
-
-        // We extract the params without with and without defaults, and keep the order between them
-        val (withDefaults, withoutDefaults) = function.valueParameters
-            .runIf(hasTrailingFunction) { dropLast(1) }
-            .partition { it.hasDefaultValue() }
-
-        // As ComposeModifierMissingCheck will catch modifiers without a Modifier default, we don't have to care
-        // about that case. We will sort the params with defaults so that the modifier(s) go first.
-        val sortedWithDefaults = withDefaults.sortedWith(
-            compareByDescending<KtParameter> { with(config) { it.isModifier } }
-                .thenByDescending { it.name == "modifier" },
-        )
-
-        // We create our ideal ordering of params for the ideal composable.
-        val properOrder = withoutDefaults + sortedWithDefaults + trailingLambda
-
-        // If it's not the same as the current order, we show the rule violation.
-        if (currentOrder != properOrder) {
-            emitter.report(function, createErrorMessage(currentOrder, properOrder))
-        }
-    }
-
-    context(ComposeKtConfig)
-    private val KtFunction.hasTrailingFunction: Boolean
-        get() = valueParameters.lastOrNull()?.typeReference?.typeElement?.isLambda() == true
-
-    context(ComposeKtConfig)
-    private fun KtTypeElement.isLambda(treatAsLambda: Set<String> = getSet("treatAsLambda", emptySet())): Boolean =
-        when (this) {
+        fun KtTypeElement.isLambda(): Boolean = when (this) {
             is KtFunctionType -> true
-            is KtNullableType -> innerType?.isLambda(treatAsLambda) == true
-            is KtUserType -> getReferencedName() in getSet("treatAsLambda", emptySet())
+            is KtNullableType -> innerType?.isLambda() == true
+            is KtUserType -> getReferencedName() in lambdaTypes
             else -> false
         }
+
+        // Add typealias with functional types
+        // NOTE: it has to be last, so that isLambda picks up fun interfaces / config stuff in lambdaTypes
+        lambdaTypes += file.findChildrenByClass<KtTypeAlias>()
+            .filter { it.getTypeReference()?.typeElement?.isLambda() == true }
+            .mapNotNull { it.name }
+            .toSet()
+
+        val composables = file.findChildrenByClass<KtFunction>()
+            .filter { it.isComposable }
+
+        for (function in composables) {
+            // We need to make sure the proper order is respected. It should be:
+            // 1. params without defaults
+            // 2. modifiers
+            // 3. params with defaults
+            // 4. optional: function that might have no default
+
+            // Let's try to build the ideal ordering first, and compare against that.
+            val currentOrder = function.valueParameters
+
+            // We look in the original params without defaults and see if the last one is a function.
+            val hasTrailingFunction = function.valueParameters.lastOrNull()
+                ?.typeReference
+                ?.typeElement
+                ?.isLambda() == true
+
+            val trailingLambda = if (hasTrailingFunction) {
+                listOf(function.valueParameters.last())
+            } else {
+                emptyList()
+            }
+
+            // We extract the params without with and without defaults, and keep the order between them
+            val (withDefaults, withoutDefaults) = function.valueParameters
+                .runIf(hasTrailingFunction) { dropLast(1) }
+                .partition { it.hasDefaultValue() }
+
+            // As ComposeModifierMissingCheck will catch modifiers without a Modifier default, we don't have to care
+            // about that case. We will sort the params with defaults so that the modifier(s) go first.
+            val sortedWithDefaults = withDefaults.sortedWith(
+                compareByDescending<KtParameter> { with(config) { it.isModifier } }
+                    .thenByDescending { it.name == "modifier" },
+            )
+
+            // We create our ideal ordering of params for the ideal composable.
+            val properOrder = withoutDefaults + sortedWithDefaults + trailingLambda
+
+            // If it's not the same as the current order, we show the rule violation.
+            if (currentOrder != properOrder) {
+                emitter.report(function, createErrorMessage(currentOrder, properOrder))
+            }
+        }
+    }
 
     companion object {
         fun createErrorMessage(currentOrder: List<KtParameter>, properOrder: List<KtParameter>): String =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheckTest.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.test.lint
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 
+@Suppress("ktlint:standard:max-line-length")
 class ParameterOrderCheckTest {
 
     private val testConfig = TestConfig(
@@ -20,6 +21,11 @@ class ParameterOrderCheckTest {
     fun `no errors when ordering is correct`() {
         @Language("kotlin")
         val code = """
+            typealias TypealiasLambda = () -> Unit
+            fun interface InterfaceLambda {
+                fun whatever()
+            }
+
             fun MyComposable(text1: String, modifier: Modifier = Modifier, other: String = "1", other2: String = "2") { }
 
             @Composable
@@ -42,6 +48,20 @@ class ParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(modifier: Modifier, text1: String, m2: Modifier = Modifier, trailing: (() -> Unit)?) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: TypealiasLambda) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: TypealiasLambda?) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: InterfaceLambda) { }
+
+            @Composable
+            fun MyComposable(text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: InterfaceLambda?) { }
+
+
         """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
@@ -65,15 +85,21 @@ class ParameterOrderCheckTest {
 
             @Composable
             fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit) { }
+
+            @Composable
+            fun MyComposable(text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: NonFunctionalType) { }
+
+            typealias NonFunctionalType = String
         """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(5)
+        assertThat(errors)
             .hasStartSourceLocations(
                 SourceLocation(2, 5),
                 SourceLocation(5, 5),
                 SourceLocation(8, 5),
                 SourceLocation(11, 5),
                 SourceLocation(14, 5),
+                SourceLocation(17, 5),
             )
     }
 }


### PR DESCRIPTION
With this change we can automatically infer lambdas from typealiases and functional interfaces that are in the same file as the composable (without type resolution this is as good as it gets). This will alleviate the need to add manually all of those to the configuration, which is surely going to make things easier.

Closes #153.