### PR TITLE
Add Detekt 2.0 support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.0"
 ktlint = "1.2.1"
-detekt = "1.23.6"
+detekt = "main-SNAPSHOT"
 junit = "5.10.2"
 
 [libraries]
@@ -11,7 +11,9 @@ ktlint-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine", versi
 ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint" }
 ktlint-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
 
-detekt-core = { module = "io.gitlab.arturbosch.detekt:detekt-core", version.ref = "detekt" }
+detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
+detekt-rules-libraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
+detekt-rules-ruleauthors = { module = "io.gitlab.arturbosch.detekt:detekt-rules-ruleauthors", version.ref = "detekt" }
 detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,6 @@ ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-co
 ktlint-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint" }
 
 detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
-detekt-rules-libraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
-detekt-rules-ruleauthors = { module = "io.gitlab.arturbosch.detekt:detekt-rules-ruleauthors", version.ref = "detekt" }
 detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -23,7 +23,9 @@ tasks.shadowJar {
 }
 
 dependencies {
-    api(libs.detekt.core)
+    api(libs.detekt.api)
+    api(libs.detekt.rules.libraries)
+    api(libs.detekt.rules.ruleauthors)
     api(projects.rules.common)
 
     testImplementation(libs.detekt.test)

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -24,8 +24,6 @@ tasks.shadowJar {
 
 dependencies {
     api(libs.detekt.api)
-    api(libs.detekt.rules.libraries)
-    api(libs.detekt.rules.ruleauthors)
     api(projects.rules.common)
 
     testImplementation(libs.detekt.test)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/DetektComposeKtConfig.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/DetektComposeKtConfig.kt
@@ -3,7 +3,6 @@
 package io.nlopez.compose.rules
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.internal.valueOrDefaultCommaSeparated
 import io.nlopez.compose.core.ComposeKtConfig
 
 /**
@@ -30,7 +29,7 @@ internal class DetektComposeKtConfig(
     }
 
     override fun getList(key: String, default: List<String>): List<String> =
-        valueOrPut(key) { config.valueOrDefaultCommaSeparated(key, default) } ?: default
+        valueOrPut(key) { config.valueOrDefault(key, default) } ?: default
 
     override fun getSet(key: String, default: Set<String>): Set<String> =
         valueOrPut(key) { getList(key, default.toList()).toSet() } ?: default

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposableAnnotationNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposableAnnotationNamingCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.ComposableAnnotationNaming
 import io.nlopez.compose.rules.DetektRule
 
 class ComposableAnnotationNamingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ComposableAnnotationNaming.ComposableAnnotationDoesNotEndWithComposable),
     ComposeKtVisitor by ComposableAnnotationNaming() {
 
-    override val issue: Issue = Issue(
-        id = "ComposableAnnotationNaming",
-        severity = Severity.CodeSmell,
-        description = ComposableAnnotationNaming.ComposableAnnotationDoesNotEndWithComposable,
-        debt = Debt.FIVE_MINS,
-    )
+    override val ruleId = Id("ComposableAnnotationNaming")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -2,46 +2,45 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.detekt
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 
 class ComposeRuleSetProvider : RuleSetProvider {
-    override val ruleSetId: String = CUSTOM_RULE_SET_ID
+    override val ruleSetId = RuleSet.Id(CUSTOM_RULE_SET_ID)
 
-    override fun instance(config: Config): RuleSet = RuleSet(
-        CUSTOM_RULE_SET_ID,
+    override fun instance(): RuleSet = RuleSet(
+        ruleSetId,
         listOf(
-            ComposableAnnotationNamingCheck(config),
-            CompositionLocalAllowlistCheck(config),
-            CompositionLocalNamingCheck(config),
-            ContentEmitterReturningValuesCheck(config),
-            ContentTrailingLambdaCheck(config),
-            DefaultsVisibilityCheck(config),
-            LambdaParameterInRestartableEffectCheck(config),
-            Material2Check(config),
-            ModifierClickableOrderCheck(config),
-            ModifierComposableCheck(config),
-            ModifierComposedCheck(config),
-            ModifierMissingCheck(config),
-            ModifierNamingCheck(config),
-            ModifierNotUsedAtRootCheck(config),
-            ModifierReusedCheck(config),
-            ModifierWithoutDefaultCheck(config),
-            MultipleContentEmittersCheck(config),
-            MutableParametersCheck(config),
-            MutableStateAutoboxingCheck(config),
-            MutableStateParameterCheck(config),
-            NamingCheck(config),
-            ParameterNamingCheck(config),
-            ParameterOrderCheck(config),
-            PreviewAnnotationNamingCheck(config),
-            PreviewPublicCheck(config),
-            RememberContentMissingCheck(config),
-            RememberStateMissingCheck(config),
-            UnstableCollectionsCheck(config),
-            ViewModelForwardingCheck(config),
-            ViewModelInjectionCheck(config),
+            ::ComposableAnnotationNamingCheck,
+            ::CompositionLocalAllowlistCheck,
+            ::CompositionLocalNamingCheck,
+            ::ContentEmitterReturningValuesCheck,
+            ::ContentTrailingLambdaCheck,
+            ::DefaultsVisibilityCheck,
+            ::LambdaParameterInRestartableEffectCheck,
+            ::Material2Check,
+            ::ModifierClickableOrderCheck,
+            ::ModifierComposableCheck,
+            ::ModifierComposedCheck,
+            ::ModifierMissingCheck,
+            ::ModifierNamingCheck,
+            ::ModifierNotUsedAtRootCheck,
+            ::ModifierReusedCheck,
+            ::ModifierWithoutDefaultCheck,
+            ::MultipleContentEmittersCheck,
+            ::MutableParametersCheck,
+            ::MutableStateAutoboxingCheck,
+            ::MutableStateParameterCheck,
+            ::NamingCheck,
+            ::ParameterNamingCheck,
+            ::ParameterOrderCheck,
+            ::PreviewAnnotationNamingCheck,
+            ::PreviewPublicCheck,
+            ::RememberContentMissingCheck,
+            ::RememberStateMissingCheck,
+            ::UnstableCollectionsCheck,
+            ::ViewModelForwardingCheck,
+            ::ViewModelInjectionCheck,
         ),
     )
 

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalAllowlistCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalAllowlistCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.CompositionLocalAllowlist
 import io.nlopez.compose.rules.DetektRule
 
 class CompositionLocalAllowlistCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, CompositionLocalAllowlist.CompositionLocalNotInAllowlist),
     ComposeKtVisitor by CompositionLocalAllowlist() {
 
-    override val issue: Issue = Issue(
-        id = "CompositionLocalAllowlist",
-        severity = Severity.CodeSmell,
-        description = CompositionLocalAllowlist.CompositionLocalNotInAllowlist,
-        debt = Debt.FIVE_MINS,
-    )
+    override val ruleId = Id("CompositionLocalAllowlist")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.CompositionLocalNaming
 import io.nlopez.compose.rules.DetektRule
 
 class CompositionLocalNamingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, CompositionLocalNaming.CompositionLocalNeedsLocalPrefix),
     ComposeKtVisitor by CompositionLocalNaming() {
 
-    override val issue: Issue = Issue(
-        id = "CompositionLocalNaming",
-        severity = Severity.CodeSmell,
-        description = CompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
-        debt = Debt.FIVE_MINS,
-    )
+    override val ruleId = Id("CompositionLocalNaming")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentEmitterReturningValuesCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentEmitterReturningValuesCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.ContentEmitterReturningValues
 import io.nlopez.compose.rules.DetektRule
 
 class ContentEmitterReturningValuesCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ContentEmitterReturningValues.ContentEmitterReturningValuesToo),
     ComposeKtVisitor by ContentEmitterReturningValues() {
 
-    override val issue: Issue = Issue(
-        id = "ContentEmitterReturningValues",
-        severity = Severity.Defect,
-        description = ContentEmitterReturningValues.ContentEmitterReturningValuesToo,
-        debt = Debt.TWENTY_MINS,
-    )
+    override val ruleId = Id("ContentEmitterReturningValues")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.ContentTrailingLambda
 import io.nlopez.compose.rules.DetektRule
 
 class ContentTrailingLambdaCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ContentTrailingLambda.ContentShouldBeTrailingLambda),
     ComposeKtVisitor by ContentTrailingLambda() {
-    override val issue: Issue = Issue(
-        id = "ContentTrailingLambda",
-        severity = Severity.CodeSmell,
-        description = ContentTrailingLambda.ContentShouldBeTrailingLambda,
-        debt = Debt.TEN_MINS,
-    )
+
+    override val ruleId = Id("ContentTrailingLambda")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/DefaultsVisibilityCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/DefaultsVisibilityCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DefaultsVisibility
 import io.nlopez.compose.rules.DetektRule
 
 class DefaultsVisibilityCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, "@Composable `Defaults` objects should match visibility of the composables they serve."),
     ComposeKtVisitor by DefaultsVisibility() {
-    override val issue: Issue = Issue(
-        id = "DefaultsVisibility",
-        severity = Severity.Defect,
-        description = "@Composable `Defaults` objects should match visibility of the composables they serve.",
-        debt = Debt.TEN_MINS,
-    )
+
+    override val ruleId = Id("DefaultsVisibility")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/LambdaParameterInRestartableEffectCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/LambdaParameterInRestartableEffectCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.LambdaParameterInRestartableEffect
 
 class LambdaParameterInRestartableEffectCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, LambdaParameterInRestartableEffect.LambdaUsedInRestartableEffect),
     ComposeKtVisitor by LambdaParameterInRestartableEffect() {
 
-    override val issue: Issue = Issue(
-        id = "LambdaParameterInRestartableEffect",
-        severity = Severity.Defect,
-        description = LambdaParameterInRestartableEffect.LambdaUsedInRestartableEffect,
-        debt = Debt.TWENTY_MINS,
-    )
+    override val ruleId = Id("LambdaParameterInRestartableEffect")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Material2Check.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Material2Check.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.Material2
 
 class Material2Check(config: Config) :
-    DetektRule(config),
+    DetektRule(config, Material2.DisallowedUsageOfMaterial2),
     ComposeKtVisitor by Material2() {
-    override val issue: Issue = Issue(
-        id = "Material2",
-        severity = Severity.Maintainability,
-        description = Material2.DisallowedUsageOfMaterial2,
-        debt = Debt.TEN_MINS,
-    )
+
+    override val ruleId = Id("Material2")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierClickableOrder
 
 class ModifierClickableOrderCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, "ModifierClickableOrder.ModifierChainWithSuspiciousOrder"),
     ComposeKtVisitor by ModifierClickableOrder() {
-    override val issue: Issue = Issue(
-        id = "ModifierClickableOrder",
-        severity = Severity.Defect,
-        description = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
-        debt = Debt.FIVE_MINS,
-    )
+
+    override val ruleId = Id("ModifierClickableOrder")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierComposableCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierComposableCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierComposable
 
 class ModifierComposableCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ModifierComposable.ComposableModifier),
     ComposeKtVisitor by ModifierComposable() {
-    override val issue: Issue = Issue(
-        id = "ModifierComposable",
-        severity = Severity.Performance,
-        description = ModifierComposable.ComposableModifier,
-        debt = Debt.TEN_MINS,
-    )
+
+    override val ruleId = Id("ModifierComposable")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierComposedCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierComposedCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierComposed
 
 class ModifierComposedCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, "Modifier composed check description"),
     ComposeKtVisitor by ModifierComposed() {
-    override val issue: Issue = Issue(
-        id = "ModifierComposed",
-        severity = Severity.Performance,
-        description = ModifierComposed.ComposedModifier,
-        debt = Debt.TEN_MINS,
-    )
+
+    override val ruleId = Id("ModifierComposed")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierMissing
 
 class ModifierMissingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ModifierMissing.MissingModifierContentComposable),
     ComposeKtVisitor by ModifierMissing() {
-    override val issue: Issue = Issue(
-        id = "ModifierMissing",
-        severity = Severity.Defect,
-        description = ModifierMissing.MissingModifierContentComposable,
-        debt = Debt.TEN_MINS,
-    )
+
+    override val ruleId = Id("ModifierMissing")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierNamingCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierNaming
 
 class ModifierNamingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone),
     ComposeKtVisitor by ModifierNaming() {
-    override val issue: Issue = Issue(
-        id = "ModifierNaming",
-        severity = Severity.CodeSmell,
-        description = ModifierNaming.ModifiersAreSupposedToBeCalledModifierWhenAlone,
-        debt = Debt.FIVE_MINS,
-    )
+
+    override val ruleId = Id("ModifierNaming")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierNotUsedAtRoot
 
 class ModifierNotUsedAtRootCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ModifierNotUsedAtRoot.ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace),
     ComposeKtVisitor by ModifierNotUsedAtRoot() {
-    override val issue: Issue = Issue(
-        id = "ModifierNotUsedAtRoot",
-        severity = Severity.Defect,
-        description = ModifierNotUsedAtRoot.ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
-        debt = Debt.FIVE_MINS,
-    )
+
+    override val ruleId = Id("ModifierNotUsedAtRoot")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierReused
 
 class ModifierReusedCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ModifierReused.ModifierShouldBeUsedOnceOnly),
     ComposeKtVisitor by ModifierReused() {
-    override val issue: Issue = Issue(
-        id = "ModifierReused",
-        severity = Severity.Defect,
-        description = ModifierReused.ModifierShouldBeUsedOnceOnly,
-        debt = Debt.TWENTY_MINS,
-    )
+
+    override val ruleId = Id("ModifierReused")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierWithoutDefaultCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ModifierWithoutDefaultCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ModifierWithoutDefault
 
 class ModifierWithoutDefaultCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ModifierWithoutDefault.MissingModifierDefaultParam),
     ComposeKtVisitor by ModifierWithoutDefault() {
 
-    override val issue: Issue = Issue(
-        id = "ModifierWithoutDefault",
-        severity = Severity.CodeSmell,
-        description = ModifierWithoutDefault.MissingModifierDefaultParam,
-        debt = Debt.FIVE_MINS,
-    )
+    override val ruleId = Id("ModifierWithoutDefault")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.MultipleContentEmitters
 
 class MultipleContentEmittersCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, MultipleContentEmitters.MultipleContentEmittersDetected),
     ComposeKtVisitor by MultipleContentEmitters() {
 
-    override val issue: Issue = Issue(
-        id = "MultipleEmitters",
-        severity = Severity.Defect,
-        description = MultipleContentEmitters.MultipleContentEmittersDetected,
-        debt = Debt.TWENTY_MINS,
-    )
+    override val ruleId = Id("MultipleEmitters")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableParametersCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableParametersCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.MutableParameters
 
 class MutableParametersCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, MutableParameters.MutableParameterInCompose),
     ComposeKtVisitor by MutableParameters() {
-    override val issue: Issue = Issue(
-        id = "MutableParams",
-        severity = Severity.Defect,
-        description = MutableParameters.MutableParameterInCompose,
-        debt = Debt.TWENTY_MINS,
-    )
+
+    override val ruleId = Id("MutableParams")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheck.kt
@@ -8,13 +8,8 @@ import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.MutableStateAutoboxing
 
 class MutableStateAutoboxingCheck(config: Config) :
-    DetektRule(config, DESCRIPTION),
+    DetektRule(config, "Using mutableInt/Long/Double/FloatStateOf is recommended over mutableStateOf<X> for Int/Long/Double/Float"),
     ComposeKtVisitor by MutableStateAutoboxing() {
 
     override val ruleId = Id("MutableStateAutoboxing")
-
-    private companion object {
-        private const val DESCRIPTION = "Using mutableInt/Long/Double/FloatStateOf is recommended over " +
-            "mutableStateOf<X> for Int/Long/Double/Float, as it uses the primitives directly which is more performant."
-    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheck.kt
@@ -3,21 +3,18 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.MutableStateAutoboxing
 
 class MutableStateAutoboxingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, DESCRIPTION),
     ComposeKtVisitor by MutableStateAutoboxing() {
-    override val issue: Issue = Issue(
-        id = "MutableStateAutoboxing",
-        severity = Severity.Performance,
-        description = "Using mutableInt/Long/Double/FloatStateOf is recommended over mutableStateOf<X> for " +
-            "Int/Long/Double/Float, as it uses the primitives directly which is more performant.",
-        debt = Debt.FIVE_MINS,
-    )
+
+    override val ruleId = Id("MutableStateAutoboxing")
+
+    private companion object {
+        private const val DESCRIPTION = "Using mutableInt/Long/Double/FloatStateOf is recommended over " +
+            "mutableStateOf<X> for Int/Long/Double/Float, as it uses the primitives directly which is more performant."
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateParameterCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MutableStateParameterCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.MutableStateParameter
 
 class MutableStateParameterCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, MutableStateParameter.MutableStateParameterInCompose),
     ComposeKtVisitor by MutableStateParameter() {
-    override val issue: Issue = Issue(
-        id = "MutableStateParam",
-        severity = Severity.Defect,
-        description = MutableStateParameter.MutableStateParameterInCompose,
-        debt = Debt.TWENTY_MINS,
-    )
+
+    override val ruleId = Id("MutableStateParam")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/NamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/NamingCheck.kt
@@ -3,24 +3,21 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.Naming
 
 class NamingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, DESCRIPTION),
     ComposeKtVisitor by Naming() {
-    override val issue: Issue = Issue(
-        id = "ComposableNaming",
-        severity = Severity.CodeSmell,
-        description = """
+
+    override val ruleId = Id("ComposableNaming")
+
+    private companion object {
+        private val DESCRIPTION = """
         Composable functions that return Unit should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
 
         However, Composable functions that return a value should start with a lowercase letter instead. They should follow the standard Kotlin Coding Conventions for the naming of functions for any function annotated @Composable that returns a value other than Unit
-        """.trimIndent(),
-        debt = Debt.TEN_MINS,
-    )
+        """.trimIndent()
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheck.kt
@@ -3,24 +3,21 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ParameterNaming
 
 class ParameterNamingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, description),
     ComposeKtVisitor by ParameterNaming() {
-    override val issue: Issue = Issue(
-        id = "ParameterNaming",
-        severity = Severity.CodeSmell,
-        description = """
+
+    override val ruleId = Id("ParameterNaming")
+
+    private companion object {
+        private val description = """
         Lambda parameters in a composable function should be in present tense, not past tense.
 
         Examples: `onClick` and not `onClicked`, `onTextChange` and not `onTextChanged`, etc.
-        """.trimIndent(),
-        debt = Debt.FIVE_MINS,
-    )
+        """.trimIndent()
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheck.kt
@@ -8,16 +8,8 @@ import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ParameterNaming
 
 class ParameterNamingCheck(config: Config) :
-    DetektRule(config, description),
+    DetektRule(config, "Lambda parameters in a composable function should be in present tense, not past tense."),
     ComposeKtVisitor by ParameterNaming() {
 
     override val ruleId = Id("ParameterNaming")
-
-    private companion object {
-        private val description = """
-        Lambda parameters in a composable function should be in present tense, not past tense.
-
-        Examples: `onClick` and not `onClicked`, `onTextChange` and not `onTextChanged`, etc.
-        """.trimIndent()
-    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ParameterOrderCheck.kt
@@ -3,22 +3,19 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ParameterOrder
 
 class ParameterOrderCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, DESCRIPTION),
     ComposeKtVisitor by ParameterOrder() {
-    override val issue: Issue = Issue(
-        id = "ComposableParamOrder",
-        severity = Severity.CodeSmell,
-        description = "Parameters in a composable function should be ordered following this pattern: " +
-            "params without defaults, modifiers, params with defaults and optionally, " +
-            "a trailing function that might not have a default param.",
-        debt = Debt.TEN_MINS,
-    )
+
+    override val ruleId = Id("ComposableParamOrder")
+
+    private companion object {
+        private const val DESCRIPTION = "Parameters in a composable function should be ordered following this " +
+            "pattern: params without defaults, modifiers, params with defaults and optionally, " +
+            "a trailing function that might not have a default param."
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/PreviewAnnotationNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/PreviewAnnotationNamingCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.PreviewAnnotationNaming
 
 class PreviewAnnotationNamingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, "Multipreview annotations should begin with the `Preview` suffix"),
     ComposeKtVisitor by PreviewAnnotationNaming() {
 
-    override val issue: Issue = Issue(
-        id = "PreviewAnnotationNaming",
-        severity = Severity.CodeSmell,
-        description = "Multipreview annotations should begin with the `Preview` suffix",
-        debt = Debt.FIVE_MINS,
-    )
+    override val ruleId = Id("PreviewAnnotationNaming")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/PreviewPublicCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/PreviewPublicCheck.kt
@@ -3,21 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.PreviewPublic
 
 class PreviewPublicCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, PreviewPublic.ComposablesPreviewShouldNotBePublic),
     ComposeKtVisitor by PreviewPublic() {
 
-    override val issue: Issue = Issue(
-        id = "PreviewPublic",
-        severity = Severity.CodeSmell,
-        description = PreviewPublic.ComposablesPreviewShouldNotBePublic,
-        debt = Debt.FIVE_MINS,
-    )
+    override val ruleId = Id("PreviewPublic")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberContentMissingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberContentMissingCheck.kt
@@ -3,23 +3,19 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.RememberContentMissing
 
 class RememberContentMissingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, DESCRIPTION),
     ComposeKtVisitor by RememberContentMissing() {
 
-    override val issue: Issue = Issue(
-        id = "RememberContentMissing",
-        severity = Severity.Defect,
-        description = """
-            Using movableContentOf/movableContentWithReceiverOf in a @Composable function without it being remembered can cause visual problems, as the content would be recycled when detached from the composition.
-        """.trimIndent(),
-        debt = Debt.FIVE_MINS,
-    )
+    override val ruleId = Id("RememberContentMissing")
+
+    private companion object {
+        private const val DESCRIPTION = "Using movableContentOf/movableContentWithReceiverOf in a @Composable " +
+            "function without it being remembered can cause visual problems, as the content would be recycled " +
+            "when detached from the composition."
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberContentMissingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberContentMissingCheck.kt
@@ -8,14 +8,8 @@ import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.RememberContentMissing
 
 class RememberContentMissingCheck(config: Config) :
-    DetektRule(config, DESCRIPTION),
+    DetektRule(config, "movableContentOf/movableContentWithReceiverOf need to be remembered"),
     ComposeKtVisitor by RememberContentMissing() {
 
     override val ruleId = Id("RememberContentMissing")
-
-    private companion object {
-        private const val DESCRIPTION = "Using movableContentOf/movableContentWithReceiverOf in a @Composable " +
-            "function without it being remembered can cause visual problems, as the content would be recycled " +
-            "when detached from the composition."
-    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheck.kt
@@ -8,15 +8,8 @@ import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.RememberStateMissing
 
 class RememberStateMissingCheck(config: Config) :
-    DetektRule(config, description),
+    DetektRule(config, "mutableStateOf/derivedStateOf need to be remembered"),
     ComposeKtVisitor by RememberStateMissing() {
 
     override val ruleId = Id("RememberMissing")
-
-    private companion object {
-        private val description = """
-            Using mutableStateOf/derivedStateOf in a @Composable function without it being inside of a remember function.
-            If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-        """.trimIndent()
-    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheck.kt
@@ -3,24 +3,20 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.RememberStateMissing
 
 class RememberStateMissingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, description),
     ComposeKtVisitor by RememberStateMissing() {
 
-    override val issue: Issue = Issue(
-        id = "RememberMissing",
-        severity = Severity.Defect,
-        description = """
+    override val ruleId = Id("RememberMissing")
+
+    private companion object {
+        private val description = """
             Using mutableStateOf/derivedStateOf in a @Composable function without it being inside of a remember function.
             If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-        """.trimIndent(),
-        debt = Debt.FIVE_MINS,
-    )
+        """.trimIndent()
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/UnstableCollectionsCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/UnstableCollectionsCheck.kt
@@ -8,17 +8,8 @@ import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.UnstableCollections
 
 class UnstableCollectionsCheck(config: Config) :
-    DetektRule(config, description),
+    DetektRule(config, "The Compose compiler cannot infer stability of List/Set/Map"),
     ComposeKtVisitor by UnstableCollections() {
 
     override val ruleId = Id("UnstableCollections")
-
-    private companion object {
-        private val description = """
-            The Compose Compiler cannot infer the stability of a parameter if a List/Set/Map is used in it, even if the item type is stable.
-            You should use Kotlinx Immutable Collections instead, or create an `@Immutable` wrapper for this class.
-
-            See https://mrmans0n.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information.
-        """.trimIndent()
-    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/UnstableCollectionsCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/UnstableCollectionsCheck.kt
@@ -3,25 +3,22 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.UnstableCollections
 
 class UnstableCollectionsCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, description),
     ComposeKtVisitor by UnstableCollections() {
-    override val issue: Issue = Issue(
-        id = "UnstableCollections",
-        severity = Severity.Defect,
-        description = """
+
+    override val ruleId = Id("UnstableCollections")
+
+    private companion object {
+        private val description = """
             The Compose Compiler cannot infer the stability of a parameter if a List/Set/Map is used in it, even if the item type is stable.
             You should use Kotlinx Immutable Collections instead, or create an `@Immutable` wrapper for this class.
 
             See https://mrmans0n.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information.
-        """.trimIndent(),
-        debt = Debt.TWENTY_MINS,
-    )
+        """.trimIndent()
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ViewModelForwardingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ViewModelForwardingCheck.kt
@@ -3,20 +3,13 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ViewModelForwarding
 
 class ViewModelForwardingCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, ViewModelForwarding.AvoidViewModelForwarding),
     ComposeKtVisitor by ViewModelForwarding() {
-    override val issue: Issue = Issue(
-        id = "ViewModelForwarding",
-        severity = Severity.CodeSmell,
-        description = ViewModelForwarding.AvoidViewModelForwarding,
-        debt = Debt.TWENTY_MINS,
-    )
+
+    override val ruleId = Id("ViewModelForwarding")
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ViewModelInjectionCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ViewModelInjectionCheck.kt
@@ -3,25 +3,21 @@
 package io.nlopez.compose.rules.detekt
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Severity
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ViewModelInjection
 
 class ViewModelInjectionCheck(config: Config) :
-    DetektRule(config),
+    DetektRule(config, description),
     ComposeKtVisitor by ViewModelInjection() {
 
-    override val issue: Issue = Issue(
-        id = "ViewModelInjection",
-        severity = Severity.CodeSmell,
-        description = """
+    override val ruleId = Id("ViewModelInjection")
+
+    private companion object {
+        private val description = """
             Implicit dependencies of composables should be made explicit.
 
             Acquiring a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
-        """.trimIndent(),
-        debt = Debt.TEN_MINS,
-    )
+        """.trimIndent()
+    }
 }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ViewModelInjectionCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ViewModelInjectionCheck.kt
@@ -8,16 +8,8 @@ import io.nlopez.compose.rules.DetektRule
 import io.nlopez.compose.rules.ViewModelInjection
 
 class ViewModelInjectionCheck(config: Config) :
-    DetektRule(config, description),
+    DetektRule(config, "Implicit dependencies of composables should be made explicit."),
     ComposeKtVisitor by ViewModelInjection() {
 
     override val ruleId = Id("ViewModelInjection")
-
-    private companion object {
-        private val description = """
-            Implicit dependencies of composables should be made explicit.
-
-            Acquiring a ViewModel should be done in composable default parameters, so that it is more testable and flexible.
-        """.trimIndent()
-    }
 }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/DetektComposeKtConfigTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/DetektComposeKtConfigTest.kt
@@ -10,10 +10,10 @@ class DetektComposeKtConfigTest {
     private val detektConfig = TestConfig(
         "myInt" to 10,
         "myString" to "abcd",
-        "myList" to "a,b,c,a",
-        "myList2" to "a , b , c,a",
-        "mySet" to "a,b,c,a,b,c",
-        "mySet2" to "  a, b,c ,a  , b  ,  c ",
+        "myList" to "[a,b,c,a]",
+        "myList2" to "[a , b , c,a]",
+        "mySet" to "[a,b,c,a,b,c]",
+        "mySet2" to "[  a, b,c ,a  , b  ,  c ]",
         "myBool" to true,
     )
     private val config = DetektComposeKtConfig(detektConfig)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
@@ -11,19 +11,22 @@ import org.reflections.Reflections
 class ComposeRuleSetProviderTest {
 
     private val ruleSetProvider = ComposeRuleSetProvider()
-    private val ruleSet = ruleSetProvider.instance(Config.empty)
+    private val ruleSet = ruleSetProvider.instance()
 
     @Test
     fun `ensure all rules in the package are represented in the ruleset`() {
         val reflections = Reflections(ruleSetProvider.javaClass.packageName)
         val ruleClassesInPackage = reflections.getSubTypesOf(DetektRule::class.java)
-        val ruleClassesInRuleSet = ruleSet.rules.filterIsInstance<DetektRule>().map { it::class.java }.toSet()
+        val ruleClassesInRuleSet = ruleSet.rules.values.map {
+            it(Config.empty)
+        }.filterIsInstance<DetektRule>().map { it::class.java }.toSet()
         assertThat(ruleClassesInRuleSet).containsExactlyInAnyOrderElementsOf(ruleClassesInPackage)
     }
 
     @Test
     fun `ensure all rules in the package are listed in alphabetical order`() {
         val isOrdered = ruleSet.rules
+            .values.map { it(Config.empty) }
             .filterIsInstance<DetektRule>()
             .asSequence()
             .map { it::class.java.simpleName }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
@@ -17,16 +17,18 @@ class ComposeRuleSetProviderTest {
     fun `ensure all rules in the package are represented in the ruleset`() {
         val reflections = Reflections(ruleSetProvider.javaClass.packageName)
         val ruleClassesInPackage = reflections.getSubTypesOf(DetektRule::class.java)
-        val ruleClassesInRuleSet = ruleSet.rules.values.map {
-            it(Config.empty)
-        }.filterIsInstance<DetektRule>().map { it::class.java }.toSet()
+        val ruleClassesInRuleSet = ruleSet.rules.values
+            .map { it(Config.empty) }
+            .filterIsInstance<DetektRule>()
+            .map { it::class.java }
+            .toSet()
         assertThat(ruleClassesInRuleSet).containsExactlyInAnyOrderElementsOf(ruleClassesInPackage)
     }
 
     @Test
     fun `ensure all rules in the package are listed in alphabetical order`() {
-        val isOrdered = ruleSet.rules
-            .values.map { it(Config.empty) }
+        val isOrdered = ruleSet.rules.values
+            .map { it(Config.empty) }
             .filterIsInstance<DetektRule>()
             .asSequence()
             .map { it::class.java.simpleName }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.URI
+
 // Copyright 2024 Nacho Lopez
 // SPDX-License-Identifier: Apache-2.0
 plugins {
@@ -7,6 +9,9 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        maven {
+            url = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 }
 


### PR DESCRIPTION
Makes the custom Detekt rules compatible with Detekt v2.0 APIs.

Currently using a snapshot build, but understand if ya want to wait to merge until a 2.0 build of Detekt is released.

Addresses #276