### PR TITLE
Add opt-in rule for disallowing Material2 APIs

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.rules.core.util
 
+import org.jetbrains.kotlin.name.FqName
 import java.util.*
 
 fun <T> T.runIf(value: Boolean, block: T.() -> T): T = if (value) block() else this
@@ -10,6 +11,8 @@ fun <T, R> T.runIfNotNull(value: R?, block: T.(R) -> T): T = value?.let { block(
 
 fun <T, R> Sequence<T>.mapIf(condition: (T) -> Boolean, transform: (T) -> R): Sequence<R> =
     mapNotNull { if (condition(it)) transform(it) else null }
+
+operator fun FqName.plus(other: String): FqName = FqName(asString() + "." + other)
 
 fun String?.matchesAnyOf(patterns: Sequence<Regex>): Boolean {
     if (isNullOrEmpty()) return false

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtDotQualifiedExpressions.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtDotQualifiedExpressions.kt
@@ -4,6 +4,7 @@ package io.nlopez.rules.core.util
 
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 
 val KtDotQualifiedExpression.rootExpression: KtExpression
     get() {
@@ -13,3 +14,16 @@ val KtDotQualifiedExpression.rootExpression: KtExpression
         }
         return current
     }
+
+/**
+ * [KtDotQualifiedExpression] can be nested, and if we only care about the one that contains all the expression,
+ * this method will filter out all the others from the [Sequence].
+ *
+ * For example: "androidx.compose.material" would have "androidx.compose.material", "androidx.compose" and "androidx".
+ * If these were in the same sequence, we'd only use "androidx.compose.material" and get rid of the others.
+ */
+fun Sequence<KtDotQualifiedExpression>.dedupUsingOutermost(): Sequence<KtDotQualifiedExpression> =
+    map { it.outermost }.distinct()
+
+val KtDotQualifiedExpression.outermost: KtDotQualifiedExpression
+    get() = parentsWithSelf.takeWhile { it is KtDotQualifiedExpression }.last() as KtDotQualifiedExpression

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
@@ -4,6 +4,7 @@ package io.nlopez.rules.core.util
 
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiNameIdentifierOwner
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import java.util.Deque
 import java.util.LinkedList
@@ -43,3 +44,6 @@ inline fun <reified T : PsiElement> PsiElement.findDirectChildrenByClass(): Sequ
 
 val PsiNameIdentifierOwner.startOffsetFromName: Int
     get() = nameIdentifier?.startOffset ?: startOffset
+
+val PsiElement.range: IntRange
+    get() = IntRange(startOffset, endOffset)

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -46,6 +46,10 @@ Compose:
     active: true
     # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
     # treatAsLambda: MyLambdaType
+  Material2:
+    active: false # Opt-in, disabled by default. Turn on if you want to disallow Material 2 usages.
+    # -- You can optionally allow parts of it, if you are in the middle of a migration.
+    # allowedFromM2: icons.Icons,TopAppBar
   ModifierClickableOrder:
     active: true
     # -- You can optionally add your own Modifier types

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -135,6 +135,25 @@ The `param-order-check` rule will do its best to identify trailing lambdas. Howe
 compose_treat_as_lambda = MyLambdaType,MyOtherLambdaType
 ```
 
+### Enabling the Material 2 detector
+
+The `material-two` rule will flag any usage of a Material 2 API. This rule is disabled by default, so you'll need to explicitly enable it in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_disallow_material2 = true
+```
+
+You might also want to disallow Material 2, but allow a specific set / subset of APIs. The rule allows this too.
+
+For example, let's say you want to allow all filled icons (whose fully qualified names are androidx.compose.material.icons.filled.*) and the `Button` composable (androidx.compose.material.Button). This is how you'd allow those:
+
+```editorconfig
+[*.{kt,kts}]
+compose_disallow_material2 = true
+compose_allowed_from_m2 = icons.filled,Button
+```
+
 ## Disabling a specific rule
 
 To disable a rule you have to follow the [instructions from the ktlint documentation](https://github.com/pinterest/ktlint#how-do-i-suppress-an-errors-for-a-lineblockfile), and use the id of the rule you want to disable with the `compose` tag.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -468,3 +468,17 @@ If your composable has an associated `Defaults` object to contain its default va
 More info: [Compose Component API Guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md#default-expressions)
 
 Related rule: [compose:defaults-visibility](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/DefaultsVisibility.kt)
+
+## Opt-in rules
+
+> **Note**: These rules are disabled by default, you'll need to explicitly enable them individually in detekt/ktlint if you.
+
+### Don't use Material 2
+
+Material Design 3 is the next evolution of Material Design. It includes updated theming, components, and Material You personalization features like dynamic color. It supersedes Material 2, and using Material 3 usage is recommended instead of Material 2.
+
+Enabling: [ktlint](https://mrmans0n.github.io/compose-rules/ktlint/#enabling-the-material-2-detector), [detekt](https://mrmans0n.github.io/compose-rules/detekt/#enabling-rules)
+
+More info: [Migration to Material 3](https://developer.android.com/develop/ui/compose/designsystems/material2-material3)
+
+Related rule: [compose:material-two](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/Material2.kt)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/Material2.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/Material2.kt
@@ -1,0 +1,87 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtConfig
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.dedupUsingOutermost
+import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.plus
+import io.nlopez.rules.core.util.range
+import io.nlopez.rules.core.util.runIfNotNull
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
+class Material2 : ComposeKtVisitor {
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
+        // Allowed elements/apis from material2, in the format of whatever comes after androidx.compose.material
+        // For instance, if we want to allow icons, we'll put just `Icons`, or if we only allowed the filled icons,
+        // we'll put `icons.filled` (regardless of the specifics that could come after)
+        val allowedFqNames = config.getSet("allowedFromM2", emptySet()).map { M2FqName + it }
+
+        // Find in import list
+        val imports = file.importList?.imports.orEmpty()
+            .filterNotNull()
+            .filter { it.importedFqName?.startsWith(M2FqName) == true }
+            .filterNot { directive ->
+                allowedFqNames.any { directive.importedFqName?.startsWith(it) == true }
+            }
+
+        for (directive in imports) {
+            emitter.report(directive, DisallowedUsageOfMaterial2)
+        }
+
+        // Find usages that don't need imports (e.g. androidx.compose.material.Icons.Arrow being used directly)
+        val dotQualified = file.findChildrenByClass<KtDotQualifiedExpression>()
+            // Ignore the ones in imports
+            .runIfNotNull(file.importList) { imps -> filter { it.startOffset !in imps.range } }
+            // Ignore the ones in package definitions
+            .runIfNotNull(file.packageDirective) { pkg -> filter { it.startOffset !in pkg.range } }
+            // De-dup nested KtDotQualifiedExpression and only process the outermost
+            .dedupUsingOutermost()
+            .filter { it.hasReferenceToM2(allowedFqNames) }
+
+        for (reference in dotQualified) {
+            emitter.report(reference, DisallowedUsageOfMaterial2)
+        }
+    }
+
+    private fun KtDotQualifiedExpression.hasReferenceToM2(allowlist: List<FqName>): Boolean {
+        // 2 possible routes here:
+        // - the reference expression is a KtCallExpression (e.g. `androidx.compose.material.Text(...)`)
+        // - the reference expression is a KtReferenceExpression (e.g. `androidx.compose.material.Icons.Arrow`)
+        // It needs to be in that order, as KtCallExpression is a KtReferenceExpression.
+        return when (val expression = selectorExpression) {
+            is KtCallExpression -> {
+                runCatching {
+                    val fqn = FqName(receiverExpression.text + "." + expression.calleeExpression?.text)
+                    fqn.startsWith(M2FqName) && allowlist.none { fqn.startsWith(it) }
+                }.getOrDefault(false)
+            }
+
+            is KtReferenceExpression -> {
+                runCatching {
+                    val fqn = FqName(text)
+                    fqn.startsWith(M2FqName) && allowlist.none { fqn.startsWith(it) }
+                }.getOrDefault(false)
+            }
+
+            else -> false
+        }
+    }
+
+    companion object {
+        private val M2FqName = FqName.fromSegments(listOf("androidx", "compose", "material"))
+        val DisallowedUsageOfMaterial2 = """
+            Compose Material 2 is disallowed by your configuration.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#dont-use-material-2 for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -18,6 +18,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             ContentEmitterReturningValuesCheck(config),
             DefaultsVisibilityCheck(config),
             LambdaParameterInRestartableEffectCheck(config),
+            Material2Check(config),
             ModifierClickableOrderCheck(config),
             ModifierComposableCheck(config),
             ModifierComposedCheck(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Material2Check.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Material2Check.kt
@@ -1,0 +1,22 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.Material2
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class Material2Check(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by Material2() {
+    override val issue: Issue = Issue(
+        id = "Material2",
+        severity = Severity.Maintainability,
+        description = Material2.DisallowedUsageOfMaterial2,
+        debt = Debt.TEN_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -13,8 +13,10 @@ Compose:
     active: true
   DefaultsVisibility:
     active: true
-  LambdaParameterInRestartableEffectCheck:
+  LambdaParameterInRestartableEffect:
     active: true
+  Material2:
+    active: false
   ModifierClickableOrder:
     active: true
   ModifierComposable:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/Material2CheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/Material2CheckTest.kt
@@ -1,0 +1,94 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.Material2
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class Material2CheckTest {
+
+    private val testConfig = TestConfig(
+        "allowedFromM2" to listOf("icons.Icons", "TopAppBar"),
+    )
+    private val rule = Material2Check(testConfig)
+
+    @Test
+    fun `errors when there is a M2 reference in imports`() {
+        @Language("kotlin")
+        val code =
+            """
+                import androidx.compose.material.Surface
+                import androidx.compose.material.Text
+                import androidx.compose.material.Typography as M2Typography
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(1, 1),
+                SourceLocation(2, 1),
+                SourceLocation(3, 1),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(Material2.DisallowedUsageOfMaterial2)
+        }
+    }
+
+    @Test
+    fun `passes when there is a M2 reference in imports but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                import androidx.compose.material.icons.Icons
+                import androidx.compose.material.icons.Icons.Arrow
+                import androidx.compose.material.TopAppBar
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `errors when there is a M2 reference in dot qualified expressions`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    androidx.compose.material.Text("hi")
+                    Icon(imageVector = androidx.compose.material.icons.filled.ArrowBack, contentDescription = null)
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(3, 5),
+                SourceLocation(4, 24),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(Material2.DisallowedUsageOfMaterial2)
+        }
+    }
+
+    @Test
+    fun `passes when there is a M2 reference in dot qualified expressions but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    androidx.compose.material.TopAppBar(title = { Text("boo") })
+                    Icon(imageVector = androidx.compose.material.icons.Icons.Arrow, contentDescription = null)
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -17,6 +17,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { ContentEmitterReturningValuesCheck() },
         RuleProvider { DefaultsVisibilityCheck() },
         RuleProvider { LambdaParameterInRestartableEffectCheck() },
+        RuleProvider { Material2Check() },
         RuleProvider { ModifierClickableOrderCheck() },
         RuleProvider { ModifierComposableCheck() },
         RuleProvider { ModifierComposedCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -188,3 +188,32 @@ val treatAsLambda: EditorConfigProperty<String> =
             }
         },
     )
+
+val allowedFromM2: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_allowed_from_m2",
+            "A comma separated list of Material 2 APIs that are allowed",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
+val disallowMaterial2: EditorConfigProperty<Boolean> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_disallow_material2",
+            "When enabled, Compose Material 2 (M2) usages will be disallowed.",
+            PropertyValueParser.BOOLEAN_VALUE_PARSER,
+            setOf(true.toString(), false.toString()),
+        ),
+        defaultValue = false,
+    )

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/Material2Check.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/Material2Check.kt
@@ -1,0 +1,26 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.Material2
+import io.nlopez.rules.core.ComposeKtConfig
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.ktlint.KtlintRule
+import org.jetbrains.kotlin.psi.KtFile
+
+class Material2Check :
+    KtlintRule(
+        id = "compose:material-two",
+        editorConfigProperties = setOf(allowedFromM2, disallowMaterial2),
+    ),
+    ComposeKtVisitor {
+    private val visitor = Material2()
+
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
+        // ktlint allows all rules by default, so we'll add an extra param to make sure it's disabled by default
+        if (config.getBoolean("disallowMaterial2", false)) {
+            visitor.visitFile(file, autoCorrect, emitter, config)
+        }
+    }
+}

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/Material2CheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/Material2CheckTest.kt
@@ -1,0 +1,122 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.Material2
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class Material2CheckTest {
+
+    private val ruleAssertThat = assertThatRule { Material2Check() }
+
+    @Test
+    fun `disabled by default`() {
+        @Language("kotlin")
+        val code =
+            """
+                import androidx.compose.material.Surface
+            """.trimIndent()
+
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `errors when there is a M2 reference in imports`() {
+        @Language("kotlin")
+        val code =
+            """
+                import androidx.compose.material.Surface
+                import androidx.compose.material.Text
+                import androidx.compose.material.Typography as M2Typography
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(disallowMaterial2 to true)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 1,
+                    col = 1,
+                    detail = Material2.DisallowedUsageOfMaterial2,
+                ),
+                LintViolation(
+                    line = 2,
+                    col = 1,
+                    detail = Material2.DisallowedUsageOfMaterial2,
+                ),
+                LintViolation(
+                    line = 3,
+                    col = 1,
+                    detail = Material2.DisallowedUsageOfMaterial2,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when there is a M2 reference in imports but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                import androidx.compose.material.icons.Icons
+                import androidx.compose.material.icons.Icons.Arrow
+                import androidx.compose.material.TopAppBar
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                disallowMaterial2 to true,
+                allowedFromM2 to "icons.Icons,TopAppBar",
+            )
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `errors when there is a M2 reference in dot qualified expressions`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    androidx.compose.material.Text("hi")
+                    Icon(imageVector = androidx.compose.material.icons.Icons.ArrowBack, contentDescription = null)
+                }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(disallowMaterial2 to true)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = Material2.DisallowedUsageOfMaterial2,
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 24,
+                    detail = Material2.DisallowedUsageOfMaterial2,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when there is a M2 reference in dot qualified expressions but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    androidx.compose.material.TopAppBar(title = { Text("boo") })
+                    Icon(imageVector = androidx.compose.material.icons.Icons.Arrow, contentDescription = null)
+                }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                disallowMaterial2 to true,
+                allowedFromM2 to "icons.Icons,TopAppBar",
+            )
+            .hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
Add a new rule (opt-in) to detect Material 2 usages. This has bit me in the ass at work, so I have a vested interest it goes in 🤣 

It will detect usages of the material 2 apis in imports and as fqns in the code. It also has support for an allowlist of apis, based on their package hierarchy.