### PR TITLE
Improve content emitter logic and support for conditional emitter count

### DIFF
--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -153,6 +153,60 @@ class MultipleContentEmittersCheckTest {
     }
 
     @Test
+    fun `errors when a Composable function emits multiple content with conditionals`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A() {
+                    if (something) {
+                        Text("1")
+                        Text("2")
+                    } else {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun B() {
+                    if (something) {
+                        Text("1")
+                        Text("2")
+                    } else {
+                        Text("1")
+                    }
+                }
+                @Composable
+                fun C() {
+                    if (something) {
+                        Text("1")
+                    } else {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun D() {
+                    if (something) {
+                        Text("1")
+                    }
+                    Text("2")
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 5),
+                SourceLocation(12, 5),
+                SourceLocation(21, 5),
+                SourceLocation(30, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
+        }
+    }
+
+    @Test
     fun `make sure to not report twice the same composable`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -158,6 +158,72 @@ class MultipleContentEmittersCheckTest {
     }
 
     @Test
+    fun `errors when a Composable function emits multiple content with conditionals`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A() {
+                    if (something) {
+                        Text("1")
+                        Text("2")
+                    } else {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun B() {
+                    if (something) {
+                        Text("1")
+                        Text("2")
+                    } else {
+                        Text("1")
+                    }
+                }
+                @Composable
+                fun C() {
+                    if (something) {
+                        Text("1")
+                    } else {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun D() {
+                    if (something) {
+                        Text("1")
+                    }
+                    Text("2")
+                }
+            """.trimIndent()
+        emittersRuleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 21,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 30,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+            )
+    }
+
+    @Test
     fun `make sure to not report twice the same composable`() {
         @Language("kotlin")
         val code =


### PR DESCRIPTION
Improves the basics behind the content emitter counts, and makes it more flexible and easier to update. 

I've also added  support for branching code (e.g. if/else), so that if any of the branches contains emitters, they are taken into account.