### PR TITLE
Ignore modifier factory functions in ModifierMissing/ModifierWithoutDefault

### DIFF
--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierMissingCheckTest.kt
@@ -356,4 +356,20 @@ class ModifierMissingCheckTest {
         assertThat(errors).hasTextLocations("MyDialog")
         assertThat(errors[0]).hasMessage(ModifierMissing.MissingModifierContentComposable)
     }
+
+    @Test
+    fun `Modifier factory functions are ignored`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Modifier.Something() {
+                    Row {
+                    }
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierWithoutDefaultCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierWithoutDefaultCheckTest.kt
@@ -94,4 +94,19 @@ class ModifierWithoutDefaultCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes for Modifier factory functions`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Modifier.something(modifier: Modifier) {
+                    Row(modifier = modifier) {
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierMissingCheckTest.kt
@@ -395,4 +395,19 @@ class ModifierMissingCheckTest {
             ),
         )
     }
+
+    @Test
+    fun `Modifier factory functions are ignored`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Modifier.Something() {
+                    Row {
+                    }
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierWithoutDefaultCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierWithoutDefaultCheckTest.kt
@@ -103,4 +103,18 @@ class ModifierWithoutDefaultCheckTest {
             """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `passes for Modifier factory functions`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Modifier.something(modifier: Modifier) {
+                    Row(modifier = modifier) {
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Add special cases to ignore some of the Modifier adjacent rules (ModifierMissing, ModifierWithoutDefault) if the composable function is an extension function for Modifier (aka a Modifier factory function, which is now less frowned upon).