### PR TITLE
Add support to when statements while counting emitters

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
@@ -11,11 +11,12 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtLoopExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 import kotlin.math.max
@@ -103,8 +104,8 @@ private fun KtExpression.uiEmitterCount(): Int = when (val current = this) {
         else -> 0
     }
 
-    // for loops. E.g. for (item in list) { Text(item) }
-    is KtForExpression -> {
+    // for loops, while loops, do while loops, etc. E.g. for (item in list) { Text(item) }
+    is KtLoopExpression -> {
         // Assume at least 2 iterations if any, as we can't know how many there will be.
         current.body?.uiEmitterCount()?.takeIf { it > 0 }?.let { it + 1 } ?: 0
     }
@@ -136,6 +137,10 @@ private fun KtExpression.uiEmitterCount(): Int = when (val current = this) {
         val ifCount = current.then?.uiEmitterCount() ?: 0
         val elseCount = current.`else`?.uiEmitterCount() ?: 0
         max(ifCount, elseCount)
+    }
+
+    is KtWhenExpression -> {
+        current.entries.maxOfOrNull { it.expression?.uiEmitterCount() ?: 0 } ?: 0
     }
 
     else -> 0

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -263,6 +263,71 @@ class MultipleContentEmittersCheckTest {
     }
 
     @Test
+    fun `errors when a Composable function emits multiple content with a when`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A() {
+                    when {
+                        isPotato -> {
+                            Text("1")
+                            Text("2")
+                        }
+                        else -> {
+                            Text("1")
+                            Text("2")
+                        }
+                    }
+                }
+                @Composable
+                fun B() {
+                    when {
+                        isPotato -> {
+                            Text("1")
+                        }
+                        else -> {
+                            Text("1")
+                            Text("2")
+                        }
+                    }
+                }
+                @Composable
+                fun C() {
+                    when {
+                        isPotato -> {
+                            Text("1")
+                            Text("2")
+                        }
+                        else -> {
+                            Text("1")
+                        }
+                    }
+                }
+                @Composable
+                fun D() {
+                    Text("1")
+                    when {
+                        isPotato -> Text("2")
+                        else -> {}
+                    }
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 5),
+                SourceLocation(15, 5),
+                SourceLocation(27, 5),
+                SourceLocation(39, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
+        }
+    }
+
+    @Test
     fun `make sure to not report twice the same composable`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -296,6 +296,82 @@ class MultipleContentEmittersCheckTest {
     }
 
     @Test
+    fun `errors when a Composable function emits multiple content with a when`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A() {
+                    when {
+                        isPotato -> {
+                            Text("1")
+                            Text("2")
+                        }
+                        else -> {
+                            Text("1")
+                            Text("2")
+                        }
+                    }
+                }
+                @Composable
+                fun B() {
+                    when {
+                        isPotato -> {
+                            Text("1")
+                        }
+                        else -> {
+                            Text("1")
+                            Text("2")
+                        }
+                    }
+                }
+                @Composable
+                fun C() {
+                    when {
+                        isPotato -> {
+                            Text("1")
+                            Text("2")
+                        }
+                        else -> {
+                            Text("1")
+                        }
+                    }
+                }
+                @Composable
+                fun D() {
+                    Text("1")
+                    when {
+                        isPotato -> Text("2")
+                        else -> {}
+                    }
+                }
+            """.trimIndent()
+        emittersRuleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 15,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 27,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+                LintViolation(
+                    line = 39,
+                    col = 5,
+                    detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+                ),
+            )
+    }
+
+    @Test
     fun `make sure to not report twice the same composable`() {
         @Language("kotlin")
         val code =


### PR DESCRIPTION
Now it supports `when` statements, plus more forms of loops (`while`, `do ... while`, and the former `for`).