### PR TITLE
Stop content emitter detection also by contentEmittersDenylist

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/PsiElements.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/PsiElements.kt
@@ -8,9 +8,14 @@ import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import java.util.*
+import java.util.Deque
+import java.util.LinkedList
 
-inline fun <reified T : PsiElement> PsiElement.findChildrenByClass(): Sequence<T> = sequence {
+val PsiElementAlwaysTruePredicate: (PsiElement) -> Boolean = { true }
+
+inline fun <reified T : PsiElement> PsiElement.findChildrenByClass(
+    noinline shouldVisitChildren: (PsiElement) -> Boolean = PsiElementAlwaysTruePredicate,
+): Sequence<T> = sequence {
     val queue: Deque<PsiElement> = LinkedList()
     queue.add(this@findChildrenByClass)
     while (queue.isNotEmpty()) {
@@ -18,7 +23,9 @@ inline fun <reified T : PsiElement> PsiElement.findChildrenByClass(): Sequence<T
         if (current is T) {
             yield(current)
         }
-        queue.addAll(current.children)
+        if (shouldVisitChildren(current)) {
+            queue.addAll(current.children)
+        }
     }
 }
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheckTest.kt
@@ -14,6 +14,7 @@ class ModifierMissingCheckTest {
 
     private val testConfig = TestConfig(
         "customModifiers" to listOf("BananaModifier"),
+        "contentEmittersDenylist" to listOf("PotatoDialog"),
     )
     private val rule = ModifierMissingCheck(testConfig)
 
@@ -316,13 +317,17 @@ class ModifierMissingCheckTest {
         @Language("kotlin")
         val code =
             """
-                @Composable
                 fun MyDialog() {
-                  AlertDialog(
-                    onDismissRequest = { /*TODO*/ },
-                    buttons = { Text(text = "Button") },
-                    text = { Text(text = "Body") },
-                  )
+                    AlertDialog(
+                        onDismissRequest = { /*TODO*/ },
+                        buttons = { Text(text = "Button") },
+                        text = { Text(text = "Body") },
+                    )
+                    PotatoDialog(
+                        onDismissRequest = { /*TODO*/ },
+                        buttons = { Text(text = "Button") },
+                        text = { Text(text = "Body") },
+                    )
                 }
             """.trimIndent()
 
@@ -337,13 +342,13 @@ class ModifierMissingCheckTest {
             """
                 @Composable
                 fun MyDialog() {
-                  Text(text = "Unicorn")
+                    Text(text = "Unicorn")
 
-                  AlertDialog(
-                    onDismissRequest = { /*TODO*/ },
-                    buttons = { Text(text = "Button") },
-                    text = { Text(text = "Body") },
-                  )
+                    AlertDialog(
+                        onDismissRequest = { /*TODO*/ },
+                        buttons = { Text(text = "Button") },
+                        text = { Text(text = "Body") },
+                    )
                 }
             """.trimIndent()
 

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheck.kt
@@ -9,6 +9,11 @@ import io.nlopez.compose.rules.ModifierMissing
 class ModifierMissingCheck :
     KtlintRule(
         id = "compose:modifier-missing-check",
-        editorConfigProperties = setOf(checkModifiersForVisibility, contentEmittersProperty, customModifiers),
+        editorConfigProperties = setOf(
+            checkModifiersForVisibility,
+            contentEmittersProperty,
+            customModifiers,
+            contentEmittersDenylist,
+        ),
     ),
     ComposeKtVisitor by ModifierMissing()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.compose.rules.ModifierReused
 class ModifierReusedCheck :
     KtlintRule(
         id = "compose:modifier-reused-check",
-        editorConfigProperties = setOf(contentEmittersProperty, customModifiers),
+        editorConfigProperties = setOf(contentEmittersProperty, customModifiers, contentEmittersDenylist),
     ),
     ComposeKtVisitor by ModifierReused()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheckTest.kt
@@ -352,15 +352,22 @@ class ModifierMissingCheckTest {
             """
                 @Composable
                 fun MyDialog() {
-                  AlertDialog(
-                    onDismissRequest = { /*TODO*/ },
-                    buttons = { Text(text = "Button") },
-                    text = { Text(text = "Body") },
-                  )
+                    AlertDialog(
+                        onDismissRequest = { /*TODO*/ },
+                        buttons = { Text(text = "Button") },
+                        text = { Text(text = "Body") },
+                    )
+                    PotatoDialog(
+                        onDismissRequest = { /*TODO*/ },
+                        buttons = { Text(text = "Button") },
+                        text = { Text(text = "Body") },
+                    )
                 }
             """.trimIndent()
 
-        modifierRuleAssertThat(code).hasNoLintViolations()
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(contentEmittersDenylist to "PotatoDialog")
+            .hasNoLintViolations()
     }
 
     @Test
@@ -370,13 +377,13 @@ class ModifierMissingCheckTest {
             """
                 @Composable
                 fun MyDialog() {
-                  Text(text = "Unicorn")
+                    Text(text = "Unicorn")
 
-                  AlertDialog(
-                    onDismissRequest = { /*TODO*/ },
-                    buttons = { Text(text = "Button") },
-                    text = { Text(text = "Body") },
-                  )
+                    AlertDialog(
+                        onDismissRequest = { /*TODO*/ },
+                        buttons = { Text(text = "Button") },
+                        text = { Text(text = "Body") },
+                    )
                 }
             """.trimIndent()
 


### PR DESCRIPTION
Simplified the detection of potential content emitters in functions, with a slight behavior change:

Before, no children would be considered if the parents were any of these set of hardcoded composables:
```
    setOf(
        "AlertDialog",
        "DatePickerDialog",
        "Dialog",
        "ModalBottomSheetLayout",
        "ModalBottomSheet",
        "Popup",
    )
```

Now, no children will be considered if the parents were any of these hardcoded composables, plus any of the composables defined in `contentEmittersDenylist` in the rules configuration. That way, you can get rid of false positives that might have originated with your own foundational composables.