### PR TITLE
Fix false positives with vm-injection rule when in android.navigation DSL

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 
 context(ComposeKtConfig)
@@ -263,13 +264,7 @@ private val RestartableEffects by lazy(LazyThreadSafetyMode.NONE) {
     )
 }
 
-fun KtCallExpression.isRemembered(stopAt: PsiElement): Boolean {
-    var current: PsiElement = parent
-    while (current != stopAt) {
-        (current as? KtCallExpression)?.let { callExpression ->
-            if (callExpression.calleeExpression?.text?.startsWith("remember") == true) return true
-        }
-        current = current.parent
-    }
-    return false
-}
+fun KtCallExpression.isRemembered(stopAt: PsiElement): Boolean = parents
+    .takeWhile { it != stopAt }
+    .filterIsInstance<KtCallExpression>()
+    .any { it.calleeExpression?.text?.startsWith("remember") == true }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ViewModelInjectionCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ViewModelInjectionCheckTest.kt
@@ -51,7 +51,7 @@ class ViewModelInjectionCheckTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
-    fun `errors when a weaverViewModel is used at the beginning of a Composable`(viewModel: String) {
+    fun `errors when a viewModel is used at the beginning of a Composable`(viewModel: String) {
         @Language("kotlin")
         val code =
             """
@@ -82,7 +82,26 @@ class ViewModelInjectionCheckTest {
 
     @ParameterizedTest
     @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
-    fun `errors when a weaverViewModel is used in different branches`(viewModel: String) {
+    fun `passes when a viewModel is used inside the navigation DSL`(viewModel: String) {
+        @Language("kotlin")
+        val code =
+            """
+            @Composable
+            fun MyComposable(modifier: Modifier) {
+                NavHost() {
+                    composable("bleh") {
+                        val viewModel = $viewModel<MyVM>()
+                    }
+                }
+            }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["viewModel", "weaverViewModel", "hiltViewModel", "bananaViewModel", "potatoViewModel"])
+    fun `errors when a viewModel is used in different branches`(viewModel: String) {
         @Language("kotlin")
         val code =
             """


### PR DESCRIPTION
Filters out the rule violation candidates if they are used inside of a androidx.navigation DSL (NavHost/composable), as it'd be legit using them there. It also removes the autofix capability when the VM factories have arguments, as it's just not practical to check where all the params would come from (and if they'd be available in the composable params).

Fixes #212 