### PR TITLE
Add ContentSlotReused rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -49,6 +49,11 @@ Compose:
     # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically).
     # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
     # treatAsComposableLambda: MyComposableLambdaType
+  ContentSlotReused:
+      active: true
+      # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically).
+      # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
+      # treatAsComposableLambda: MyComposableLambdaType
   DefaultsVisibility:
     active: true
   LambdaParameterEventTrailing:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -236,6 +236,47 @@ fun Profile(user: User, modifier: Modifier = Modifier) {
 
     :material-chevron-right-box: [compose:content-trailing-lambda](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentTrailingLambda.kt) ktlint :material-chevron-right-box: [ContentTrailingLambda](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentTrailingLambda.kt) detekt
 
+### Content slots should not be reused in branching code
+
+Content slot parameters should not be disposed and recomposed when the parent composable changes, structurally or visually (changes that are typically due to branching code).
+
+Developers should ensure that the lifecycle of visible slot parameter composables either matches the lifecycle of the composable accepting the slot or is connected to the slot's visibility within the viewport.
+
+To ensure proper behavior, you could either:
+
+- Use `remember { movableContentOf { ... } }` to make sure the content is preserved correctly; or
+- Create a custom layout where the internal state of the slot is preserved.
+
+```kotlin
+// ❌
+@Composable
+fun Avatar(user: User, content: @Composable () -> Unit) {
+    if (user.isFollower) {
+        content()
+    } else {
+        content()
+    }
+}
+
+// ✅
+@Composable
+fun Avatar(user: User, content: @Composable () -> Unit) {
+    val content = remember { movableContentOf { content() } }
+    if (user.isFollower) {
+        content()
+    } else {
+        content()
+    }
+}
+```
+
+More information: [Lifecycle expectations for slot parameters](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-component-api-guidelines.md#lifecycle-expectations-for-slot-parameters)
+
+!!! info ""
+
+    :material-chevron-right-box: [compose:content-slot-reused](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentSlotReused.kt) ktlint :material-chevron-right-box: [ContentSlotReused](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentSlotReused.kt) detekt
+
+
 ### Avoid using the trailing lambda for event lambdas in UI Composables
 
 In Compose, trailing lambdas in composable functions are typically used for content slots. To avoid confusion and maintain consistency, event lambdas (e.g., `onClick`, `onValueChange`) should generally not be placed in the trailing position.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KotlinUtils.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KotlinUtils.kt
@@ -3,7 +3,8 @@
 package io.nlopez.compose.core.util
 
 import org.jetbrains.kotlin.name.FqName
-import java.util.*
+import org.jetbrains.kotlin.psi.KtElement
+import java.util.Locale
 
 fun <T> T.runIf(value: Boolean, block: T.() -> T): T = if (value) block() else this
 
@@ -49,3 +50,12 @@ private val humps by lazy { "(?<=.)(?=\\p{Upper})".toRegex() }
 
 val KotlinScopeFunctions = setOf("with", "apply", "run", "also", "let")
 val KotlinItObjectScopeFunctions = setOf("let", "also")
+
+fun <T : KtElement> Sequence<T>.uniquePairs(): Sequence<Pair<T, T>> = sequence {
+    val list = toList()
+    for (i in list.indices) {
+        for (j in i + 1 until list.size) {
+            yield(Pair(list[i], list[j]))
+        }
+    }
+}

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentSlotReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ContentSlotReused.kt
@@ -1,0 +1,104 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.compose.core.ComposeKtConfig
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.core.Emitter
+import io.nlopez.compose.core.report
+import io.nlopez.compose.core.util.composableLambdaTypes
+import io.nlopez.compose.core.util.contentSlots
+import io.nlopez.compose.core.util.findChildrenByClass
+import io.nlopez.compose.core.util.findShadowingRedeclarations
+import io.nlopez.compose.core.util.lambdaTypes
+import io.nlopez.compose.core.util.uniquePairs
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtWhenExpression
+import org.jetbrains.kotlin.psi.psiUtil.parents
+
+class ContentSlotReused : ComposeKtVisitor {
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        val lambdaTypes = function.containingKtFile.lambdaTypes(config)
+        val composableLambdaTypes = function.containingKtFile.composableLambdaTypes(config)
+
+        val slots = function.contentSlots(lambdaTypes, composableLambdaTypes)
+            .filter { it.name?.isNotEmpty() == true }
+
+        val slotsWithMultipleUsages = slots.filter { it.name != null }
+            .map { slot -> slot to function.findUsages(slot.name!!) }
+            .filter { (_, usages) -> usages.count() >= 2 }
+
+        // Now that we found some candidates, we need to make sure the slots being reused are in different branches
+        // in the ast tree. We'll need to search for parent ifs, whens, etc.
+        val slotsInDifferentBranches = slotsWithMultipleUsages
+            .filter { (_, usages) -> isSlotUsedInSeparateBranches(usages, function) }
+            .map { (slot, _) -> slot }
+
+        for (slot in slotsInDifferentBranches) {
+            emitter.report(slot, ContentSlotReusedInDifferentBranches)
+        }
+    }
+
+    private fun KtFunction.findUsages(name: String): Sequence<KtCallExpression> =
+        findChildrenByClass<KtCallExpression>().filter { it.calleeExpression?.text == name }
+            // Remove shadowed usages
+            .filter { it.findShadowingRedeclarations(name, this).count() == 0 }
+
+    private fun isSlotUsedInSeparateBranches(slots: Sequence<KtCallExpression>, stopAt: KtFunction): Boolean =
+        slots.uniquePairs()
+            .any { (slot1, slot2) ->
+                findCommonAncestor(slot1, slot2, stopAt).isBranchingElement()
+            }
+
+    private fun findCommonAncestor(slot1: KtCallExpression, slot2: KtCallExpression, stopAt: KtFunction): KtElement {
+        val height1 = slot1.parents.takeWhile { it != stopAt }.count()
+        val height2 = slot2.parents.takeWhile { it != stopAt }.count()
+
+        var current1: KtElement = slot1
+        var current2: KtElement = slot2
+
+        // If the heights are different, we'll need to go up in the one that's deeper until they
+        when {
+            height1 > height2 -> {
+                repeat(height1 - height2) { current1 = current1.parent as KtElement }
+            }
+
+            height1 < height2 -> {
+                repeat(height2 - height1) { current2 = current2.parent as KtElement }
+            }
+        }
+
+        // Traverse up until they are at the same level
+        while (current1 != current2) {
+            current1 = current1.parent as KtElement
+            current2 = current2.parent as KtElement
+        }
+
+        return current1
+    }
+
+    private fun KtElement.isBranchingElement(): Boolean = when (val current = this) {
+        // Always true, if not, the ancestor would have been found in then or in else expressions
+        is KtIfExpression -> true
+        // Always true, if not, the ancestor would have been found in a when entry
+        is KtWhenExpression -> true
+        // Only branching if it's an elvis operator
+        is KtBinaryExpression -> current.operationToken == KtTokens.ELVIS
+        else -> false
+    }
+
+    companion object {
+        val ContentSlotReusedInDifferentBranches = """
+            Content slots should not be reused in different code branches of a composable function (e.g. if/when/elvis).
+
+            You can wrap the usages in a remember { movableContentOf { ... }} block to make sure their internal state is preserved correctly.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#content-slots-should-not-be-reused-in-branching-code for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -16,6 +16,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             CompositionLocalAllowlistCheck(config),
             CompositionLocalNamingCheck(config),
             ContentEmitterReturningValuesCheck(config),
+            ContentSlotReusedCheck(config),
             ContentTrailingLambdaCheck(config),
             DefaultsVisibilityCheck(config),
             LambdaParameterEventTrailingCheck(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheck.kt
@@ -1,0 +1,22 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.rules.ContentSlotReused
+import io.nlopez.compose.rules.DetektRule
+
+class ContentSlotReusedCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by ContentSlotReused() {
+    override val issue: Issue = Issue(
+        id = "ContentSlotReused",
+        severity = Severity.Defect,
+        description = ContentSlotReused.ContentSlotReusedInDifferentBranches,
+        debt = Debt.TEN_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -11,6 +11,8 @@ Compose:
     active: true
   ContentEmitterReturningValues:
     active: true
+  ContentSlotReusedCheck:
+    active: true
   ContentTrailingLambda:
     active: true
   DefaultsVisibility:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheckTest.kt
@@ -1,0 +1,93 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.ContentSlotReused
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ContentSlotReusedCheckTest {
+
+    private val testConfig = TestConfig(
+        "treatAsComposableLambda" to listOf("Potato"),
+        "treatAsLambda" to listOf("Plum"),
+    )
+    private val rule = ContentSlotReusedCheck(testConfig)
+
+    @Test
+    fun `errors when there is a slot being reused in different branches`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(text: String, content: @Composable () -> Unit) {
+                    if (x) content() else content()
+                }
+                @Composable
+                fun B(text: String, content: @Composable () -> Unit) {
+                    when {
+                        x -> content()
+                        else -> content()
+                    }
+                }
+                @Composable
+                fun C(text: String, content: @Composable () -> Unit) {
+                    potato?.let { content() } ?: content()
+                }
+                @Composable
+                fun D(text: String, content: Potato) {
+                    potato?.let { content() } ?: content()
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 21),
+                SourceLocation(6, 21),
+                SourceLocation(13, 21),
+                SourceLocation(17, 21),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ContentSlotReused.ContentSlotReusedInDifferentBranches)
+        }
+    }
+
+    @Test
+    fun `passes when used in a movableContentOf`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: @Composable () -> Unit, text: String) {
+                    val content = remember { movableContentOf { content() } }
+                    if (x) content() else content()
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when content is not composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: () -> Unit, text: String) {
+                    if (x) content() else content()
+                }
+                fun B(content: Plum, text: String) {
+                    if (x) content() else content()
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentTrailingLambdaCheckTest.kt
@@ -94,4 +94,17 @@ class ContentTrailingLambdaCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes when content is not composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: () -> Unit, text: String) {}
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -16,6 +16,7 @@ class ComposeRuleSetProvider :
         RuleProvider { CompositionLocalAllowlistCheck() },
         RuleProvider { CompositionLocalNamingCheck() },
         RuleProvider { ContentEmitterReturningValuesCheck() },
+        RuleProvider { ContentSlotReusedCheck() },
         RuleProvider { ContentTrailingLambdaCheck() },
         RuleProvider { DefaultsVisibilityCheck() },
         RuleProvider { LambdaParameterEventTrailingCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheck.kt
@@ -1,0 +1,14 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.rules.ContentSlotReused
+import io.nlopez.compose.rules.KtlintRule
+
+class ContentSlotReusedCheck :
+    KtlintRule(
+        id = "compose:content-slot-reused",
+        editorConfigProperties = setOf(treatAsLambda, treatAsComposableLambda),
+    ),
+    ComposeKtVisitor by ContentSlotReused()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheckTest.kt
@@ -1,0 +1,102 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ContentSlotReused
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ContentSlotReusedCheckTest {
+
+    private val ruleAssertThat = assertThatRule { ContentSlotReusedCheck() }
+
+    @Test
+    fun `errors when there is a slot being reused in different branches`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(text: String, content: @Composable () -> Unit) {
+                    if (x) content() else content()
+                }
+                @Composable
+                fun B(text: String, content: @Composable () -> Unit) {
+                    when {
+                        x -> content()
+                        else -> content()
+                    }
+                }
+                @Composable
+                fun C(text: String, content: @Composable () -> Unit) {
+                    potato?.let { content() } ?: content()
+                }
+                @Composable
+                fun D(text: String, content: Potato) {
+                    potato?.let { content() } ?: content()
+                }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(treatAsComposableLambda to "Potato")
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 21,
+                    detail = ContentSlotReused.ContentSlotReusedInDifferentBranches,
+                ),
+                LintViolation(
+                    line = 6,
+                    col = 21,
+                    detail = ContentSlotReused.ContentSlotReusedInDifferentBranches,
+                ),
+                LintViolation(
+                    line = 13,
+                    col = 21,
+                    detail = ContentSlotReused.ContentSlotReusedInDifferentBranches,
+                ),
+                LintViolation(
+                    line = 17,
+                    col = 21,
+                    detail = ContentSlotReused.ContentSlotReusedInDifferentBranches,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when used in a movableContentOf`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: @Composable () -> Unit, text: String) {
+                    val content = remember { movableContentOf { content() } }
+                    if (x) content() else content()
+                }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(treatAsComposableLambda to "Potato", treatAsLambda to "Plum")
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when content is not composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: () -> Unit, text: String) {
+                    if (x) content() else content()
+                }
+                fun B(content: Plum, text: String) {
+                    if (x) content() else content()
+                }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(treatAsComposableLambda to "Potato", treatAsLambda to "Plum")
+            .hasNoLintViolations()
+    }
+}

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentTrailingLambdaCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentTrailingLambdaCheckTest.kt
@@ -97,4 +97,16 @@ class ContentTrailingLambdaCheckTest {
             .withEditorConfigOverride(treatAsComposableLambda to "Potato", treatAsLambda to "Plum")
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when content is not composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(content: () -> Unit, text: String) {}
+            """.trimIndent()
+
+        ruleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Adds a detector for slots being used in different branches of a composable function. 

Idea to do this came from https://github.com/slackhq/compose-lints/issues/367 😄 