### PR TITLE
Add rule to use the non-autoboxing versions of mutableStateOf when possible

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
@@ -12,6 +12,9 @@ fun <T, R> T.runIfNotNull(value: R?, block: T.(R) -> T): T = value?.let { block(
 fun <T, R> Sequence<T>.mapIf(condition: (T) -> Boolean, transform: (T) -> R): Sequence<R> =
     mapNotNull { if (condition(it)) transform(it) else null }
 
+fun <F, S, T : Pair<F, S>> Sequence<T>.mapFirst() = map { it.first }
+fun <F, S, T : Pair<F, S>> Sequence<T>.mapSecond() = map { it.second }
+
 operator fun FqName.plus(other: String): FqName = FqName(asString() + "." + other)
 
 fun String?.matchesAnyOf(patterns: Sequence<Regex>): Boolean {

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtConstantExpressions.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KtConstantExpressions.kt
@@ -1,0 +1,24 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.rules.core.util
+
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.psi.KtConstantExpression
+
+val KtConstantExpression.isInt: Boolean
+    get() = isIntegerConstant && !isLong
+
+val KtConstantExpression.isLong: Boolean
+    get() = isIntegerConstant && text.endsWith("L")
+
+val KtConstantExpression.isDouble: Boolean
+    get() = isFloatConstant && !isFloat
+
+val KtConstantExpression.isFloat: Boolean
+    get() = isFloatConstant && text.endsWith("f")
+
+private val KtConstantExpression.isIntegerConstant: Boolean
+    get() = node.elementType == KtNodeTypes.INTEGER_CONSTANT
+
+private val KtConstantExpression.isFloatConstant: Boolean
+    get() = node.elementType == KtNodeTypes.FLOAT_CONSTANT

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -93,6 +93,8 @@ Compose:
     # contentEmittersDenylist: MyNonEmitterComposable
   MutableParams:
     active: true
+  MutableStateAutoboxing:
+    active: true
   MutableStateParam:
     active: true
   PreviewAnnotationNaming:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -65,6 +65,14 @@ More info: [Jetpack Compose Stability Explained](https://medium.com/androiddevel
 
 Related rule: [compose:unstable-collections](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt)
 
+### Use mutableStateOf type-specific variants when possible
+
+`mutableIntStateOf`, `mutableLongStateOf`, `mutableDoubleStateOf`, `mutableFloatStateOf` are essentially counterparts to `mutableStateOf`, but with the added advantage of circumventing autoboxing on JVM platforms. This distinction renders them more memory efficient, making them the preferable choice when dealing with primitive types such as double, float, int, and long.
+
+Functionally are the same, but they are preferred when dealing with these specific types.
+
+Related rule: [compose:mutable-state-autoboxing](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateAutoboxing.kt)
+
 ## Composables
 
 ### Do not use inherently mutable types as parameters

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateAutoboxing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateAutoboxing.kt
@@ -1,0 +1,150 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtConfig
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.findChildrenByClass
+import io.nlopez.rules.core.util.isDouble
+import io.nlopez.rules.core.util.isFloat
+import io.nlopez.rules.core.util.isInt
+import io.nlopez.rules.core.util.isLong
+import io.nlopez.rules.core.util.mapFirst
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtConstantExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+
+class MutableStateAutoboxing : ComposeKtVisitor {
+
+    override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
+        // Things we can realistically support without type resolution without going bananas
+        // - numeric constants
+        // - stuff that comes from function params
+        val allMutableStateOfWithConstantSingleArgument = file.findMutableStateOf()
+            .filter { it.singleArgumentExpression is KtConstantExpression }
+            .map { it to it.singleArgumentExpression as KtConstantExpression }
+
+        // mutableIntStateOf
+        val ints = allMutableStateOfWithConstantSingleArgument
+            .filter { (_, constantExpression) -> constantExpression.isInt }
+            .mapFirst()
+
+        for (item in ints) {
+            emitter.report(item, MutableStateAutoboxingInt)
+        }
+
+        // mutableLongStateOf
+        val longs = allMutableStateOfWithConstantSingleArgument
+            .filter { (_, constantExpression) -> constantExpression.isLong }
+            .mapFirst()
+
+        for (item in longs) {
+            emitter.report(item, MutableStateAutoboxingLong)
+        }
+
+        // mutableDoubleStateOf
+        val doubles = allMutableStateOfWithConstantSingleArgument
+            .filter { (_, constantExpression) -> constantExpression.isDouble }
+            .mapFirst()
+
+        for (item in doubles) {
+            emitter.report(item, MutableStateAutoboxingDouble)
+        }
+
+        // mutableFloatStateOf
+        val floats = allMutableStateOfWithConstantSingleArgument
+            .filter { (_, constantExpression) -> constantExpression.isFloat }
+            .mapFirst()
+
+        for (item in floats) {
+            emitter.report(item, MutableStateAutoboxingFloat)
+        }
+    }
+
+    override fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
+        // Find the relevant names associated with the types we want (Int, Long, Double, Float)
+        val namesAndTypes = function.valueParameters
+            .filter { it.typeReference?.text in SupportedTypes }
+            .associateBy(
+                keySelector = { it.nameAsSafeName.asString() },
+                valueTransform = { it.typeReference!!.text },
+            )
+
+        // Find the mutableStateOf(x) where x is any of those parameter names we found before
+        val candidates = function.findMutableStateOf()
+            .filter { it.singleArgumentExpression is KtReferenceExpression }
+            .filter { it.singleArgumentExpression?.text in namesAndTypes.keys }
+
+        // mutableIntStateOf
+        val ints = candidates
+            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Int" }
+
+        for (item in ints) {
+            emitter.report(item, MutableStateAutoboxingInt)
+        }
+
+        // mutableLongStateOf
+        val longs = candidates
+            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Long" }
+
+        for (item in longs) {
+            emitter.report(item, MutableStateAutoboxingLong)
+        }
+
+        // mutableDoubleStateOf
+        val doubles = candidates
+            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Double" }
+
+        for (item in doubles) {
+            emitter.report(item, MutableStateAutoboxingDouble)
+        }
+
+        // mutableFloatStateOf
+        val floats = candidates
+            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Float" }
+
+        for (item in floats) {
+            emitter.report(item, MutableStateAutoboxingFloat)
+        }
+    }
+
+    private val KtCallExpression.singleArgumentExpression: KtExpression?
+        get() = valueArguments.singleOrNull()?.getArgumentExpression()
+
+    private fun PsiElement.findMutableStateOf() = findChildrenByClass<KtCallExpression>()
+        .filter { it.calleeExpression?.text == "mutableStateOf" }
+        .filter { it.valueArguments.size == 1 }
+
+    companion object {
+        private val SupportedTypes = setOf("Int", "Long", "Float", "Double")
+        val MutableStateAutoboxingInt = """
+            Using mutableIntStateOf is recommended over mutableStateOf<Int>, as it uses the Int primitive directly which is more performant.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingLong = """
+            Using mutableLongStateOf is recommended over mutableStateOf<Long>, as it uses the Long primitive directly which is more performant.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingDouble = """
+            Using mutableDoubleStateOf is recommended over mutableStateOf<Double>, as it uses the Double primitive directly which is more performant.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingFloat = """
+            Using mutableFloatStateOf is recommended over mutableStateOf<Float>, as it uses the Float primitive directly which is more performant.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -29,6 +29,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             ModifierWithoutDefaultCheck(config),
             MultipleContentEmittersCheck(config),
             MutableParametersCheck(config),
+            MutableStateAutoboxingCheck(config),
             MutableStateParameterCheck(config),
             NamingCheck(config),
             ParameterOrderCheck(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheck.kt
@@ -1,0 +1,23 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.MutableStateAutoboxing
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class MutableStateAutoboxingCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by MutableStateAutoboxing() {
+    override val issue: Issue = Issue(
+        id = "MutableStateAutoboxing",
+        severity = Severity.Performance,
+        description = "Using mutableInt/Long/Double/FloatStateOf is recommended over mutableStateOf<X> for " +
+            "Int/Long/Double/Float, as it uses the primitives directly which is more performant.",
+        debt = Debt.FIVE_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -37,6 +37,8 @@ Compose:
     active: true
   MutableParams:
     active: true
+  MutableStateAutoboxing:
+    active: true
   MutableStateParam:
     active: true
   PreviewAnnotationNaming:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheckTest.kt
@@ -1,0 +1,81 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.MutableStateAutoboxing
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class MutableStateAutoboxingCheckTest {
+
+    private val rule = MutableStateAutoboxingCheck(Config.empty)
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric constant is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                var a by mutableStateOf(0)
+                var b by mutableStateOf(0L)
+                var c by mutableStateOf(0.0)
+                var d by mutableStateOf(0f)
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(1, 10),
+                SourceLocation(2, 10),
+                SourceLocation(3, 10),
+                SourceLocation(4, 10),
+            )
+        assertThat(errors[0]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingInt)
+        assertThat(errors[1]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLong)
+        assertThat(errors[2]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingDouble)
+        assertThat(errors[3]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloat)
+    }
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric parameter is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: Int, b: Long, c: Double, d: Float) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                    var d by mutableStateOf(d)
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 14),
+                SourceLocation(3, 14),
+                SourceLocation(4, 14),
+                SourceLocation(5, 14),
+            )
+        assertThat(errors[0]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingInt)
+        assertThat(errors[1]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLong)
+        assertThat(errors[2]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingDouble)
+        assertThat(errors[3]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloat)
+    }
+
+    @Test
+    fun `no errors when a mutableStateOf is used for other things`() {
+        @Language("kotlin")
+        val code =
+            """
+                var a by mutableStateOf("")
+                var b by mutableStateOf(true)
+                fun bleh(c: String) {
+                    var ccc by mutableStateOf(c)
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -28,6 +28,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { ModifierWithoutDefaultCheck() },
         RuleProvider { MultipleContentEmittersCheck() },
         RuleProvider { MutableParametersCheck() },
+        RuleProvider { MutableStateAutoboxingCheck() },
         RuleProvider { MutableStateParameterCheck() },
         RuleProvider { NamingCheck() },
         RuleProvider { ParameterOrderCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.MutableStateAutoboxing
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class MutableStateAutoboxingCheck :
+    KtlintRule("compose:mutable-state-autoboxing"),
+    ComposeKtVisitor by MutableStateAutoboxing()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheckTest.kt
@@ -1,0 +1,99 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.MutableStateAutoboxing
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class MutableStateAutoboxingCheckTest {
+
+    private val ruleAssertThat = assertThatRule { MutableStateAutoboxingCheck() }
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric constant is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                var a by mutableStateOf(0)
+                var b by mutableStateOf(0L)
+                var c by mutableStateOf(0.0)
+                var d by mutableStateOf(0f)
+            """.trimIndent()
+
+        ruleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 1,
+                col = 10,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingInt,
+            ),
+            LintViolation(
+                line = 2,
+                col = 10,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingLong,
+            ),
+            LintViolation(
+                line = 3,
+                col = 10,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingDouble,
+            ),
+            LintViolation(
+                line = 4,
+                col = 10,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingFloat,
+            ),
+        )
+    }
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric parameter is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: Int, b: Long, c: Double, d: Float) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                    var d by mutableStateOf(d)
+                }
+            """.trimIndent()
+        ruleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 14,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingInt,
+            ),
+            LintViolation(
+                line = 3,
+                col = 14,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingLong,
+            ),
+            LintViolation(
+                line = 4,
+                col = 14,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingDouble,
+            ),
+            LintViolation(
+                line = 5,
+                col = 14,
+                detail = MutableStateAutoboxing.MutableStateAutoboxingFloat,
+            ),
+        )
+    }
+
+    @Test
+    fun `no errors when a mutableStateOf is used for other things`() {
+        @Language("kotlin")
+        val code =
+            """
+                var a by mutableStateOf("")
+                var b by mutableStateOf(true)
+                fun bleh(c: String) {
+                    var ccc by mutableStateOf(c)
+                }
+            """.trimIndent()
+        ruleAssertThat(code).hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
`mutableIntStateOf`, `mutableLongStateOf`, `mutableDoubleStateOf`, `mutableFloatStateOf` are essentially counterparts to `mutableStateOf`, but with the added advantage of circumventing autoboxing on JVM platforms. This distinction renders them more memory efficient, making them the preferable choice when dealing with primitive types such as double, float, int, and long.

There is an official lint rule already for this, but lint won't help with KMP projects like the one I work on at my day job, so detecting this is useful anyway. 