### PR TITLE
Update ParameterNaming to use treatAsLambda instead of treatAsComposableLambda

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -103,8 +103,8 @@ Compose:
     active: true
   ParameterNaming:
     active: true
-    # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically)
-    # treatAsComposableLambda: MyComposableLambdaType
+    # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
+    # treatAsLambda: MyLambdaType
   PreviewAnnotationNaming:
     active: true
   PreviewPublic:

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
@@ -6,8 +6,8 @@ import io.nlopez.compose.core.ComposeKtConfig
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.core.Emitter
 import io.nlopez.compose.core.report
-import io.nlopez.compose.core.util.composableLambdaTypes
 import io.nlopez.compose.core.util.isLambda
+import io.nlopez.compose.core.util.lambdaTypes
 import org.jetbrains.kotlin.psi.KtFunction
 
 class ParameterNaming : ComposeKtVisitor {
@@ -16,7 +16,7 @@ class ParameterNaming : ComposeKtVisitor {
         // For lambda parameters only: if it starts with `on`, we want it to not be in past tense, to be all consistent.
         // E.g. onClick, onTextChange, onValueChange, and a myriad of other examples in the compose foundation code.
 
-        val lambdaTypes = function.containingKtFile.composableLambdaTypes
+        val lambdaTypes = function.containingKtFile.lambdaTypes
 
         val errors = function.valueParameters
             .filter { it.typeReference?.isLambda(lambdaTypes) == true }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheckTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 class ParameterNamingCheckTest {
 
     private val testConfig = TestConfig(
-        "treatAsComposableLambda" to listOf("Potato"),
+        "treatAsLambda" to listOf("Potato"),
     )
     private val rule = ParameterNamingCheck(testConfig)
 

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.compose.rules.ParameterNaming
 class ParameterNamingCheck :
     KtlintRule(
         id = "compose:parameter-naming",
-        editorConfigProperties = setOf(treatAsComposableLambda),
+        editorConfigProperties = setOf(treatAsLambda),
     ),
     ComposeKtVisitor by ParameterNaming()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
@@ -26,7 +26,7 @@ class ParameterNamingCheckTest {
             """.trimIndent()
         ruleAssertThat(code)
             .withEditorConfigOverride(
-                treatAsComposableLambda to "Potato",
+                treatAsLambda to "Potato",
             )
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(


### PR DESCRIPTION
I just noticed I used the wrong parameter when updating this rule. This introduces a breaking change though, but it's good... as it will spare us from future issues.

ParameterNaming lambdas shouldn't be just composable lambdas, but all lambdas instead.