### PR TITLE
Add more autoboxing detections

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateAutoboxing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateAutoboxing.kt
@@ -25,15 +25,18 @@ class MutableStateAutoboxing : ComposeKtVisitor {
     override fun visitFile(file: KtFile, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
         // Things we can realistically support without type resolution without going bananas
         // - numeric constants
+        // - explicit types
         // - stuff that comes from function params
-        val allMutableStateOfWithConstantSingleArgument = file.findMutableStateOf()
+        val msofs = file.findMutableStateOf()
+
+        // Let's try inferring by the constant expressions (e.g. mutableStateOf(0) or mutableStateOf(3f)
+        val allMutableStateOfWithConstantSingleArgument = msofs
             .filter { it.singleArgumentExpression is KtConstantExpression }
             .map { it to it.singleArgumentExpression as KtConstantExpression }
 
         // mutableIntStateOf
         val ints = allMutableStateOfWithConstantSingleArgument
-            .filter { (_, constantExpression) -> constantExpression.isInt }
-            .mapFirst()
+            .mapCallExpressionIfConstantExpression { it.isInt }
 
         for (item in ints) {
             emitter.report(item, MutableStateAutoboxingInt)
@@ -41,8 +44,7 @@ class MutableStateAutoboxing : ComposeKtVisitor {
 
         // mutableLongStateOf
         val longs = allMutableStateOfWithConstantSingleArgument
-            .filter { (_, constantExpression) -> constantExpression.isLong }
-            .mapFirst()
+            .mapCallExpressionIfConstantExpression { it.isLong }
 
         for (item in longs) {
             emitter.report(item, MutableStateAutoboxingLong)
@@ -50,8 +52,7 @@ class MutableStateAutoboxing : ComposeKtVisitor {
 
         // mutableDoubleStateOf
         val doubles = allMutableStateOfWithConstantSingleArgument
-            .filter { (_, constantExpression) -> constantExpression.isDouble }
-            .mapFirst()
+            .mapCallExpressionIfConstantExpression { it.isDouble }
 
         for (item in doubles) {
             emitter.report(item, MutableStateAutoboxingDouble)
@@ -59,59 +60,131 @@ class MutableStateAutoboxing : ComposeKtVisitor {
 
         // mutableFloatStateOf
         val floats = allMutableStateOfWithConstantSingleArgument
-            .filter { (_, constantExpression) -> constantExpression.isFloat }
-            .mapFirst()
+            .mapCallExpressionIfConstantExpression { it.isFloat }
 
         for (item in floats) {
             emitter.report(item, MutableStateAutoboxingFloat)
         }
     }
 
+    private inline fun Sequence<Pair<KtCallExpression, KtConstantExpression>>.mapCallExpressionIfConstantExpression(
+        crossinline predicate: (KtConstantExpression) -> Boolean,
+    ): Sequence<KtCallExpression> = filter { (_, constantExpression) -> predicate(constantExpression) }.mapFirst()
+
     override fun visitFunction(function: KtFunction, autoCorrect: Boolean, emitter: Emitter, config: ComposeKtConfig) {
-        // Find the relevant names associated with the types we want (Int, Long, Double, Float)
-        val namesAndTypes = function.valueParameters
+        // Find the relevant parameter names associated with the types we want (Int, Long, Double, Float)
+        val parameterNamesAndTypes = function.valueParameters
             .filter { it.typeReference?.text in SupportedTypes }
             .associateBy(
                 keySelector = { it.nameAsSafeName.asString() },
                 valueTransform = { it.typeReference!!.text },
             )
 
-        // Find the mutableStateOf(x) where x is any of those parameter names we found before
-        val candidates = function.findMutableStateOf()
+        val mutableStateOfReferences = function.findMutableStateOf()
             .filter { it.singleArgumentExpression is KtReferenceExpression }
-            .filter { it.singleArgumentExpression?.text in namesAndTypes.keys }
+
+        // Find the mutableStateOf(x) where x is any of those parameter names we found before
+        val primitiveCandidates = mutableStateOfReferences
+            .filter { it.singleArgumentExpression?.text in parameterNamesAndTypes.keys }
+
+        fun emitIfParameterTypeIs(message: String, predicate: (String) -> Boolean) {
+            val matches = primitiveCandidates.filter {
+                parameterNamesAndTypes[it.singleArgumentExpression?.text]?.let { type -> predicate(type) } ?: false
+            }
+            for (match in matches) {
+                emitter.report(match, message)
+            }
+        }
 
         // mutableIntStateOf
-        val ints = candidates
-            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Int" }
-
-        for (item in ints) {
-            emitter.report(item, MutableStateAutoboxingInt)
-        }
+        emitIfParameterTypeIs(MutableStateAutoboxingInt) { it == "Int" }
 
         // mutableLongStateOf
-        val longs = candidates
-            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Long" }
-
-        for (item in longs) {
-            emitter.report(item, MutableStateAutoboxingLong)
-        }
+        emitIfParameterTypeIs(MutableStateAutoboxingLong) { it == "Long" }
 
         // mutableDoubleStateOf
-        val doubles = candidates
-            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Double" }
-
-        for (item in doubles) {
-            emitter.report(item, MutableStateAutoboxingDouble)
-        }
+        emitIfParameterTypeIs(MutableStateAutoboxingDouble) { it == "Double" }
 
         // mutableFloatStateOf
-        val floats = candidates
-            .filter { namesAndTypes[it.singleArgumentExpression?.text] == "Float" }
+        emitIfParameterTypeIs(MutableStateAutoboxingFloat) { it == "Float" }
 
-        for (item in floats) {
-            emitter.report(item, MutableStateAutoboxingFloat)
+        // mutableIntListOf
+        emitIfParameterTypeIs(MutableStateAutoboxingIntList) {
+            it == "List<Int>" || it == "PersistentList<Int>" || it == "ImmutableList<Int>"
         }
+
+        // mutableLongListOf
+        emitIfParameterTypeIs(MutableStateAutoboxingLongList) {
+            it == "List<Long>" || it == "PersistentList<Long>" || it == "ImmutableList<Long>"
+        }
+
+        // mutableFloatListOf
+        emitIfParameterTypeIs(MutableStateAutoboxingFloatList) {
+            it == "List<Float>" || it == "PersistentList<Float>" || it == "ImmutableList<Float>"
+        }
+
+        // mutableIntSetOf
+        emitIfParameterTypeIs(MutableStateAutoboxingIntSet) {
+            it == "Set<Int>" || it == "PersistentSet<Int>" || it == "ImmutableSet<Int>"
+        }
+
+        // mutableLongSetOf
+        emitIfParameterTypeIs(MutableStateAutoboxingLongSet) {
+            it == "Set<Long>" || it == "PersistentSet<Long>" || it == "ImmutableSet<Long>"
+        }
+
+        // mutableFloatSetOf
+        emitIfParameterTypeIs(MutableStateAutoboxingFloatSet) {
+            it == "Set<Float>" || it == "PersistentSet<Float>" || it == "ImmutableSet<Float>"
+        }
+
+        // mutableIntIntMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingIntIntMap) {
+            it == "Map<Int, Int>" || it == "PersistentMap<Int, Int>" || it == "ImmutableMap<Int, Int>"
+        }
+
+        // mutableIntLongMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingIntLongMap) {
+            it == "Map<Int, Long>" || it == "PersistentMap<Int, Long>" || it == "ImmutableMap<Int, Long>"
+        }
+
+        // mutableIntFloatMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingIntFloatMap) {
+            it == "Map<Int, Float>" || it == "PersistentMap<Int, Float>" || it == "ImmutableMap<Int, Float>"
+        }
+
+        // mutableLongIntMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingLongIntMap) {
+            it == "Map<Long, Int>" || it == "PersistentMap<Long, Int>" || it == "ImmutableMap<Long, Int>"
+        }
+
+        // mutableLongLongMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingLongLongMap) {
+            it == "Map<Long, Long>" || it == "PersistentMap<Long, Long>" || it == "ImmutableMap<Long, Long>"
+        }
+
+        // mutableLongFloatMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingLongFloatMap) {
+            it == "Map<Long, Float>" || it == "PersistentMap<Long, Float>" || it == "ImmutableMap<Long, Float>"
+        }
+
+        // mutableFloatIntMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingFloatIntMap) {
+            it == "Map<Float, Int>" || it == "PersistentMap<Float, Int>" || it == "ImmutableMap<Float, Int>"
+        }
+
+        // mutableFloatLongMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingFloatLongMap) {
+            it == "Map<Float, Long>" || it == "PersistentMap<Float, Long>" || it == "ImmutableMap<Float, Long>"
+        }
+
+        // mutableFloatFloatMapOf
+        emitIfParameterTypeIs(MutableStateAutoboxingFloatFloatMap) {
+            it == "Map<Float, Float>" || it == "PersistentMap<Float, Float>" || it == "ImmutableMap<Float, Float>"
+        }
+
+        // TODO Add support to mutableObjectListOf, mutableObjectSetOf, mutableObjectMapOf, mutableObjectFloatMapOf,
+        //  mutableObjectLongMapOf, mutableObjectIntMapOf
     }
 
     private val KtCallExpression.singleArgumentExpression: KtExpression?
@@ -122,7 +195,62 @@ class MutableStateAutoboxing : ComposeKtVisitor {
         .filter { it.valueArguments.size == 1 }
 
     companion object {
-        private val SupportedTypes = setOf("Int", "Long", "Float", "Double")
+        private val SupportedTypes = setOf(
+            "Int",
+            "Long",
+            "Float",
+            "Double",
+            // Lists
+            "List<Int>",
+            "PersistentList<Int>",
+            "ImmutableList<Int>",
+            "List<Long>",
+            "PersistentList<Long>",
+            "ImmutableList<Long>",
+            "List<Float>",
+            "PersistentList<Float>",
+            "ImmutableList<Float>",
+            // Sets
+            "Set<Int>",
+            "PersistentSet<Int>",
+            "ImmutableSet<Int>",
+            "Set<Long>",
+            "PersistentSet<Long>",
+            "ImmutableSet<Long>",
+            "Set<Float>",
+            "PersistentSet<Float>",
+            "ImmutableSet<Float>",
+            // Maps
+            "Map<Int, Int>",
+            "PersistentMap<Int, Int>",
+            "ImmutableMap<Int, Int>",
+            "Map<Int, Long>",
+            "PersistentMap<Int, Long>",
+            "ImmutableMap<Int, Long>",
+            "Map<Int, Float>",
+            "PersistentMap<Int, Float>",
+            "ImmutableMap<Int, Float>",
+            "Map<Long, Int>",
+            "PersistentMap<Long, Int>",
+            "ImmutableMap<Long, Int>",
+            "Map<Long, Long>",
+            "PersistentMap<Long, Long>",
+            "ImmutableMap<Long, Long>",
+            "Map<Long, Float>",
+            "PersistentMap<Long, Float>",
+            "ImmutableMap<Long, Float>",
+            "Map<Float, Int>",
+            "PersistentMap<Float, Int>",
+            "ImmutableMap<Float, Int>",
+            "Map<Float, Long>",
+            "PersistentMap<Float, Long>",
+            "ImmutableMap<Float, Long>",
+            "Map<Float, Float>",
+            "PersistentMap<Float, Float>",
+            "ImmutableMap<Float, Float>",
+        )
+
+        // Primitives
         val MutableStateAutoboxingInt = """
             Using mutableIntStateOf is recommended over mutableStateOf<Int>, as it uses the Int primitive directly which is more performant.
 
@@ -143,6 +271,101 @@ class MutableStateAutoboxing : ComposeKtVisitor {
 
         val MutableStateAutoboxingFloat = """
             Using mutableFloatStateOf is recommended over mutableStateOf<Float>, as it uses the Float primitive directly which is more performant.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        // Primitive Lists
+        val MutableStateAutoboxingIntList = """
+            Using mutableIntListOf is recommended over mutableStateOf Immutable/Persistent/List<Int> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingLongList = """
+            Using mutableLongListOf is recommended over mutableStateOf Immutable/Persistent/List<Long> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingFloatList = """
+            Using mutableFloatListOf is recommended over mutableStateOf Immutable/Persistent/List<Float> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        // Primitive Sets
+        val MutableStateAutoboxingIntSet = """
+            Using mutableIntSetOf is recommended over mutableStateOf Immutable/Persistent/Set<Int> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingLongSet = """
+            Using mutableLongSetOf is recommended over mutableStateOf Immutable/Persistent/Set<Long> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingFloatSet = """
+            Using mutableFloatSetOf is recommended over mutableStateOf Immutable/Persistent/Set<Float> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        // Maps (Int -> X)
+        val MutableStateAutoboxingIntIntMap = """
+            Using mutableIntIntMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Int, Int> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingIntLongMap = """
+            Using mutableIntLongMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Int, Long> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingIntFloatMap = """
+            Using mutableIntFloatMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Int, Float> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        // Maps (Long -> X)
+        val MutableStateAutoboxingLongIntMap = """
+            Using mutableLongIntMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Long, Int> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingLongLongMap = """
+            Using mutableLongLongMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Long, Long> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingLongFloatMap = """
+            Using mutableLongFloatMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Long, Float> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        // Maps (Float -> X)
+        val MutableStateAutoboxingFloatIntMap = """
+            Using mutableFloatIntMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Float, Int> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingFloatLongMap = """
+            Using mutableFloatLongMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Float, Long> due to its better performance.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
+        """.trimIndent()
+
+        val MutableStateAutoboxingFloatFloatMap = """
+            Using mutableFloatFloatMapOf is recommended over mutableStateOf Immutable/Persistent/Map<Float, Float> due to its better performance.
 
             See https://mrmans0n.github.io/compose-rules/rules/#use-mutablestateof-type-specific-variants-when-possible for more information.
         """.trimIndent()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheckTest.kt
@@ -65,6 +65,141 @@ class MutableStateAutoboxingCheckTest {
     }
 
     @Test
+    fun `errors when a mutableStateOf for a numeric list parameter is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: List<Int>, b: List<Long>, c: List<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: ImmutableList<Int>, b: ImmutableList<Long>, c: ImmutableList<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: PersistentList<Int>, b: PersistentList<Long>, c: PersistentList<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 14),
+                SourceLocation(3, 14),
+                SourceLocation(4, 14),
+                SourceLocation(7, 14),
+                SourceLocation(8, 14),
+                SourceLocation(9, 14),
+                SourceLocation(12, 14),
+                SourceLocation(13, 14),
+                SourceLocation(14, 14),
+            )
+        assertThat(errors[0]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntList)
+        assertThat(errors[1]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongList)
+        assertThat(errors[2]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatList)
+        assertThat(errors[3]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntList)
+        assertThat(errors[4]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongList)
+        assertThat(errors[5]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatList)
+        assertThat(errors[6]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntList)
+        assertThat(errors[7]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongList)
+        assertThat(errors[8]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatList)
+    }
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric set parameter is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: Set<Int>, b: Set<Long>, c: Set<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: ImmutableSet<Int>, b: ImmutableSet<Long>, c: ImmutableSet<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: PersistentSet<Int>, b: PersistentSet<Long>, c: PersistentSet<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 14),
+                SourceLocation(3, 14),
+                SourceLocation(4, 14),
+                SourceLocation(7, 14),
+                SourceLocation(8, 14),
+                SourceLocation(9, 14),
+                SourceLocation(12, 14),
+                SourceLocation(13, 14),
+                SourceLocation(14, 14),
+            )
+        assertThat(errors[0]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntSet)
+        assertThat(errors[1]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongSet)
+        assertThat(errors[2]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatSet)
+        assertThat(errors[3]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntSet)
+        assertThat(errors[4]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongSet)
+        assertThat(errors[5]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatSet)
+        assertThat(errors[6]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntSet)
+        assertThat(errors[7]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongSet)
+        assertThat(errors[8]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatSet)
+    }
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric map parameter pair is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: Map<Int, Int>, b: Map<Int, Long>, c: Map<Int, Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: Map<Long, Int>, b: Map<Long, Long>, c: Map<Long, Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: Map<Float, Int>, b: Map<Float, Long>, c: Map<Float, Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 14),
+                SourceLocation(3, 14),
+                SourceLocation(4, 14),
+                SourceLocation(7, 14),
+                SourceLocation(8, 14),
+                SourceLocation(9, 14),
+                SourceLocation(12, 14),
+                SourceLocation(13, 14),
+                SourceLocation(14, 14),
+            )
+        assertThat(errors[0]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntIntMap)
+        assertThat(errors[1]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntLongMap)
+        assertThat(errors[2]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingIntFloatMap)
+        assertThat(errors[3]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongIntMap)
+        assertThat(errors[4]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongLongMap)
+        assertThat(errors[5]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingLongFloatMap)
+        assertThat(errors[6]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatIntMap)
+        assertThat(errors[7]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatLongMap)
+        assertThat(errors[8]).hasMessage(MutableStateAutoboxing.MutableStateAutoboxingFloatFloatMap)
+    }
+
+    @Test
     fun `no errors when a mutableStateOf is used for other things`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheckTest.kt
@@ -84,6 +84,219 @@ class MutableStateAutoboxingCheckTest {
     }
 
     @Test
+    fun `errors when a mutableStateOf for a numeric list parameter is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: List<Int>, b: List<Long>, c: List<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: ImmutableList<Int>, b: ImmutableList<Long>, c: ImmutableList<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: PersistentList<Int>, b: PersistentList<Long>, c: PersistentList<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntList,
+                ),
+                LintViolation(
+                    line = 3,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongList,
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatList,
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntList,
+                ),
+                LintViolation(
+                    line = 8,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongList,
+                ),
+                LintViolation(
+                    line = 9,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatList,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntList,
+                ),
+                LintViolation(
+                    line = 13,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongList,
+                ),
+                LintViolation(
+                    line = 14,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatList,
+                ),
+            )
+    }
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric set parameter is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: Set<Int>, b: Set<Long>, c: Set<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: ImmutableSet<Int>, b: ImmutableSet<Long>, c: ImmutableSet<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: PersistentSet<Int>, b: PersistentSet<Long>, c: PersistentSet<Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntSet,
+                ),
+                LintViolation(
+                    line = 3,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongSet,
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatSet,
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntSet,
+                ),
+                LintViolation(
+                    line = 8,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongSet,
+                ),
+                LintViolation(
+                    line = 9,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatSet,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntSet,
+                ),
+                LintViolation(
+                    line = 13,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongSet,
+                ),
+                LintViolation(
+                    line = 14,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatSet,
+                ),
+            )
+    }
+
+    @Test
+    fun `errors when a mutableStateOf for a numeric map parameter pair is used`() {
+        @Language("kotlin")
+        val code =
+            """
+                fun myFunction(a: Map<Int, Int>, b: Map<Int, Long>, c: Map<Int, Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: Map<Long, Int>, b: Map<Long, Long>, c: Map<Long, Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+                fun myFunction(a: Map<Float, Int>, b: Map<Float, Long>, c: Map<Float, Float>) {
+                    var a by mutableStateOf(a)
+                    var b by mutableStateOf(b)
+                    var c by mutableStateOf(c)
+                }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntIntMap,
+                ),
+                LintViolation(
+                    line = 3,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntLongMap,
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingIntFloatMap,
+                ),
+                LintViolation(
+                    line = 7,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongIntMap,
+                ),
+                LintViolation(
+                    line = 8,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongLongMap,
+                ),
+                LintViolation(
+                    line = 9,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingLongFloatMap,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatIntMap,
+                ),
+                LintViolation(
+                    line = 13,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatLongMap,
+                ),
+                LintViolation(
+                    line = 14,
+                    col = 14,
+                    detail = MutableStateAutoboxing.MutableStateAutoboxingFloatFloatMap,
+                ),
+            )
+    }
+
+    @Test
     fun `no errors when a mutableStateOf is used for other things`() {
         @Language("kotlin")
         val code =


### PR DESCRIPTION
Adds a bunch of more detectors for Lists/Sets/Maps of numeric primitives. TBH it's not very worth pursuing more coverage here, as it's trivial with type resolution but super annoying when done manually, so I guess it'll be left as it is for now.