### PR TITLE
Add binary expressions support to MultipleContentEmitters

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KotlinUtils.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KotlinUtils.kt
@@ -46,3 +46,6 @@ fun String.toCamelCase() = split('_').joinToString(
 fun String.toSnakeCase() = replace(humps, "_").lowercase(Locale.getDefault())
 
 private val humps by lazy { "(?<=.)(?=\\p{Upper})".toRegex() }
+
+val KotlinScopeFunctions = setOf("with", "apply", "run", "also", "let")
+val KotlinItObjectScopeFunctions = setOf("let", "also")

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelForwarding.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelForwarding.kt
@@ -5,6 +5,8 @@ package io.nlopez.compose.rules
 import io.nlopez.compose.core.ComposeKtConfig
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.core.Emitter
+import io.nlopez.compose.core.util.KotlinItObjectScopeFunctions
+import io.nlopez.compose.core.util.KotlinScopeFunctions
 import io.nlopez.compose.core.util.definedInInterface
 import io.nlopez.compose.core.util.findChildrenByClass
 import io.nlopez.compose.core.util.findDirectChildrenByClass
@@ -129,13 +131,13 @@ class ViewModelForwarding : ComposeKtVisitor {
     }
 
     private val KtCallExpression.isScopeFunction: Boolean
-        get() = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() in scopeFunctions
+        get() = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() in KotlinScopeFunctions
 
     private val KtCallExpression.isWithScope: Boolean
         get() = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() == "with"
 
     private val KtCallExpression.hasItObjectReference: Boolean
-        get() = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() in itObjectScopeFunctions
+        get() = (calleeExpression as? KtNameReferenceExpression)?.getReferencedName() in KotlinItObjectScopeFunctions
 
     private fun KtCallExpression.getScopedParameterValue(): String? = if (isWithScope) {
         valueArguments.firstOrNull()?.getArgumentExpression()?.text
@@ -145,8 +147,6 @@ class ViewModelForwarding : ComposeKtVisitor {
 
     companion object {
         private val defaultStateHolderNames = listOf(".*ViewModel", ".*Presenter")
-        private val scopeFunctions = setOf("with", "apply", "run", "also", "let")
-        private val itObjectScopeFunctions = setOf("let", "also")
         val AvoidViewModelForwarding = """
             Forwarding a ViewModel/Presenter through multiple @Composable functions should be avoided. Consider using state hoisting.
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -100,6 +100,11 @@ class MultipleContentEmittersCheckTest {
                     title?.let { Text(title) }
                     subtitle?.let { Text(subtitle) }
                 }
+                @Composable
+                fun Something(title: String?, subtitle: String?) {
+                    with(title) { Text(this) }
+                    with(subtitle) { Text(this) }
+                }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors)
@@ -107,6 +112,7 @@ class MultipleContentEmittersCheckTest {
                 SourceLocation(2, 5),
                 SourceLocation(7, 5),
                 SourceLocation(12, 5),
+                SourceLocation(17, 5),
             )
         for (error in errors) {
             assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
@@ -200,6 +206,56 @@ class MultipleContentEmittersCheckTest {
                 SourceLocation(12, 5),
                 SourceLocation(21, 5),
                 SourceLocation(30, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
+        }
+    }
+
+    @Test
+    fun `errors when a Composable function emits multiple content with elvis operators`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A() {
+                    text?.let {
+                        Text("1")
+                        Text("2")
+                    } ?: run {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun B() {
+                    text?.let {
+                        Text("1")
+                        Text("2")
+                    } ?: Text("1")
+                }
+                @Composable
+                fun C() {
+                    text?.let {
+                        Text("1")
+                    } ?: run {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun D() {
+                    text?.let { Text("1") }
+                    Text("2")
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 5),
+                SourceLocation(12, 5),
+                SourceLocation(19, 5),
+                SourceLocation(28, 5),
             )
         for (error in errors) {
             assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -91,6 +91,11 @@ class MultipleContentEmittersCheckTest {
                     title?.let { Text(title) }
                     subtitle?.let { Text(subtitle) }
                 }
+                @Composable
+                fun Something(title: String?, subtitle: String?) {
+                    with(title) { Text(this) }
+                    with(subtitle) { Text(this) }
+                }
             """.trimIndent()
         emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
             LintViolation(
@@ -105,6 +110,11 @@ class MultipleContentEmittersCheckTest {
             ),
             LintViolation(
                 line = 12,
+                col = 5,
+                detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+            ),
+            LintViolation(
+                line = 17,
                 col = 5,
                 detail = MultipleContentEmitters.MultipleContentEmittersDetected,
             ),
@@ -217,6 +227,68 @@ class MultipleContentEmittersCheckTest {
                 ),
                 LintViolation(
                     line = 30,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+            )
+    }
+
+    @Test
+    fun `errors when a Composable function emits multiple content with elvis operators`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A() {
+                    text?.let {
+                        Text("1")
+                        Text("2")
+                    } ?: run {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun B() {
+                    text?.let {
+                        Text("1")
+                        Text("2")
+                    } ?: Text("1")
+                }
+                @Composable
+                fun C() {
+                    text?.let {
+                        Text("1")
+                    } ?: run {
+                        Text("1")
+                        Text("2")
+                    }
+                }
+                @Composable
+                fun D() {
+                    text?.let { Text("1") }
+                    Text("2")
+                }
+            """.trimIndent()
+        emittersRuleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 12,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 19,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 28,
                     col = 5,
                     detail = MultipleContentEmitters.MultipleContentEmittersDetected,
                 ),


### PR DESCRIPTION
Adds support for elvis operator operations when finding content emitters, and also adds direct support for scoped operations as well - not only for safe accessors this time (so anything wrapped with a with, run, etc would also be found).