### PR TITLE
Add PreviewNaming opt-in rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -125,6 +125,11 @@ Compose:
     # treatAsLambda: MyLambdaType
   PreviewAnnotationNaming:
     active: true
+  PreviewNaming:
+    active: false # Opt-in, disabled by default.
+    # -- You can optionally configure the naming strategy for previews.
+    # -- Possible values are: `suffix`, `prefix`, `anywhere`. By default, it will be `suffix`.
+    # previewNamingStrategy: suffix
   PreviewPublic:
     active: true
   RememberMissing:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -189,6 +189,21 @@ The `unstable-collections` rule will flag any usage of any unstable collection (
 compose_disallow_unstable_collections = true
 ```
 
+### Enabling and configuring the preview naming detector
+
+If you want to enforce a naming strategy for previews, you can enable the `compose:preview-naming` rule and configure the `compose_preview_naming_strategy` property in your `.editorconfig` file:
+
+```editorconfig
+[*.{kt,kts}]
+compose_preview_naming_enabled = true
+compose_preview_naming_strategy = suffix
+```
+
+Possible values of `compose_preview_naming_strategy` are:
+- `suffix`: Previews should have `Preview` as suffix.
+- `prefix`: Previews should have `Preview` as prefix.
+- `anywhere`: Previews should contain `Preview` in their names.
+
 ### Disable `standard:function-naming` rule for Composable
 
 The function name for a Composable starts with an uppercase. This causes the ktlint rule `standard:function-naming` to report a violation. This rule can be configured to ignore Composable functions in your `.editorconfig` file:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -645,7 +645,9 @@ More info: [Compose Component API Guidelines](https://github.com/androidx/androi
 
 ## Opt-in rules
 
-> **Note**: These rules are disabled by default, you'll need to explicitly enable them individually in detekt/ktlint.
+!!! note "These rules are disabled by default"
+
+    You'll need to explicitly enable them individually in your project's detekt/ktlint configuration.
 
 ### Don't use Material 2
 
@@ -661,7 +663,9 @@ More info: [Migration to Material 3](https://developer.android.com/develop/ui/co
 
 ### Avoid using unstable collections
 
-> **Note**: This rule will become unnecessary from the Compose version where strong skipping is enabled by default.
+!!! tip "Did you know?"
+
+    You can add the kotlin collections to your stability configuration (`kotlin.collections.*`) to make this rule unnecessary.
 
 Collections are defined as interfaces (e.g. `List<T>`, `Map<T>`, `Set<T>`) in Kotlin, which can't guarantee that they are actually immutable. For example, you could write:
 
@@ -697,3 +701,19 @@ More info: [Jetpack Compose Stability Explained](https://medium.com/androiddevel
 !!! info ""
 
     :material-chevron-right-box: [compose:unstable-collections](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt) ktlint :material-chevron-right-box: [UnstableCollections](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt) detekt
+
+### Naming previews properly
+
+You can configure the naming strategy for previews, so that they follow your project's naming conventions.
+
+By default, enabling this rule will make sure that previews use `Preview` as suffix.
+
+In case you want to change this, you can configure the `previewNamingStrategy` property to one of the following values:
+
+- `suffix`: Previews should have `Preview` as suffix.
+- `prefix`: Previews should have `Preview` as prefix.
+- `anywhere`: Previews should contain `Preview` in their names.
+
+!!! info ""
+
+    :material-chevron-right-box: [compose:preview-naming](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNamign.kt) ktlint :material-chevron-right-box: [PreviewNaming](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNaming.kt) detekt

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Previews.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Previews.kt
@@ -9,4 +9,4 @@ val KtAnnotated.isPreview: Boolean
     get() = annotationEntries.any { it.isPreviewAnnotation }
 
 val KtAnnotationEntry.isPreviewAnnotation: Boolean
-    get() = calleeExpression?.text?.run { contains("Preview") } == true
+    get() = calleeExpression?.text?.contains("Preview") == true

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNaming.kt
@@ -1,0 +1,80 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.compose.core.ComposeKtConfig
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.core.Emitter
+import io.nlopez.compose.core.ifFix
+import io.nlopez.compose.core.util.isPreview
+import org.jetbrains.kotlin.psi.KtFunction
+
+class PreviewNaming : ComposeKtVisitor {
+
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        if (!function.isPreview) return
+
+        val strategy = when (config.getString("previewNamingStrategy", "suffix")) {
+            "suffix" -> PreviewNamingType.Suffix
+            "prefix" -> PreviewNamingType.Prefix
+            "anywhere" -> PreviewNamingType.Anywhere
+            else -> PreviewNamingType.Suffix
+        }
+
+        val name = function.nameAsSafeName.asString()
+        // By default, we expect Preview to be the suffix. It can be configured to be the prefix though.
+
+        when (strategy) {
+            PreviewNamingType.Suffix -> {
+                if (!name.endsWith("Preview")) {
+                    emitter.report(function, PreviewDoesNotEndWithPreview, true).ifFix {
+                        function.setName("${name}Preview")
+                    }
+                }
+            }
+
+            PreviewNamingType.Prefix -> {
+                if (!name.startsWith("Preview")) {
+                    emitter.report(function, PreviewDoesNotStartWithPreview, true).ifFix {
+                        function.setName("Preview$name")
+                    }
+                }
+            }
+
+            PreviewNamingType.Anywhere -> {
+                if (!name.contains("Preview")) {
+                    emitter.report(function, PreviewDoesNotContainPreview, true).ifFix {
+                        // If anywhere is fine, we'll just add it as suffix \_(ツ)_/
+                        function.setName("${name}Preview")
+                    }
+                }
+            }
+        }
+    }
+
+    private enum class PreviewNamingType {
+        Suffix,
+        Prefix,
+        Anywhere,
+    }
+
+    companion object {
+        val PreviewDoesNotStartWithPreview = """
+            Preview functions should have `Preview` as prefix, per your project's configuration.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-previews-properly for more information.
+        """.trimIndent()
+
+        val PreviewDoesNotEndWithPreview = """
+            Preview functions should have `Preview` as suffix, per your project's configuration.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-previews-properly for more information.
+        """.trimIndent()
+
+        val PreviewDoesNotContainPreview = """
+            Preview functions should contain `Preview` in their names, per your project's configuration.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#naming-previews-properly for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -38,6 +38,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             ParameterNamingCheck(config),
             ParameterOrderCheck(config),
             PreviewAnnotationNamingCheck(config),
+            PreviewNamingCheck(config),
             PreviewPublicCheck(config),
             RememberContentMissingCheck(config),
             RememberStateMissingCheck(config),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/PreviewNamingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/PreviewNamingCheck.kt
@@ -1,0 +1,23 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.rules.DetektRule
+import io.nlopez.compose.rules.PreviewNaming
+
+class PreviewNamingCheck(config: Config) :
+    DetektRule(config),
+    ComposeKtVisitor by PreviewNaming() {
+
+    override val issue: Issue = Issue(
+        id = "PreviewNaming",
+        severity = Severity.Style,
+        description = "Enforces a cohesive naming strategy for preview @Composable functions.",
+        debt = Debt.FIVE_MINS,
+    )
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -51,6 +51,8 @@ Compose:
     active: true
   PreviewAnnotationNaming:
     active: true
+  PreviewNaming:
+    active: true
   PreviewPublic:
     active: true
   RememberMissing:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/PreviewNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/PreviewNamingCheckTest.kt
@@ -1,0 +1,118 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import io.nlopez.compose.rules.PreviewNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class PreviewNamingCheckTest {
+
+    private val rule = PreviewNamingCheck(Config.empty)
+
+    @Test
+    fun `fails (suffix)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun A() { }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasStartSourceLocations(
+            SourceLocation(3, 5),
+        )
+        for (error in errors) {
+            assertThat(error).hasMessage(PreviewNaming.PreviewDoesNotEndWithPreview)
+        }
+    }
+
+    @Test
+    fun `fails (prefix)`() {
+        val rule = PreviewNamingCheck(TestConfig("previewNamingStrategy" to "prefix"))
+
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun A() { }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasStartSourceLocations(
+            SourceLocation(3, 5),
+        )
+        for (error in errors) {
+            assertThat(error).hasMessage(PreviewNaming.PreviewDoesNotStartWithPreview)
+        }
+    }
+
+    @Test
+    fun `fails (anywhere)`() {
+        val rule = PreviewNamingCheck(TestConfig("previewNamingStrategy" to "anywhere"))
+
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun A() { }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasStartSourceLocations(
+            SourceLocation(3, 5),
+        )
+        for (error in errors) {
+            assertThat(error).hasMessage(PreviewNaming.PreviewDoesNotContainPreview)
+        }
+    }
+
+    @Test
+    fun `passes (suffix)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun APreview() { }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes (prefix)`() {
+        val rule = PreviewNamingCheck(TestConfig("previewNamingStrategy" to "prefix"))
+
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun PreviewA() { }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes (anywhere)`() {
+        val rule = PreviewNamingCheck(TestConfig("previewNamingStrategy" to "anywhere"))
+
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun BananaPreviewPotato() { }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -38,6 +38,7 @@ class ComposeRuleSetProvider :
         RuleProvider { ParameterNamingCheck() },
         RuleProvider { ParameterOrderCheck() },
         RuleProvider { PreviewAnnotationNamingCheck() },
+        RuleProvider { PreviewNamingCheck() },
         RuleProvider { PreviewPublicCheck() },
         RuleProvider { RememberContentMissingCheck() },
         RuleProvider { RememberStateMissingCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -284,3 +284,32 @@ val modifierMissingIgnoreAnnotated: EditorConfigProperty<String> =
             }
         },
     )
+
+val composePreviewNamingEnabled: EditorConfigProperty<Boolean> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_preview_naming_enabled",
+            "When enabled, preview composables should follow the configured naming strategy.",
+            PropertyValueParser.BOOLEAN_VALUE_PARSER,
+            setOf(true.toString(), false.toString()),
+        ),
+        defaultValue = false,
+    )
+
+val composePreviewNamingStrategy: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_preview_naming_strategy",
+            "The naming strategy for preview composables.",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "suffix",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/PreviewNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/PreviewNamingCheck.kt
@@ -1,0 +1,26 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.core.ComposeKtConfig
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.core.Emitter
+import io.nlopez.compose.rules.KtlintRule
+import io.nlopez.compose.rules.PreviewNaming
+import org.jetbrains.kotlin.psi.KtFunction
+
+class PreviewNamingCheck :
+    KtlintRule(
+        id = "compose:preview-naming",
+        editorConfigProperties = setOf(composePreviewNamingEnabled, composePreviewNamingStrategy),
+    ),
+    ComposeKtVisitor {
+    private val visitor = PreviewNaming()
+
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        // ktlint allows all rules by default, so we'll add an extra param to make sure it's disabled by default
+        if (config.getBoolean("previewNamingEnabled", false)) {
+            visitor.visitComposable(function, emitter, config)
+        }
+    }
+}

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/PreviewNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/PreviewNamingCheckTest.kt
@@ -1,0 +1,156 @@
+// Copyright 2023 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.PreviewNaming
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class PreviewNamingCheckTest {
+
+    private val ruleAssertThat = assertThatRule { PreviewNamingCheck() }
+
+    @Test
+    fun `fails (suffix)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun A() { }
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                composePreviewNamingEnabled to true,
+                composePreviewNamingStrategy to "suffix",
+            )
+            .hasLintViolations(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = PreviewNaming.PreviewDoesNotEndWithPreview,
+                ),
+            )
+            .isFormattedAs(
+                """
+                @Preview
+                @Composable
+                fun APreview() { }
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `fails (prefix)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun A() { }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                composePreviewNamingEnabled to true,
+                composePreviewNamingStrategy to "prefix",
+            )
+            .hasLintViolations(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = PreviewNaming.PreviewDoesNotStartWithPreview,
+                ),
+            )
+            .isFormattedAs(
+                """
+                @Preview
+                @Composable
+                fun PreviewA() { }
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `fails (anywhere)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun A() { }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                composePreviewNamingEnabled to true,
+                composePreviewNamingStrategy to "anywhere",
+            )
+            .hasLintViolations(
+                LintViolation(
+                    line = 3,
+                    col = 5,
+                    detail = PreviewNaming.PreviewDoesNotContainPreview,
+                ),
+            )
+            .isFormattedAs(
+                """
+                @Preview
+                @Composable
+                fun APreview() { }
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `passes (suffix)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun APreview() { }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                composePreviewNamingEnabled to true,
+                composePreviewNamingStrategy to "suffix",
+            )
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes (prefix)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun PreviewA() { }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                composePreviewNamingEnabled to true,
+                composePreviewNamingStrategy to "prefix",
+            )
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes (anywhere)`() {
+        @Language("kotlin")
+        val code =
+            """
+            @Preview
+            @Composable
+            fun BananaPreviewPotato() { }
+            """.trimIndent()
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                composePreviewNamingEnabled to true,
+                composePreviewNamingStrategy to "anywhere",
+            )
+            .hasNoLintViolations()
+    }
+}


### PR DESCRIPTION
Adds an opt-in rule to be able to enforce a naming rule on preview composable functions. It allows users to be able to add `Preview` as suffix, prefix or ensure that's anywhere in the text. It also contains an autofix that adds it for you. As preview composables shouldn't be called by anybody else in your codebase, it should be fine (and if they are called, make better choices lol)

Closes #229