### PR TITLE
Add ContentTrailingLambda rule to ensure content slot is trailing

### DIFF
--- a/core-common/src/main/kotlin/io/nlopez/rules/core/util/Lambdas.kt
+++ b/core-common/src/main/kotlin/io/nlopez/rules/core/util/Lambdas.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtUserType
 fun KtTypeElement.isLambda(treatAsLambdaTypes: Set<String>): Boolean = when (this) {
     is KtFunctionType -> true
     is KtNullableType -> innerType?.isLambda(treatAsLambdaTypes) == true
-    is KtUserType -> getReferencedName() in treatAsLambdaTypes
+    is KtUserType -> referencedName in treatAsLambdaTypes
     else -> false
 }
 
@@ -41,6 +41,52 @@ val KtFile.lambdaTypes: Set<String>
         addAll(
             findChildrenByClass<KtTypeAlias>()
                 .filter { it.getTypeReference()?.isLambda(this) == true }
+                .mapNotNull { it.name },
+        )
+    }
+
+context(ComposeKtConfig)
+val KtFile.composableLambdaTypes: Set<String>
+    get() = buildSet {
+        // Add the provided types
+        addAll(getSet("treatAsComposableLambda", emptySet()))
+
+        // Add fun interfaces that have their sam method as composable
+        addAll(
+            findChildrenByClass<KtClass>()
+                .filter { it.isInterface() && it.hasModifier(KtTokens.FUN_KEYWORD) }
+                .filter { funInterface ->
+                    // Find if the method that has no implementation (aka the SAM) is @Composable
+                    funInterface.body
+                        ?.functions
+                        ?.filterNot { it.hasBody() }
+                        ?.map { it.isComposable }
+                        ?.firstOrNull() ?: false
+                }
+                .mapNotNull { it.name },
+        )
+
+        // Add typealias with functional types
+        // NOTE: it has to be last, so that isLambda picks up fun interfaces / config stuff in lambdaTypes
+        addAll(
+            findChildrenByClass<KtTypeAlias>()
+                .filter {
+                    val typeReference = it.getTypeReference() ?: return@filter false
+                    when (val typeElement = typeReference.typeElement) {
+                        null -> false
+                        // typealias A = @Composable () -> Unit
+                        is KtFunctionType -> typeReference.isComposable
+                        // typealias B = @Composable (() -> Unit?)
+                        // typealias B = A?
+                        is KtNullableType -> {
+                            (typeReference.isComposable && typeElement.innerType is KtFunctionType) ||
+                                typeElement.innerType?.name in this
+                        }
+                        // typealias C = A
+                        is KtUserType -> typeElement.referencedName in this
+                        else -> false
+                    }
+                }
                 .mapNotNull { it.name },
         )
     }

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -40,6 +40,10 @@ Compose:
     active: true
     # -- You can optionally add your own composables here
     # contentEmitters: MyComposable,MyOtherComposable
+  ContentTrailingLambda:
+    active: true
+    # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsComposableLambda: MyComposableLambdaType
   DefaultsVisibility:
     active: true
   LambdaParameterInRestartableEffect:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -134,13 +134,22 @@ Most of the modifier-related rules will look for modifiers based their type: eit
 compose_custom_modifiers = BananaModifier,PotatoModifier
 ```
 
-### Configure types to treat as lambdas in ParamOrder check
+### Configure types to treat as lambdas (e.g. for ParamOrder check)
 
 The `param-order-check` rule will do its best to identify trailing lambdas. However, in cases where a typedef / functional interface is being used, we might want to have this rule to treat them as if they were lambdas: not reporting them if they are the last in a method signature and they don't have a default value. To give ktlint some hints, you can configure this in your `.editorconfig` file:
 
 ```editorconfig
 [*.{kt,kts}]
 compose_treat_as_lambda = MyLambdaType,MyOtherLambdaType
+```
+
+### Configure types to treat as composable lambdas (e.g. for ContentTrailingLambda check)
+
+The `content-trailing-lambda` rule will do its best to identify `@Composable` trailing lambdas. However, in cases where a typedef / functional interface is being used, we might want to have this rule to treat them as if they were composable lambdas: not reporting them if they are the last in a method signature and they don't have a default value. To give ktlint some hints, you can configure this in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_treat_as_composable_lambda = MyLambdaComposableType,MyOtherComposableLambdaType
 ```
 
 ### Enabling the Material 2 detector

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -236,6 +236,31 @@ Related rule: [compose:multiple-emitters-check](https://github.com/mrmans0n/comp
 
 > **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
 
+### Slots for main content should be the trailing lambda
+
+The slots used to display the main content for a composable, which are typically in the form of `content: @Composable () -> Unit` (or their nullable counterpart) should always be placed as the last parameter of a composable function, so they can be written as the trailing lambda. This makes following the flow of the main pieces of UI / content more natural and easy to reason about.
+
+```kotlin
+// ❌
+@Composable
+fun Avatar(content: @Composable () -> Unit, subtitle: String, modifier: Modifier = Modifier) { ... }
+
+// ✅ The usage of the main content as a trailing lambda is more natural
+@Composable
+fun Avatar(subtitle: String, modifier: Modifier = Modifier, content: @Composable () -> Unit) { ... }
+
+@Composable
+fun Profile(user: User, modifier: Modifier = Modifier) {
+    Column(modifier) {
+        Avatar(subtitle = user.name) {
+            AsyncImage(url = user.avatarUrl)
+        }
+    }
+}
+```
+
+Related rule: [compose:content-trailing-lambda](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentTrailingLambda.kt)
+
 ### Naming CompositionLocals properly
 
 `CompositionLocal`s should be named by using the adjective `Local` as prefix, followed by a descriptive noun that describes the value they hold. This makes it easier to know when a value comes from a `CompositionLocal`. Given that these are implicit dependencies, we should make them obvious.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentTrailingLambda.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentTrailingLambda.kt
@@ -1,0 +1,39 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.rules.core.ComposeKtConfig
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.Emitter
+import io.nlopez.rules.core.report
+import io.nlopez.rules.core.util.composableLambdaTypes
+import io.nlopez.rules.core.util.isLambda
+import org.jetbrains.kotlin.psi.KtFunction
+
+class ContentTrailingLambda : ComposeKtVisitor {
+
+    override fun visitComposable(
+        function: KtFunction,
+        autoCorrect: Boolean,
+        emitter: Emitter,
+        config: ComposeKtConfig,
+    ) = with(config) {
+        val lambdaTypes = function.containingKtFile.composableLambdaTypes
+
+        val candidate = function.valueParameters
+            .filter { it.name == "content" }
+            .singleOrNull { it.typeReference?.isLambda(lambdaTypes) == true }
+
+        if (candidate != null && candidate != function.valueParameters.last()) {
+            emitter.report(candidate, ContentShouldBeTrailingLambda)
+        }
+    }
+
+    companion object {
+        val ContentShouldBeTrailingLambda = """
+            A @Composable `content` parameter should be moved to be the trailing lambda in a composable function.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#slots-for-main-content-should-be-the-trailing-lambda for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -16,6 +16,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             CompositionLocalAllowlistCheck(config),
             CompositionLocalNamingCheck(config),
             ContentEmitterReturningValuesCheck(config),
+            ContentTrailingLambdaCheck(config),
             DefaultsVisibilityCheck(config),
             LambdaParameterInRestartableEffectCheck(config),
             Material2Check(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheck.kt
@@ -1,0 +1,22 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.rules.ContentTrailingLambda
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.detekt.DetektRule
+
+class ContentTrailingLambdaCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ContentTrailingLambda() {
+    override val issue: Issue = Issue(
+        id = "ContentTrailingLambda",
+        severity = Severity.CodeSmell,
+        description = ContentTrailingLambda.ContentShouldBeTrailingLambda,
+        debt = Debt.TEN_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -11,6 +11,8 @@ Compose:
     active: true
   ContentEmitterReturningValues:
     active: true
+  ContentTrailingLambda:
+    active: true
   DefaultsVisibility:
     active: true
   LambdaParameterInRestartableEffect:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheckTest.kt
@@ -1,0 +1,94 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ContentTrailingLambda
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ContentTrailingLambdaCheckTest {
+
+    private val testConfig = TestConfig(
+        "treatAsComposableLambda" to listOf("Potato"),
+    )
+    private val rule = ContentTrailingLambdaCheck(testConfig)
+
+    @Test
+    fun `errors when there is a content parameter not being last`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: @Composable () -> Unit, text: String) {}
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 7),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ContentTrailingLambda.ContentShouldBeTrailingLambda)
+        }
+    }
+
+    @Test
+    fun `errors when there is an inferred content parameter not being last`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: Potato, text: String) {}
+                @Composable
+                fun A(content: Apple, text: String) {}
+                @Composable
+                fun A(content: Banana, text: String) {}
+
+                typealias Apple = @Composable () -> Unit
+
+                fun interface Banana {
+                    @Composable fun Content()
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 7),
+                SourceLocation(4, 7),
+                SourceLocation(6, 7),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ContentTrailingLambda.ContentShouldBeTrailingLambda)
+        }
+    }
+
+    @Test
+    fun `passes when content is the last parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(text: String, content: @Composable () -> Unit) {}
+                @Composable
+                fun A(text: String, content: Potato) {}
+                @Composable
+                fun A(text: String, content: Banana) {}
+                @Composable
+                fun A(text: String, content: Apple) {}
+
+                typealias Apple = @Composable () -> Unit
+
+                fun interface Banana {
+                    @Composable fun Content()
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -15,6 +15,7 @@ class ComposeRuleSetProvider : RuleSetProviderV3(
         RuleProvider { CompositionLocalAllowlistCheck() },
         RuleProvider { CompositionLocalNamingCheck() },
         RuleProvider { ContentEmitterReturningValuesCheck() },
+        RuleProvider { ContentTrailingLambdaCheck() },
         RuleProvider { DefaultsVisibilityCheck() },
         RuleProvider { LambdaParameterInRestartableEffectCheck() },
         RuleProvider { Material2Check() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ContentTrailingLambdaCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ContentTrailingLambdaCheck.kt
@@ -1,0 +1,14 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.rules.ContentTrailingLambda
+import io.nlopez.rules.core.ComposeKtVisitor
+import io.nlopez.rules.core.ktlint.KtlintRule
+
+class ContentTrailingLambdaCheck :
+    KtlintRule(
+        id = "compose:content-trailing-lambda",
+        editorConfigProperties = setOf(treatAsComposableLambda),
+    ),
+    ComposeKtVisitor by ContentTrailingLambda()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -208,6 +208,25 @@ val treatAsLambda: EditorConfigProperty<String> =
         },
     )
 
+val treatAsComposableLambda: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_treat_as_composable_lambda",
+            "A comma separated list of types that should be treated as @Composable lambdas " +
+                "(e.g. typedefs of lambdas, fun interfaces)",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
 val allowedFromM2: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentTrailingLambdaCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentTrailingLambdaCheckTest.kt
@@ -1,0 +1,98 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ContentTrailingLambda
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ContentTrailingLambdaCheckTest {
+
+    private val ruleAssertThat = assertThatRule { ContentTrailingLambdaCheck() }
+
+    @Test
+    fun `errors when there is a content parameter not being last`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: @Composable () -> Unit, text: String) {}
+            """.trimIndent()
+
+        ruleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 7,
+                detail = ContentTrailingLambda.ContentShouldBeTrailingLambda,
+            ),
+        )
+    }
+
+    @Test
+    fun `errors when there is an inferred content parameter not being last`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: Potato, text: String) {}
+                @Composable
+                fun A(content: Apple, text: String) {}
+                @Composable
+                fun A(content: Banana, text: String) {}
+
+                typealias Apple = @Composable () -> Unit
+
+                fun interface Banana {
+                    @Composable fun Content()
+                }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(treatAsComposableLambda to "Potato")
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 7,
+                    detail = ContentTrailingLambda.ContentShouldBeTrailingLambda,
+                ),
+                LintViolation(
+                    line = 4,
+                    col = 7,
+                    detail = ContentTrailingLambda.ContentShouldBeTrailingLambda,
+                ),
+                LintViolation(
+                    line = 6,
+                    col = 7,
+                    detail = ContentTrailingLambda.ContentShouldBeTrailingLambda,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when content is the last parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(text: String, content: @Composable () -> Unit) {}
+                @Composable
+                fun A(text: String, content: Potato) {}
+                @Composable
+                fun A(text: String, content: Banana) {}
+                @Composable
+                fun A(text: String, content: Apple) {}
+
+                typealias Apple = @Composable () -> Unit
+
+                fun interface Banana {
+                    @Composable fun Content()
+                }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(treatAsComposableLambda to "Potato")
+            .hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
Adds a new rule so that the `content` composable is the trailing lambda. This one is less restrictive than the one in the official lints (where anything with "content" in it could be asked to be trailing, even if things like `titleContent` might not make much sense). 