### PR TITLE
Detect shadowing of modifier names in ModifierReused

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
@@ -5,9 +5,10 @@ package io.nlopez.rules.core.util
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiNameIdentifierOwner
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
+import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import java.util.Deque
-import java.util.LinkedList
+import java.util.*
 
 inline fun <reified T : PsiElement> PsiElement.findChildrenByClass(): Sequence<T> = sequence {
     val queue: Deque<PsiElement> = LinkedList()
@@ -41,6 +42,10 @@ inline fun <reified T : PsiElement> PsiElement.findDirectChildrenByClass(): Sequ
         current = current.nextSibling
     }
 }
+
+fun PsiElement.walkBackwards(stopAtParent: PsiElement? = null): Sequence<PsiElement> = parentsWithSelf
+    .flatMap { it.siblings(forward = false, withItself = true) }
+    .takeWhile { it != stopAtParent }
 
 val PsiNameIdentifierOwner.startOffsetFromName: Int
     get() = nameIdentifier?.startOffset ?: startOffset

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -29,7 +29,7 @@ class ModifierClickableOrder : ComposeKtVisitor {
         val code = function.bodyBlockExpression ?: return
 
         val initialModifierNames = with(config) { function.modifierParameters.mapNotNull { it.name } }
-        val modifiers = initialModifierNames.flatMap { code.obtainAllModifierNames(it) }
+        val modifiers = initialModifierNames.flatMap { code.obtainAllModifierNames(it) }.toSet()
 
         val suspiciousOrderModifiers = code.findChildrenByClass<KtCallExpression>()
             .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -29,7 +29,7 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
         if (modifier.name != "modifier") return
         val code = function.bodyBlockExpression ?: return
 
-        val modifiers = code.obtainAllModifierNames("modifier")
+        val modifiers = code.obtainAllModifierNames("modifier").toSet()
 
         val errors = code.findChildrenByClass<KtCallExpression>()
             .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -9,10 +9,13 @@ import io.nlopez.rules.core.util.emitsContent
 import io.nlopez.rules.core.util.findChildrenByClass
 import io.nlopez.rules.core.util.isUsingModifiers
 import io.nlopez.rules.core.util.modifierParameters
+import io.nlopez.rules.core.util.modifiersBeingUsedFrom
 import io.nlopez.rules.core.util.obtainAllModifierNames
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 class ModifierReused : ComposeKtVisitor {
@@ -26,19 +29,21 @@ class ModifierReused : ComposeKtVisitor {
         with(config) { if (!function.emitsContent) return }
 
         val composableBlockExpression = function.bodyBlockExpression ?: return
-        val initialModifierNames = with(config) { function.modifierParameters.mapNotNull { it.name } }
+        val initialModifierNames = with(config) { function.modifierParameters.mapNotNull { it.name }.toSet() }
         if (initialModifierNames.isEmpty()) return
 
         initialModifierNames
             .map {
                 // Try to get all possible names for each modifier by iterating on possible name reassignments until it's stable
-                composableBlockExpression.obtainAllModifierNames(it)
+                composableBlockExpression.obtainAllModifierNames(it).toSet()
             }
             .forEach { modifierNames ->
                 // Find all composable-looking CALL_EXPRESSIONs that are using any of these modifier names
                 composableBlockExpression.findChildrenByClass<KtCallExpression>()
                     .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
                     .filter { it.isUsingModifiers(modifierNames) }
+                    // TODO modifierNames is not enough, we need to know if there were reassignments and where they were made
+                    .filterNot { it.isModifierShadowed(initialModifierNames, function) }
                     .map { callExpression ->
                         // To get an accurate count (and respecting if/when/whatever different branches)
                         // we'll need to traverse upwards to [function] from each one of these usages
@@ -72,6 +77,30 @@ class ModifierReused : ComposeKtVisitor {
                         emitter.report(callExpression, ModifierShouldBeUsedOnceOnly, false)
                     }
             }
+    }
+
+    private fun KtCallExpression.isModifierShadowed(modifierNames: Set<String>, function: KtFunction): Boolean {
+        // First we want to know which modifiers we have to watch for in this specific KtCallExpression
+        val currentModifiers = modifiersBeingUsedFrom(modifierNames)
+
+        // For those modifiers, we look at the parents and see if any of them is a function that has a param with
+        //  the same name.
+        return parents.takeWhile { it != function }
+            .filterIsInstance<KtCallableDeclaration>()
+            .flatMap { it.valueParameters }
+            .flatMap { parameter ->
+                when {
+                    // Normal parameters
+                    parameter.name != null -> listOfNotNull(parameter.name)
+                    // Destructured parameters
+                    parameter.destructuringDeclaration != null ->
+                        parameter.destructuringDeclaration!!
+                            .entries
+                            .mapNotNull { it.name }
+                    else -> emptyList()
+                }
+            }
+            .any { it in currentModifiers }
     }
 
     companion object {

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -128,7 +128,7 @@ class ModifierReusedCheckTest {
                 }
             """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(10)
+        assertThat(errors)
             .hasStartSourceLocations(
                 SourceLocation(3, 5),
                 SourceLocation(4, 9),
@@ -176,7 +176,7 @@ class ModifierReusedCheckTest {
                 }
             """.trimIndent()
         val errors = rule.lint(code)
-        assertThat(errors).hasSize(7)
+        assertThat(errors)
             .hasStartSourceLocations(
                 SourceLocation(6, 5),
                 SourceLocation(8, 9),
@@ -288,6 +288,39 @@ class ModifierReusedCheckTest {
                     }
                 }
             """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when the modifier parameter of a Composable is shadowed`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        val x = @Composable { modifier: Modifier ->
+                            SomethingElse(modifier)
+                        }
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        val x = @Composable { (modifier, _) ->
+                            SomethingElse(modifier)
+                        }
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier) {
+                        Bleh { modifier -> Potato(modifier) }
+                    }
+                }
+            """.trimIndent()
+
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -391,4 +391,36 @@ class ModifierReusedCheckTest {
             """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when the modifier parameter of a Composable is shadowed`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        val x = @Composable { modifier: Modifier ->
+                            SomethingElse(modifier)
+                        }
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        val x = @Composable { (modifier, _) ->
+                            SomethingElse(modifier)
+                        }
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier) {
+                        Bleh { modifier -> Potato(modifier) }
+                    }
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Detects whether modifier parameters are being shadowed by another function's parameters.

Fixes #236 