### PR TITLE
Add an allowlist for VM names for whose ViewModelForwarding is allowed

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
@@ -26,6 +26,16 @@ fun String?.matchesAnyOf(patterns: Sequence<Regex>): Boolean {
     return false
 }
 
+fun Set<String>.joinToRegexOrNull(): Regex? = if (isEmpty()) null else joinToRegex()
+
+fun Set<String>.joinToRegex(): Regex = Regex(
+    joinToString(
+        separator = "|",
+        prefix = "(",
+        postfix = ")",
+    ),
+)
+
 fun String.toCamelCase() = split('_').joinToString(
     separator = "",
     transform = { original ->

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -113,6 +113,8 @@ Compose:
     # allowedStateHolderNames: .*ViewModel,.*Presenter
     # -- You can optionally add an allowlist for Composable names that won't be affected by this rule
     # allowedForwarding: .*Content,.*FancyStuff
+    # -- You can optionally add an allowlist for ViewModel/StateHolder names that won't be affected by this rule
+    # allowedForwardingOfTypes: PotatoViewModel,(Apple|Banana)ViewModel,.*FancyViewModel
   ViewModelInjection:
     active: true
     # -- You can optionally add your own ViewModel factories here

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -93,14 +93,22 @@ The `vm-forwarding-check` rule will, by default, design as a state holder any cl
 compose_allowed_state_holder_names = .*ViewModel,.*Presenter,.*Component,.*SomethingElse
 ```
 
-
 ### Allowlist for composable names that aren't affected by the ViewModelForwarding rule
 
-The `vm-forwarding-check` will catch VMs/state holder classes that are relayed to other composables. However, in some situations this can be a valid use-case. The rule can be configured so that all the names that matches a list of regexes are exempt to this rule. You can configure this in your `.editorconfig` file:
+The `vm-forwarding-check` will catch VMs/state holder classes that are relayed to other composables. However, in some situations this can be a valid use-case. The rule can be configured so that all the names of composables that match a list of regexes are exempt to this rule. You can configure this in your `.editorconfig` file:
 
 ```editorconfig
 [*.{kt,kts}]
 compose_allowed_forwarding = .*Content,.*SomethingElse
+```
+
+### Allowlist for ViewModel/state holder names that aren't affected by the ViewModelForwarding rule
+
+The `vm-forwarding-check` will catch VMs/state holder classes that are relayed to other composables. However, in some situations this can be a valid use-case. The rule can be configured so that all the names of ViewModels that match a list of regexes are exempt to this rule. You can configure this in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_allowed_forwarding_of_types = .*MyViewModel,PotatoViewModel
 ```
 
 ### Configure the visibility of the composables where to check for missing modifiers

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ViewModelForwardingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ViewModelForwardingCheckTest.kt
@@ -15,6 +15,7 @@ class ViewModelForwardingCheckTest {
     private val testConfig = TestConfig(
         "allowedStateHolderNames" to listOf(".*Component", ".*StateHolder"),
         "allowedForwarding" to listOf(".*Content"),
+        "allowedForwardingOfTypes" to listOf("PotatoViewModel"),
     )
     private val rule = ViewModelForwardingCheck(testConfig)
 
@@ -328,7 +329,7 @@ class ViewModelForwardingCheckTest {
     }
 
     @Test
-    fun `allows forwarding when a ViewModel is in the allowlist`() {
+    fun `allows forwarding when a composable is in the allowlist`() {
         @Language("kotlin")
         val code =
             """
@@ -345,6 +346,34 @@ class ViewModelForwardingCheckTest {
             @Composable
             fun MyComposable3(viewModel: MyViewModel) {
                 AnotherComposableContent(vm = viewModel)
+            }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `allows forwarding when a ViewModel is in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Composable
+            fun MyComposable(viewModel: PotatoViewModel) {
+                AnotherComposable(viewModel)
+            }
+            @Composable
+            fun MyComposable2(viewModel: PotatoViewModel) {
+                Row {
+                    AnotherComposable(viewModel)
+                }
+            }
+            @Composable
+            fun MyComposable3(viewModel: PotatoViewModel) {
+                AnotherComposable(vm = viewModel)
+            }
+            @Composable
+            fun MyComposable4(viewModel: PotatoViewModel) {
+                with(viewModel) { AnotherComposable(vm = this) }
             }
             """.trimIndent()
         val errors = rule.lint(code)

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -152,6 +152,25 @@ val allowedForwarding: EditorConfigProperty<String> =
         },
     )
 
+val allowedForwardingOfTypes: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_allowed_forwarding_of_types",
+            "A comma separated list of regexes of state holder/ViewModel names which are exempt from " +
+                "the forwarding rule",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
 val customModifiers: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ViewModelForwardingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ViewModelForwardingCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.rules.core.ktlint.KtlintRule
 class ViewModelForwardingCheck :
     KtlintRule(
         id = "compose:vm-forwarding-check",
-        editorConfigProperties = setOf(allowedStateHolderNames, allowedForwarding),
+        editorConfigProperties = setOf(allowedStateHolderNames, allowedForwarding, allowedForwardingOfTypes),
     ),
     ComposeKtVisitor by ViewModelForwarding()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ViewModelForwardingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ViewModelForwardingCheckTest.kt
@@ -365,7 +365,7 @@ class ViewModelForwardingCheckTest {
     }
 
     @Test
-    fun `allows forwarding when a ViewModel is in the allowlist`() {
+    fun `allows forwarding when a composable is in the allowlist`() {
         @Language("kotlin")
         val code =
             """
@@ -387,6 +387,37 @@ class ViewModelForwardingCheckTest {
         forwardingRuleAssertThat(code)
             .withEditorConfigOverride(
                 allowedForwarding to ".*Content",
+            )
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `allows forwarding when a ViewModel is in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Composable
+            fun MyComposable(viewModel: PotatoViewModel) {
+                AnotherComposable(viewModel)
+            }
+            @Composable
+            fun MyComposable2(viewModel: PotatoViewModel) {
+                Row {
+                    AnotherComposable(viewModel)
+                }
+            }
+            @Composable
+            fun MyComposable3(viewModel: PotatoViewModel) {
+                AnotherComposable(vm = viewModel)
+            }
+            @Composable
+            fun MyComposable4(viewModel: PotatoViewModel) {
+                with(viewModel) { AnotherComposable(vm = this) }
+            }
+            """.trimIndent()
+        forwardingRuleAssertThat(code)
+            .withEditorConfigOverride(
+                allowedForwardingOfTypes to "PotatoViewModel",
             )
             .hasNoLintViolations()
     }


### PR DESCRIPTION
Adds a new param to be able to exempt the given patterns from the ViewModelForwarding rule.

Fixes #235 