### PR TITLE
Update Naming to ignore overridden function definitions

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/Naming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/Naming.kt
@@ -8,6 +8,7 @@ import io.nlopez.compose.core.Emitter
 import io.nlopez.compose.core.report
 import io.nlopez.compose.core.util.hasReceiverType
 import io.nlopez.compose.core.util.isOperator
+import io.nlopez.compose.core.util.isOverride
 import io.nlopez.compose.core.util.isSuppressed
 import io.nlopez.compose.core.util.returnsValue
 import org.jetbrains.kotlin.psi.KtFunction
@@ -20,6 +21,9 @@ class Naming : ComposeKtVisitor {
 
         // Operators have fixed names that we can't modify, so this rule is useless in that case
         if (function.isOperator) return
+
+        // Overrides have names that we might not be able to modify (3p libraries), so the rule is useless there too
+        if (function.isOverride) return
 
         // If it's suppressed by the official lints, we will honor that too
         if (function.isSuppressed("ComposableNaming")) return

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/NamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/NamingCheckTest.kt
@@ -169,4 +169,19 @@ class NamingCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes when a composable is an override even if the naming should be wrong`() {
+        @Language("kotlin")
+        val code =
+            """
+                interface Bleh {
+                    @Composable
+                    override fun component() { }
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/NamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/NamingCheckTest.kt
@@ -166,4 +166,18 @@ class NamingCheckTest {
 
         namingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when a composable is an override even if the naming should be wrong`() {
+        @Language("kotlin")
+        val code =
+            """
+                interface Bleh {
+                    @Composable
+                    override fun component() { }
+                }
+            """.trimIndent()
+
+        namingRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
While looking into #290 I realized that we shouldn't be yapping about naming for overridden funs, as they might come from third party libraries we don't have control over. As long as the rule is applied to the interface / abstract/open class, it should be enough.

Fixes #290