### PR TITLE
Add LambdaParameterInRestartableEffect rule

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.rules.core.util
 
-import java.util.Locale
+import java.util.*
 
 fun <T> T.runIf(value: Boolean, block: T.() -> T): T = if (value) block() else this
 
 fun <T, R> T.runIfNotNull(value: R?, block: T.(R) -> T): T = value?.let { block(it) } ?: this
+
+fun <T, R> Sequence<T>.mapIf(condition: (T) -> Boolean, transform: (T) -> R): Sequence<R> =
+    mapNotNull { if (condition(it)) transform(it) else null }
 
 fun String?.matchesAnyOf(patterns: Sequence<Regex>): Boolean {
     if (isNullOrEmpty()) return false

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -42,6 +42,10 @@ Compose:
     # contentEmitters: MyComposable,MyOtherComposable
   DefaultsVisibility:
     active: true
+  LambdaParameterInRestartableEffect:
+    active: true
+    # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsLambda: MyLambdaType
   ModifierClickableOrder:
     active: true
     # -- You can optionally add your own Modifier types

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/LambdaParameterInRestartableEffect.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/LambdaParameterInRestartableEffect.kt
@@ -1,0 +1,105 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtConfig
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.isComposable
+import io.nlopez.rules.core.util.isLambda
+import io.nlopez.rules.core.util.isRestartableEffect
+import io.nlopez.rules.core.util.lambdaTypes
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+
+class LambdaParameterInRestartableEffect : ComposeKtVisitor {
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
+        val lambdaTypes = with(config) { file.lambdaTypes }
+        val composables = file.findChildrenByClass<KtFunction>()
+            .filter { it.isComposable }
+
+        for (composable in composables) {
+            // We are only interested in composables with restartable effects (the ones that have keys)
+            val effects = composable.findChildrenByClass<KtCallExpression>()
+                .filter { it.isRestartableEffect }
+
+            if (effects.none()) continue
+
+            // And of those, we are only interested in composables that have lambda params
+            val lambdaParameters = composable.valueParameters
+                .filter { it.isLambdaParameter || it.typeReference?.isLambda(lambdaTypes) == true }
+                .filter { it.name != null }
+                .associateBy { it.name!! }
+            val lambdaParameterNames = lambdaParameters.keys
+
+            if (lambdaParameterNames.isEmpty()) continue
+
+            // Then, we just want the lambda parameters that are actually used inside in any of the found effects'
+            // trailing lambda code
+            val usedLambdaParameterNames = effects.mapNotNull { it.lambdaArguments.lastOrNull() }
+                .mapNotNull { it.getLambdaExpression()?.bodyExpression }
+                .flatMap { body ->
+                    val callExpressions = body.findChildrenByClass<KtCallExpression>()
+
+                    // Lambdas used directly: myLambda()
+                    val invoked = callExpressions.mapNotNull { it.calleeExpression?.text }
+                        .filter { it in lambdaParameterNames }
+
+                    // Lambdas being tossed around to other methods
+                    val forwarded = callExpressions.flatMap {
+                        it.valueArguments.mapNotNull { argument ->
+                            when (val expression = argument.getArgumentExpression()) {
+                                // something(myLambda) || something(a = myLambda)
+                                is KtReferenceExpression -> {
+                                    if (expression.text in lambdaParameterNames) expression.text else null
+                                }
+                                // something(if (x) myLambda else otherThing)
+                                is KtIfExpression -> {
+                                    if (expression.then?.text in lambdaParameterNames) {
+                                        expression.then?.text
+                                    } else if (expression.`else`?.text in lambdaParameterNames) {
+                                        expression.`else`?.text
+                                    } else {
+                                        null
+                                    }
+                                }
+
+                                else -> null
+                            }
+                        }
+                    }
+                    invoked + forwarded
+                }
+                .toSet()
+
+            // We want to filter out the parameters that are used as key in the restartable effect
+            val keyedLambdaParameterNames = effects.flatMap { it.valueArguments }
+                .mapNotNull { it.getArgumentExpression() }
+                .filterIsInstance<KtReferenceExpression>()
+                .map { it.text }
+                .filter { it in usedLambdaParameterNames }
+                .toSet()
+
+            for (parameterName in usedLambdaParameterNames - keyedLambdaParameterNames) {
+                val parameter = lambdaParameters[parameterName]!!
+                emitter.report(parameter, LambdaUsedInRestartableEffect)
+            }
+        }
+    }
+
+    companion object {
+        val LambdaUsedInRestartableEffect = """
+            Lambda parameters in a @Composable that are referenced directly inside of restarting effects can cause issues or unpredictable behavior.
+
+            If restarting the effect is ok, you can add the reference to this parameter as a key in that effect, so when the parameter changes, a new effect is created.
+            However, if the effect is not to be restarted, you will need to use `rememberUpdatedState` on the parameter and use its result in the effect.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#be-mindful-of-the-arguments-you-use-inside-of-a-restarting-effect for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -17,6 +17,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             CompositionLocalNamingCheck(config),
             ContentEmitterReturningValuesCheck(config),
             DefaultsVisibilityCheck(config),
+            LambdaParameterInRestartableEffectCheck(config),
             ModifierClickableOrderCheck(config),
             ModifierComposableCheck(config),
             ModifierMissingCheck(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/LambdaParameterInRestartableEffectCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/LambdaParameterInRestartableEffectCheck.kt
@@ -1,0 +1,23 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.LambdaParameterInRestartableEffect
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class LambdaParameterInRestartableEffectCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by LambdaParameterInRestartableEffect() {
+
+    override val issue: Issue = Issue(
+        id = "LambdaParameterInRestartableEffect",
+        severity = Severity.Defect,
+        description = LambdaParameterInRestartableEffect.LambdaUsedInRestartableEffect,
+        debt = Debt.TWENTY_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -13,6 +13,8 @@ Compose:
     active: true
   DefaultsVisibility:
     active: true
+  LambdaParameterInRestartableEffectCheck:
+    active: true
   ModifierClickableOrder:
     active: true
   ModifierComposable:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/LambdaParameterInRestartableEffectCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/LambdaParameterInRestartableEffectCheckTest.kt
@@ -1,0 +1,81 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.LambdaParameterInRestartableEffect
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class LambdaParameterInRestartableEffectCheckTest {
+
+    private val testConfig = TestConfig(
+        "treatAsLambda" to listOf("MyLambda"),
+    )
+    private val rule = LambdaParameterInRestartableEffectCheck(testConfig)
+
+    @Test
+    fun `error out when detecting a lambda being used in an effect`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(onClick: () -> Unit) {
+                    LaunchedEffect(Unit) {
+                        onClick()
+                    }
+                }
+                @Composable
+                fun Something(onClick: MyLambda) {
+                    DisposableEffect(Unit) {
+                        onClick()
+                    }
+                }
+                fun interface MyLambda2 {
+                    fun create()
+                }
+                @Composable
+                fun Something(onClick: MyLambda2) {
+                    LaunchedEffect(Unit) {
+                        onClick()
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 15),
+                SourceLocation(8, 15),
+                SourceLocation(17, 15),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(LambdaParameterInRestartableEffect.LambdaUsedInRestartableEffect)
+        }
+    }
+
+    @Test
+    fun `passes when a lambda is properly handled before using it in an effect`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(onClick: () -> Unit) {
+                    val latestOnClick by rememberUpdatedState(onClick)
+                    LaunchedEffect(Unit) {
+                        latestOnClick()
+                    }
+                }
+                @Composable
+                fun Something(onClick: () -> Unit) {
+                    DisposableEffect(onClick) {
+                        onClick()
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -16,6 +16,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { CompositionLocalNamingCheck() },
         RuleProvider { ContentEmitterReturningValuesCheck() },
         RuleProvider { DefaultsVisibilityCheck() },
+        RuleProvider { LambdaParameterInRestartableEffectCheck() },
         RuleProvider { ModifierClickableOrderCheck() },
         RuleProvider { ModifierComposableCheck() },
         RuleProvider { ModifierMissingCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/LambdaParameterInRestartableEffectCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/LambdaParameterInRestartableEffectCheck.kt
@@ -1,0 +1,14 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.LambdaParameterInRestartableEffect
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class LambdaParameterInRestartableEffectCheck :
+    KtlintRule(
+        id = "compose:lambda-param-in-effect",
+        editorConfigProperties = setOf(treatAsLambda),
+    ),
+    ComposeKtVisitor by LambdaParameterInRestartableEffect()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/LambdaParameterInRestartableEffectCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/LambdaParameterInRestartableEffectCheckTest.kt
@@ -1,0 +1,89 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.LambdaParameterInRestartableEffect
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class LambdaParameterInRestartableEffectCheckTest {
+    private val ruleAssertThat = KtLintAssertThat.assertThatRule { LambdaParameterInRestartableEffectCheck() }
+
+    @Test
+    fun `error out when detecting a lambda being used in an effect`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(onClick: () -> Unit) {
+                    LaunchedEffect(Unit) {
+                        onClick()
+                    }
+                }
+                @Composable
+                fun Something(onClick: MyLambda) {
+                    DisposableEffect(Unit) {
+                        onClick()
+                    }
+                }
+                fun interface MyLambda2 {
+                    fun create()
+                }
+                @Composable
+                fun Something(onClick: MyLambda2) {
+                    LaunchedEffect(Unit) {
+                        onClick()
+                    }
+                }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                treatAsLambda to "MyLambda",
+            )
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 15,
+                    detail = LambdaParameterInRestartableEffect.LambdaUsedInRestartableEffect,
+                ),
+                LintViolation(
+                    line = 8,
+                    col = 15,
+                    detail = LambdaParameterInRestartableEffect.LambdaUsedInRestartableEffect,
+                ),
+                LintViolation(
+                    line = 17,
+                    col = 15,
+                    detail = LambdaParameterInRestartableEffect.LambdaUsedInRestartableEffect,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when a lambda is properly handled before using it in an effect`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(onClick: () -> Unit) {
+                    val latestOnClick by rememberUpdatedState(onClick)
+                    LaunchedEffect(Unit) {
+                        latestOnClick()
+                    }
+                }
+                @Composable
+                fun Something(onClick: () -> Unit) {
+                    DisposableEffect(onClick) {
+                        onClick()
+                    }
+                }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                treatAsLambda to "MyLambda",
+            )
+            .hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
Adds a rule to detect potential troubling scenarios where a lambda parameter in a composable is used directly in a restartable effect (e.g. LaunchedEffect/DisposableEffect), without using `rememberUpdatedState` or using the param as a key to the effect.

This currently bit me in the ass at work, so adding a basic rule for just lambdas (for now) to tackle this.