### PR TITLE
Add ModifierComposed rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -54,6 +54,10 @@ Compose:
     active: true
     # -- You can optionally add your own Modifier types
     # customModifiers: BananaModifier,PotatoModifier
+  ModifierComposed:
+    active: true
+    # -- You can optionally add your own Modifier types
+    # customModifiers: BananaModifier,PotatoModifier
   ModifierMissing:
     active: true
     # -- You can optionally control the visibility of which composables to check for here

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -451,11 +451,13 @@ Related rule: [compose:modifier-naming](https://github.com/mrmans0n/compose-rule
 
 ### Avoid Modifier extension factory functions
 
-Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use [Modifier.Node](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier.Node) instead. It will allow you to accomplish the same things while being very performant, and not using a `@Composable` unnecessarily. In instances where `Modifier.Node` is not fit for the job, you can still rely on the [composed](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#(androidx.compose.ui.Modifier).composed(kotlin.Function1,kotlin.Function1)) modifier.
+Using `@Composable` builder functions for modifiers is not recommended, as they cause unnecessary recompositions. To avoid this, you should use [Modifier.Node](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier.Node) instead. It will allow you to accomplish the same things while being very performant.
+
+There is another API for creating custom modifiers, `composed {}`. This API is no longer recommended due to the performance issues it created, and like with the extension factory functions case, Modifier.Node is recommended instead.
 
 More info: [Modifier.Node](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier.Node), [Compose Modifier.Node and where to find it, by Merab Tato Kutalia](https://proandroiddev.com/compose-modifier-node-and-where-to-find-it-merab-tato-kutalia-66f891c0e8), [Compose modifiers deep dive, with Leland Richardson](https://www.youtube.com/watch?v=BjGX2RftXsU) and [Composed modifier docs](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#(androidx.compose.ui.Modifier).composed(kotlin.Function1,kotlin.Function1)).
 
-Related rule: [compose:modifier-composable-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt)
+Related rules: [compose:modifier-composable-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt) and [compose:modifier-composed-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposed.kt)
 
 ## ComponentDefaults
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposed.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposed.kt
@@ -1,0 +1,48 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtConfig
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.findDirectChildrenByClass
+import io.nlopez.rules.core.util.isComposable
+import io.nlopez.rules.core.util.isModifierReceiver
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtReturnExpression
+
+class ModifierComposed : ComposeKtVisitor {
+
+    override fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
+        if (!with(config) { function.isModifierReceiver }) return
+        if (function.isComposable) return
+
+        // If using a body expression, we can directly check for it being a call to `composed`
+        val bodyExpression = function.bodyExpression
+        if (bodyExpression is KtCallExpression && bodyExpression.calleeExpression?.text == "composed") {
+            emitter.report(function, ComposedModifier)
+        }
+
+        // Otherwise, check the return statement expression
+        val bodyBlockExpression = function.bodyBlockExpression ?: return
+        val returnsComposed = bodyBlockExpression.findDirectChildrenByClass<KtReturnExpression>()
+            .mapNotNull { it.returnedExpression }
+            .filterIsInstance<KtCallExpression>()
+            .any { it.calleeExpression?.text == "composed" }
+
+        if (returnsComposed) {
+            emitter.report(function, ComposedModifier)
+        }
+    }
+
+    companion object {
+        val ComposedModifier = """
+            Using composed for modifiers is not recommended anymore, due to the performance issues it creates.
+            You should consider migrating this modifier to be based on Modifier.Node instead.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#avoid-modifier-extension-factory-functions for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -20,6 +20,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             LambdaParameterInRestartableEffectCheck(config),
             ModifierClickableOrderCheck(config),
             ModifierComposableCheck(config),
+            ModifierComposedCheck(config),
             ModifierMissingCheck(config),
             ModifierNamingCheck(config),
             ModifierNotUsedAtRootCheck(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierComposedCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierComposedCheck.kt
@@ -1,0 +1,22 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.ModifierComposed
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class ModifierComposedCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ModifierComposed() {
+    override val issue: Issue = Issue(
+        id = "ModifierComposed",
+        severity = Severity.Performance,
+        description = ModifierComposed.ComposedModifier,
+        debt = Debt.TEN_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -19,6 +19,8 @@ Compose:
     active: true
   ModifierComposable:
     active: true
+  ModifierComposed:
+    active: true
   ModifierMissing:
     active: true
   ModifierNaming:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierComposedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierComposedCheckTest.kt
@@ -1,0 +1,33 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ModifierComposed
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ModifierComposedCheckTest {
+
+    private val rule = ModifierComposedCheck(Config.empty)
+
+    @Test
+    fun `errors when a composed Modifier extension is detected`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun Modifier.something1(): Modifier = composed {}
+                fun Modifier.something2() = composed {}
+                fun Modifier.something3() {
+                    return composed {}
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasTextLocations("something1", "something2", "something3")
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierComposed.ComposedModifier)
+        }
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -19,6 +19,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { LambdaParameterInRestartableEffectCheck() },
         RuleProvider { ModifierClickableOrderCheck() },
         RuleProvider { ModifierComposableCheck() },
+        RuleProvider { ModifierComposedCheck() },
         RuleProvider { ModifierMissingCheck() },
         RuleProvider { ModifierNamingCheck() },
         RuleProvider { ModifierNotUsedAtRootCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierComposedCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierComposedCheck.kt
@@ -1,0 +1,14 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.ModifierComposed
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class ModifierComposedCheck :
+    KtlintRule(
+        id = "compose:modifier-composed-check",
+        editorConfigProperties = setOf(customModifiers),
+    ),
+    ComposeKtVisitor by ModifierComposed()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierComposedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierComposedCheckTest.kt
@@ -1,0 +1,45 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ModifierComposed
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ModifierComposedCheckTest {
+
+    private val modifierRuleAssertThat = assertThatRule { ModifierComposedCheck() }
+
+    @Test
+    fun `errors when a composable Modifier extension is detected`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun Modifier.something1(): Modifier = composed {}
+                fun Modifier.something2() = composed {}
+                fun Modifier.something3() {
+                    return composed {}
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 1,
+                col = 14,
+                detail = ModifierComposed.ComposedModifier,
+            ),
+            LintViolation(
+                line = 2,
+                col = 14,
+                detail = ModifierComposed.ComposedModifier,
+            ),
+            LintViolation(
+                line = 3,
+                col = 14,
+                detail = ModifierComposed.ComposedModifier,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Adds a `ModifierComposed` rule, to detect all usages of `composed` in Modifiers and direct people to use `Modifier.Node` instead, as it's more performant and the recommended option nowadays.

Closes #203 