### PR TITLE
Use lazy without LazyThreadSafetyMode.NONE

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Composables.kt
@@ -251,7 +251,7 @@ val KtProperty.declaresCompositionLocal: Boolean
         initializer is KtCallExpression &&
         (initializer as KtCallExpression).referenceExpression()?.text in CompositionLocalReferenceExpressions
 
-private val CompositionLocalReferenceExpressions by lazy(LazyThreadSafetyMode.NONE) {
+private val CompositionLocalReferenceExpressions by lazy {
     setOf(
         "staticCompositionLocalOf",
         "compositionLocalOf",
@@ -262,7 +262,7 @@ val KtCallExpression.isRestartableEffect: Boolean
     get() = calleeExpression?.text in RestartableEffects
 
 // From https://developer.android.com/jetpack/compose/side-effects#restarting-effects
-private val RestartableEffects by lazy(LazyThreadSafetyMode.NONE) {
+private val RestartableEffects by lazy {
     setOf(
         "LaunchedEffect",
         "produceState",

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/KotlinUtils.kt
@@ -45,4 +45,4 @@ fun String.toCamelCase() = split('_').joinToString(
 
 fun String.toSnakeCase() = replace(humps, "_").lowercase(Locale.getDefault())
 
-private val humps by lazy(LazyThreadSafetyMode.NONE) { "(?<=.)(?=\\p{Upper})".toRegex() }
+private val humps by lazy { "(?<=.)(?=\\p{Upper})".toRegex() }

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Modifiers.kt
@@ -85,7 +85,7 @@ fun KtCallExpression.modifiersBeingUsedFrom(modifierNames: Set<String>): Set<Str
         .filter { it in modifierNames }
         .toSet()
 
-val ModifierNames by lazy(LazyThreadSafetyMode.NONE) {
+private val ModifierNames by lazy {
     setOf(
         "Modifier",
         "GlanceModifier",

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt
@@ -31,7 +31,7 @@ class UnstableCollections : ComposeKtVisitor {
     }
 
     companion object {
-        private val DiamondRegex by lazy(LazyThreadSafetyMode.NONE) { Regex("<.*>\\??") }
+        private val DiamondRegex by lazy { Regex("<.*>\\??") }
         private val String.capitalized: String
             get() = replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
 


### PR DESCRIPTION
Yep, in hindsight, we can expect some concurrency in these executions. Let's leave `lazy` as default.

Fixes #241 