### PR TITLE
Add safe accessors + let to the content emission counters

### DIFF
--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -95,12 +95,18 @@ class MultipleContentEmittersCheckTest {
                     Spacer()
                     Text("Hola")
                 }
+                @Composable
+                fun Something(title: String?, subtitle: String?) {
+                    title?.let { Text(title) }
+                    subtitle?.let { Text(subtitle) }
+                }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors)
             .hasStartSourceLocations(
                 SourceLocation(2, 5),
                 SourceLocation(7, 5),
+                SourceLocation(12, 5),
             )
         for (error in errors) {
             assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -86,6 +86,11 @@ class MultipleContentEmittersCheckTest {
                     Spacer()
                     Text("Hola")
                 }
+                @Composable
+                fun Something(title: String?, subtitle: String?) {
+                    title?.let { Text(title) }
+                    subtitle?.let { Text(subtitle) }
+                }
             """.trimIndent()
         emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
             LintViolation(
@@ -95,6 +100,11 @@ class MultipleContentEmittersCheckTest {
             ),
             LintViolation(
                 line = 7,
+                col = 5,
+                detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+            ),
+            LintViolation(
+                line = 12,
                 col = 5,
                 detail = MultipleContentEmitters.MultipleContentEmittersDetected,
             ),


### PR DESCRIPTION
Allows for code similar to this to be counted towards emissions at the top level. 

```kotlin
@Composable
fun A(title: String?, subtitle: String?) {
  title?.let { Text(it) }
  subtitle?.let { Text(it) }
}
```

Fixes #191 