### PR TITLE
Make ModifierNotUsedAtRoot honor contentEmittersDenylist

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import java.util.*
 
+private val neverIgnore = { false }
+
 inline fun <reified T : PsiElement> PsiElement.findChildrenByClass(): Sequence<T> = sequence {
     val queue: Deque<PsiElement> = LinkedList()
     queue.add(this@findChildrenByClass)

--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/PsiElements.kt
@@ -10,8 +10,6 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import java.util.*
 
-private val neverIgnore = { false }
-
 inline fun <reified T : PsiElement> PsiElement.findChildrenByClass(): Sequence<T> = sequence {
     val queue: Deque<PsiElement> = LinkedList()
     queue.add(this@findChildrenByClass)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
@@ -14,6 +14,7 @@ class ModifierNotUsedAtRootCheckTest {
 
     private val testConfig = TestConfig(
         "contentEmitters" to listOf("Potato", "Banana"),
+        "contentEmittersDenylist" to listOf("Apple"),
     )
     private val rule = ModifierNotUsedAtRootCheck(testConfig)
 
@@ -67,6 +68,28 @@ class ModifierNotUsedAtRootCheckTest {
         for (error in errors) {
             assertThat(error).hasMessage(ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
         }
+    }
+
+    @Test
+    fun `passes out when modifier is used in too deep in the hierarchy but has a non-emitter parent`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Dialog {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Apple {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
     }
 
     @Test

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.rules.core.ktlint.KtlintRule
 class ModifierNotUsedAtRootCheck :
     KtlintRule(
         id = "compose:modifier-not-used-at-root",
-        editorConfigProperties = setOf(contentEmittersProperty, customModifiers),
+        editorConfigProperties = setOf(contentEmittersProperty, customModifiers, contentEmittersDenylist),
     ),
     ComposeKtVisitor by ModifierNotUsedAtRoot()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
@@ -84,6 +84,29 @@ class ModifierNotUsedAtRootCheckTest {
     }
 
     @Test
+    fun `passes out when modifier is used in too deep in the hierarchy but has a non-emitter parent`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Dialog {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Potato {
+                        Text("Hi", modifier = modifier)
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(contentEmittersDenylist to "Potato")
+            .hasNoLintViolations()
+    }
+
+    @Test
     fun `passes when modifier is used in the top-most place that emits content`() {
         @Language("kotlin")
         val code =


### PR DESCRIPTION
Make ModifierNotUsedAtRoot to honor contentEmittersDenylist, so if any non-content emitter (whether default one or provided by config) is in the parent hierarchy of the composable, the rule gets ignored.

Fixes #240 