### PR TITLE
Remove context receivers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,6 @@ allprojects {
             freeCompilerArgs.addAll(
                 // Enable default methods in interfaces
                 "-Xjvm-default=all",
-                // Enable context receivers
-                "-Xcontext-receivers",
             )
         }
     }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Lambdas.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Lambdas.kt
@@ -38,70 +38,66 @@ fun KtTypeReference.isComposableLambda(
     else -> false
 }
 
-context(ComposeKtConfig)
-val KtFile.lambdaTypes: Set<String>
-    get() = buildSet {
-        // Add the provided types
-        addAll(getSet("treatAsLambda", emptySet()))
+fun KtFile.lambdaTypes(config: ComposeKtConfig): Set<String> = buildSet {
+    // Add the provided types
+    addAll(config.getSet("treatAsLambda", emptySet()))
 
-        // Add fun interfaces
-        addAll(
-            findChildrenByClass<KtClass>()
-                .filter { it.isInterface() && it.hasModifier(KtTokens.FUN_KEYWORD) }
-                .mapNotNull { it.name },
-        )
+    // Add fun interfaces
+    addAll(
+        findChildrenByClass<KtClass>()
+            .filter { it.isInterface() && it.hasModifier(KtTokens.FUN_KEYWORD) }
+            .mapNotNull { it.name },
+    )
 
-        // Add typealias with functional types
-        // NOTE: it has to be last, so that isLambda picks up fun interfaces / config stuff in lambdaTypes
-        addAll(
-            findChildrenByClass<KtTypeAlias>()
-                .filter { it.getTypeReference()?.isLambda(this) == true }
-                .mapNotNull { it.name },
-        )
-    }
+    // Add typealias with functional types
+    // NOTE: it has to be last, so that isLambda picks up fun interfaces / config stuff in lambdaTypes
+    addAll(
+        findChildrenByClass<KtTypeAlias>()
+            .filter { it.getTypeReference()?.isLambda(this) == true }
+            .mapNotNull { it.name },
+    )
+}
 
-context(ComposeKtConfig)
-val KtFile.composableLambdaTypes: Set<String>
-    get() = buildSet {
-        // Add the provided types
-        addAll(getSet("treatAsComposableLambda", emptySet()))
+fun KtFile.composableLambdaTypes(config: ComposeKtConfig): Set<String> = buildSet {
+    // Add the provided types
+    addAll(config.getSet("treatAsComposableLambda", emptySet()))
 
-        // Add fun interfaces that have their sam method as composable
-        addAll(
-            findChildrenByClass<KtClass>()
-                .filter { it.isInterface() && it.hasModifier(KtTokens.FUN_KEYWORD) }
-                .filter { funInterface ->
-                    // Find if the method that has no implementation (aka the SAM) is @Composable
-                    funInterface.body
-                        ?.functions
-                        ?.filterNot { it.hasBody() }
-                        ?.map { it.isComposable }
-                        ?.firstOrNull() ?: false
-                }
-                .mapNotNull { it.name },
-        )
+    // Add fun interfaces that have their sam method as composable
+    addAll(
+        findChildrenByClass<KtClass>()
+            .filter { it.isInterface() && it.hasModifier(KtTokens.FUN_KEYWORD) }
+            .filter { funInterface ->
+                // Find if the method that has no implementation (aka the SAM) is @Composable
+                funInterface.body
+                    ?.functions
+                    ?.filterNot { it.hasBody() }
+                    ?.map { it.isComposable }
+                    ?.firstOrNull() ?: false
+            }
+            .mapNotNull { it.name },
+    )
 
-        // Add typealias with functional types
-        // NOTE: it has to be last, so that isLambda picks up fun interfaces / config stuff in lambdaTypes
-        addAll(
-            findChildrenByClass<KtTypeAlias>()
-                .filter {
-                    val typeReference = it.getTypeReference() ?: return@filter false
-                    when (val typeElement = typeReference.typeElement) {
-                        null -> false
-                        // typealias A = @Composable () -> Unit
-                        is KtFunctionType -> typeReference.isComposable
-                        // typealias B = @Composable (() -> Unit?)
-                        // typealias B = A?
-                        is KtNullableType -> {
-                            (typeReference.isComposable && typeElement.innerType is KtFunctionType) ||
-                                typeElement.innerType?.name in this
-                        }
-                        // typealias C = A
-                        is KtUserType -> typeElement.referencedName in this
-                        else -> false
+    // Add typealias with functional types
+    // NOTE: it has to be last, so that isLambda picks up fun interfaces / config stuff in lambdaTypes
+    addAll(
+        findChildrenByClass<KtTypeAlias>()
+            .filter {
+                val typeReference = it.getTypeReference() ?: return@filter false
+                when (val typeElement = typeReference.typeElement) {
+                    null -> false
+                    // typealias A = @Composable () -> Unit
+                    is KtFunctionType -> typeReference.isComposable
+                    // typealias B = @Composable (() -> Unit?)
+                    // typealias B = A?
+                    is KtNullableType -> {
+                        (typeReference.isComposable && typeElement.innerType is KtFunctionType) ||
+                            typeElement.innerType?.name in this
                     }
+                    // typealias C = A
+                    is KtUserType -> typeElement.referencedName in this
+                    else -> false
                 }
-                .mapNotNull { it.name },
-        )
-    }
+            }
+            .mapNotNull { it.name },
+    )
+}

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -77,21 +77,16 @@ private val ModifierNames by lazy {
     )
 }
 
-context(ComposeKtConfig)
-val KtCallableDeclaration.isModifier: Boolean
-    get() = typeReference?.text in ModifierNames + getSet("customModifiers", emptySet())
+fun KtCallableDeclaration.isModifier(config: ComposeKtConfig): Boolean =
+    typeReference?.text in ModifierNames + config.getSet("customModifiers", emptySet())
 
-context(ComposeKtConfig)
-val KtCallableDeclaration.isModifierReceiver: Boolean
-    get() = receiverTypeReference?.text in ModifierNames + getSet("customModifiers", emptySet())
+fun KtCallableDeclaration.isModifierReceiver(config: ComposeKtConfig): Boolean =
+    receiverTypeReference?.text in ModifierNames + config.getSet("customModifiers", emptySet())
 
-context(ComposeKtConfig)
-val KtFunction.modifierParameter: KtParameter?
-    get() {
-        val modifiers = valueParameters.filter { it.isModifier }
-        return modifiers.firstOrNull { it.name == "modifier" } ?: modifiers.firstOrNull()
-    }
+fun KtFunction.modifierParameter(config: ComposeKtConfig): KtParameter? {
+    val modifiers = valueParameters.filter { it.isModifier(config) }
+    return modifiers.firstOrNull { it.name == "modifier" } ?: modifiers.firstOrNull()
+}
 
-context(ComposeKtConfig)
-val KtFunction.modifierParameters: List<KtParameter>
-    get() = valueParameters.filter { it.isModifier }
+fun KtFunction.modifierParameters(config: ComposeKtConfig): List<KtParameter> =
+    valueParameters.filter { it.isModifier(config) }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentEmitterReturningValues.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentEmitterReturningValues.kt
@@ -27,7 +27,7 @@ class ContentEmitterReturningValues : ComposeKtVisitor {
             .filterNot { it.hasReceiverType }
 
         // Now we want to get the count of direct emitters in them: the composables we know for a fact that output UI
-        val composableToEmissionCount = with(config) { composables.createDirectComposableToEmissionCountMapping() }
+        val composableToEmissionCount = composables.createDirectComposableToEmissionCountMapping(config)
 
         // Now we can give some extra passes through the list of composables, and try to get a more accurate count.
         // We want to make sure that if these composables are using other composables in this file that emit UI,
@@ -35,7 +35,7 @@ class ContentEmitterReturningValues : ComposeKtVisitor {
         // @Composable fun Comp1() { Text("Hi") }
         // @Composable fun Comp2() { Text("Hola") }
         // @Composable fun Comp3() { Comp1() Comp2() } // This wouldn't be picked up at first, but should after 1 loop
-        val mapping = with(config) { refineComposableToEmissionCountMapping(composableToEmissionCount) }
+        val mapping = refineComposableToEmissionCountMapping(composableToEmissionCount, config)
 
         // Data in currentMapping should have all the # of emissions inferred for each composable in this file,
         // so we want to iterate through all of them

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentTrailingLambda.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentTrailingLambda.kt
@@ -13,9 +13,9 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class ContentTrailingLambda : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) = with(config) {
-        val lambdaTypes = function.containingKtFile.lambdaTypes
-        val composableLambdaTypes = function.containingKtFile.composableLambdaTypes
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        val lambdaTypes = function.containingKtFile.lambdaTypes(config)
+        val composableLambdaTypes = function.containingKtFile.composableLambdaTypes(config)
 
         val candidate = function.valueParameters
             .filter { it.name == "content" }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/LambdaParameterInRestartableEffect.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/LambdaParameterInRestartableEffect.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.psi.KtReferenceExpression
 
 class LambdaParameterInRestartableEffect : ComposeKtVisitor {
     override fun visitFile(file: KtFile, emitter: Emitter, config: ComposeKtConfig) {
-        val lambdaTypes = with(config) { file.lambdaTypes }
+        val lambdaTypes = file.lambdaTypes(config)
         val composables = file.findChildrenByClass<KtFunction>()
             .filter { it.isComposable }
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -23,7 +23,7 @@ class ModifierClickableOrder : ComposeKtVisitor {
     override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         val code = function.bodyBlockExpression ?: return
 
-        val initialModifierNames = with(config) { function.modifierParameters.mapNotNull { it.name } }
+        val initialModifierNames = function.modifierParameters(config).mapNotNull { it.name }
         val modifiers = initialModifierNames.flatMap { code.obtainAllModifierNames(it) }.toSet()
 
         val suspiciousOrderModifiers = code.findChildrenByClass<KtCallExpression>()

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposable.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 class ModifierComposable : ComposeKtVisitor {
 
     override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
-        if (!with(config) { function.isModifierReceiver }) return
+        if (!function.isModifierReceiver(config)) return
 
         emitter.report(function, ComposableModifier)
     }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposed.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierComposed.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
 class ModifierComposed : ComposeKtVisitor {
 
     override fun visitFunction(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
-        if (!with(config) { function.isModifierReceiver }) return
+        if (!function.isModifierReceiver(config)) return
         if (function.isComposable) return
 
         // If using a body expression, we can directly check for it being a call to `composed`

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierMissing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierMissing.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 class ModifierMissing : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) = with(config) {
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         // We want to find all composable functions that:
         //  - emit content
         //  - are not overridden or part of an interface
@@ -30,7 +30,7 @@ class ModifierMissing : ComposeKtVisitor {
             function.isOverride ||
             function.definedInInterface ||
             function.isPreview ||
-            function.isModifierReceiver
+            function.isModifierReceiver(config)
         ) {
             return
         }
@@ -51,10 +51,10 @@ class ModifierMissing : ComposeKtVisitor {
         if (!shouldCheck) return
 
         // If there is a modifier param, we bail
-        if (function.modifierParameter != null) return
+        if (function.modifierParameter(config) != null) return
 
         // In case we didn't find any `modifier` parameters, we check if it emits content and report the error if so.
-        if (function.emitsContent) {
+        if (function.emitsContent(config)) {
             emitter.report(function, MissingModifierContentComposable)
         }
     }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNaming.kt
@@ -13,7 +13,7 @@ class ModifierNaming : ComposeKtVisitor {
 
     override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         // If there is a modifier param, we bail
-        val modifiers = function.valueParameters.filter { with(config) { it.isModifier } }
+        val modifiers = function.valueParameters.filter { it.isModifier(config) }
 
         // If there are no modifiers, or more than one, we don't care as much about the naming
         if (modifiers.isEmpty()) return

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -19,8 +19,8 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
 
 class ModifierNotUsedAtRoot : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) = with(config) {
-        val modifier = function.modifierParameter ?: return
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        val modifier = function.modifierParameter(config) ?: return
 
         // We only care about the main modifier for this rule
         if (modifier.name != "modifier") return
@@ -40,8 +40,8 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
                 callExpression.parents.takeWhile { it != code }
                     .filterIsInstance<KtCallExpression>()
                     // If there is a parent that's a non-content emitter or deny-listed, we don't want to continue
-                    .takeWhile { !it.isInContentEmittersDenylist }
-                    .any { it.emitsContent }
+                    .takeWhile { !it.isInContentEmittersDenylist(config) }
+                    .any { it.emitsContent(config) }
             }
             .mapSecond()
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -20,11 +20,11 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 class ModifierReused : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) = with(config) {
-        if (!function.emitsContent) return
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        if (!function.emitsContent(config)) return
 
         val composableBlockExpression = function.bodyBlockExpression ?: return
-        val initialModifierNames = function.modifierParameters.mapNotNull { it.name }.toSet()
+        val initialModifierNames = function.modifierParameters(config).mapNotNull { it.name }.toSet()
         if (initialModifierNames.isEmpty()) return
 
         initialModifierNames

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierWithoutDefault.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierWithoutDefault.kt
@@ -19,20 +19,20 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class ModifierWithoutDefault : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) = with(config) {
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         if (
             function.definedInInterface ||
             function.isActual ||
             function.isOverride ||
             function.isAbstract ||
             function.isOpen ||
-            function.isModifierReceiver
+            function.isModifierReceiver(config)
         ) {
             return
         }
 
         // Look for modifier params in the composable signature, and if any without a default value is found, error out.
-        function.valueParameters.filter { it.isModifier }
+        function.valueParameters.filter { it.isModifier(config) }
             .filterNot { it.hasDefaultValue() }
             .forEach { modifierParameter ->
                 emitter.report(modifierParameter, MissingModifierDefaultParam, true).ifFix {

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/MultipleContentEmitters.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/MultipleContentEmitters.kt
@@ -30,7 +30,7 @@ class MultipleContentEmitters : ComposeKtVisitor {
             .filterNot { it.hasReceiverType }
 
         // Now we want to get the count of direct emitters in them: the composables we know for a fact that output UI
-        val composableToEmissionCount = with(config) { composables.createDirectComposableToEmissionCountMapping() }
+        val composableToEmissionCount = composables.createDirectComposableToEmissionCountMapping(config)
 
         // We can start showing errors, for composables that emit more than once (from the list of known composables)
         val directEmissionsReported = composableToEmissionCount.filterValues { it > 1 }.keys
@@ -44,7 +44,7 @@ class MultipleContentEmitters : ComposeKtVisitor {
         // @Composable fun Comp1() { Text("Hi") }
         // @Composable fun Comp2() { Text("Hola") }
         // @Composable fun Comp3() { Comp1() Comp2() } // This wouldn't be picked up at first, but should after 1 loop
-        val currentMapping = with(config) { refineComposableToEmissionCountMapping(composableToEmissionCount) }
+        val currentMapping = refineComposableToEmissionCountMapping(composableToEmissionCount, config)
 
         // Here we have the settled data after all the needed passes, so we want to show errors for them,
         // if they were not caught already by the 1st emission loop

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
@@ -12,11 +12,11 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 class ParameterNaming : ComposeKtVisitor {
 
-    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) = with(config) {
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         // For lambda parameters only: if it starts with `on`, we want it to not be in past tense, to be all consistent.
         // E.g. onClick, onTextChange, onValueChange, and a myriad of other examples in the compose foundation code.
 
-        val lambdaTypes = function.containingKtFile.lambdaTypes
+        val lambdaTypes = function.containingKtFile.lambdaTypes(config)
 
         val errors = function.valueParameters
             .filter { it.typeReference?.isLambda(lambdaTypes) == true }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterOrder.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.KtParameter
 class ParameterOrder : ComposeKtVisitor {
 
     override fun visitFile(file: KtFile, emitter: Emitter, config: ComposeKtConfig) {
-        val lambdaTypes = with(config) { file.lambdaTypes }
+        val lambdaTypes = file.lambdaTypes(config)
 
         val composables = file.findChildrenByClass<KtFunction>()
             .filter { it.isComposable }
@@ -53,7 +53,7 @@ class ParameterOrder : ComposeKtVisitor {
             // As ComposeModifierMissingCheck will catch modifiers without a Modifier default, we don't have to care
             // about that case. We will sort the params with defaults so that the modifier(s) go first.
             val sortedWithDefaults = withDefaults.sortedWith(
-                compareByDescending<KtParameter> { with(config) { it.isModifier } }
+                compareByDescending<KtParameter> { it.isModifier(config) }
                     .thenByDescending { it.name == "modifier" },
             )
 


### PR DESCRIPTION
Kotlin 2.0.20 warns about context receiver deprecation, so let's get rid of them preemptively 😢 

This makes me so sad, because I liked context receivers. At some point in the future we'll get context parameters (which look like a good replacement for the usages I typically gave context receivers) but there's going to be a time in between context receivers are deprecated and context params are available, so I'm gonna go the boring route and turn them all into function params :sigh: 

![emotional-damage](https://github.com/user-attachments/assets/431a752c-52c6-44aa-820d-00fdb23ee55a)
