### PR TITLE
Add more supported cases to ModifierClickableOrder

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -106,8 +106,9 @@ class ModifierClickableOrder : ComposeKtVisitor {
 
     private val KtCallExpression.isThen: Boolean
         get() = calleeExpression?.text == "then"
+
     private val KtCallExpression.isClipWithShape: Boolean
-        get() = calleeExpression?.text == "clip" && valueArguments.any { it.isNamedShape || it.referencesShape }
+        get() = calleeExpression?.text == "clip" // any clip will reference a shape
 
     private val KtCallExpression.isBackgroundWithShape: Boolean
         get() = calleeExpression?.text == "background" && valueArguments.any { it.isNamedShape || it.referencesShape }
@@ -127,6 +128,10 @@ class ModifierClickableOrder : ComposeKtVisitor {
             // if (x) MyShape else MyOtherShape
             is KtIfExpression -> expression.then?.text?.endsWith("Shape") == true ||
                 expression.`else`?.text?.endsWith("Shape") == true
+            // MaterialTheme.shapes.x or LocalShapes.current.x or AppShapes.x or MyThemeShapes.x
+            is KtDotQualifiedExpression -> expression.text.startsWith("MaterialTheme.shapes") ||
+                expression.text.contains("Shape")
+
             else -> false
         }
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
@@ -39,6 +39,12 @@ class ModifierClickableOrderCheckTest {
                     Something7(
                         modifier = bananaModifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
                     )
+                    Something8(
+                        modifier = bananaModifier.clickable { }.clip(Potato)
+                    )
+                    Something9(
+                        modifier = bananaModifier.clickable { }.background(MaterialTheme.shapes.large)
+                    )
                 }
             """.trimIndent()
 
@@ -51,6 +57,8 @@ class ModifierClickableOrderCheckTest {
                 SourceLocation(13, 47),
                 SourceLocation(16, 18),
                 SourceLocation(19, 35),
+                SourceLocation(22, 35),
+                SourceLocation(25, 35),
             )
 
         assertThat(errors[0]).hasMessage(ModifierClickableOrder.ModifierChainWithSuspiciousOrder)

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
@@ -37,6 +37,12 @@ class ModifierClickableOrderCheckTest {
                     Something7(
                         modifier = bananaModifier.clickable { }.clip(shape = RoundedCornerShape(8.dp))
                     )
+                    Something8(
+                        modifier = bananaModifier.clickable { }.clip(Potato)
+                    )
+                    Something9(
+                        modifier = bananaModifier.clickable { }.background(MaterialTheme.shapes.large)
+                    )
                 }
             """.trimIndent()
         modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
@@ -67,6 +73,16 @@ class ModifierClickableOrderCheckTest {
             ),
             LintViolation(
                 line = 19,
+                col = 35,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 22,
+                col = 35,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 25,
                 col = 35,
                 detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
             ),


### PR DESCRIPTION
Made `ModifierClickableOrder` rule useful for more cases: if the shape is referenced via MaterialTheme.shapes or similar, or if clip is used at all (before I was checking for shape params or shape classes, but clip only takes a shape so anything goes).