### PR TITLE
Use type checking against PsiElements instead of KtNodeStubElementTypes

### DIFF
--- a/core-detekt/src/main/kotlin/io/nlopez/rules/core/detekt/DetektRule.kt
+++ b/core-detekt/src/main/kotlin/io/nlopez/rules/core/detekt/DetektRule.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 abstract class DetektRule(
     config: Config = Config.empty,
@@ -60,12 +59,11 @@ abstract class DetektRule(
 
     override fun visitKtElement(element: KtElement) {
         super.visitKtElement(element)
-        when (element.node.elementType) {
-            KtStubElementTypes.FUNCTION -> {
-                val function = element as KtFunction
-                visitFunction(function, autoCorrect, emitter, config)
-                if (function.isComposable) {
-                    visitComposable(function, autoCorrect, emitter, config)
+        when (element) {
+            is KtFunction -> {
+                visitFunction(element, autoCorrect, emitter, config)
+                if (element.isComposable) {
+                    visitComposable(element, autoCorrect, emitter, config)
                 }
             }
         }

--- a/core-ktlint/src/main/kotlin/io/nlopez/rules/core/ktlint/KtlintRule.kt
+++ b/core-ktlint/src/main/kotlin/io/nlopez/rules/core/ktlint/KtlintRule.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 abstract class KtlintRule(
     id: String,
@@ -41,25 +40,19 @@ abstract class KtlintRule(
 
     private val config: ComposeKtConfig by lazy { KtlintComposeKtConfig(properties, usesEditorConfigProperties) }
 
-    @Suppress("DEPRECATION")
     final override fun beforeVisitChildNodes(
         node: ASTNode,
         autoCorrect: Boolean,
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
     ) {
-        val psi = node.psi
-        when (node.elementType) {
-            KtStubElementTypes.FILE -> {
-                visitFile(psi as KtFile, autoCorrect, emit.toEmitter(), config)
-            }
-
-            KtStubElementTypes.CLASS -> visitClass(psi as KtClass, autoCorrect, emit.toEmitter(), config)
-            KtStubElementTypes.FUNCTION -> {
-                val function = psi as KtFunction
+        when (val psi = node.psi) {
+            is KtFile -> visitFile(psi, autoCorrect, emit.toEmitter(), config)
+            is KtClass -> visitClass(psi, autoCorrect, emit.toEmitter(), config)
+            is KtFunction -> {
                 val emitter = emit.toEmitter()
-                visitFunction(function, autoCorrect, emitter, config)
-                if (function.isComposable) {
-                    visitComposable(function, autoCorrect, emitter, config)
+                visitFunction(psi, autoCorrect, emitter, config)
+                if (psi.isComposable) {
+                    visitComposable(psi, autoCorrect, emitter, config)
                 }
             }
         }


### PR DESCRIPTION
Uses the actual type of the PsiElement to see what are we traversing. Should be harmless (?).

Might fix #176 