### PR TITLE
Fix KtTypeReference#isComposableLambda

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Lambdas.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Lambdas.kt
@@ -30,7 +30,8 @@ fun KtTypeReference.isComposableLambda(
     null -> false
     is KtFunctionType -> isComposable
     is KtNullableType -> (isComposable && element.isLambda(treatAsLambdaTypes)) ||
-        element.innerType?.isLambda(treatAsComposableLambdaTypes) == true
+        // Only possibility for this to not have a @Composable annotation is for it to be a KtUserType
+        (element.innerType as? KtUserType)?.referencedName in treatAsComposableLambdaTypes
 
     is KtUserType -> (isComposable && element.referencedName in treatAsLambdaTypes) ||
         element.referencedName in treatAsComposableLambdaTypes

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheckTest.kt
@@ -69,20 +69,24 @@ class ContentSlotReusedCheckTest {
         val code =
             """
                 @Composable
-                fun A(text: String, content: (@Composable () -> Unit)? = null) {
+                fun A(text: String, content: @Composable (() -> Unit)? = null) {
                     if (x) content?.invoke() else content?.invoke()
                 }
                 @Composable
-                fun B(text: String, content: (@Composable () -> Unit)? = null) {
+                fun B(text: String, content: @Composable (() -> Unit)? = null) {
                     when {
                         x -> content?.invoke()
                         else -> content?.invoke()
                     }
                 }
                 @Composable
-                fun C(text: String, content: (@Composable () -> Unit)? = null) {
+                fun C(text: String, content: @Composable (() -> Unit)? = null) {
                     val content1 = remember { movableContentOf { content?.invoke() } }
                     val content2 = remember { movableContentOf { content?.invoke() } }
+                }
+                @Composable
+                fun D(content: Potato? = null) {
+                    if (x) content?.invoke() else content?.invoke()
                 }
             """.trimIndent()
 
@@ -92,6 +96,7 @@ class ContentSlotReusedCheckTest {
                 SourceLocation(2, 21),
                 SourceLocation(6, 21),
                 SourceLocation(13, 21),
+                SourceLocation(18, 7),
             )
         for (error in errors) {
             assertThat(error).hasMessage(ContentSlotReused.ContentSlotsShouldNotBeReused)
@@ -125,6 +130,14 @@ class ContentSlotReusedCheckTest {
                 }
                 fun B(content: Plum, text: String) {
                     if (x) content() else content()
+                }
+                @Composable
+                fun C(content: (() -> Unit)? = null) {
+                    if (x) content?.invoke() else content?.invoke()
+                }
+                @Composable
+                fun D(content: Plum? = null) {
+                    if (x) content?.invoke() else content?.invoke()
                 }
             """.trimIndent()
 

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheckTest.kt
@@ -80,24 +80,29 @@ class ContentSlotReusedCheckTest {
         val code =
             """
                 @Composable
-                fun A(text: String, content: (@Composable () -> Unit)? = null) {
+                fun A(text: String, content: @Composable (() -> Unit)? = null) {
                     if (x) content?.invoke() else content?.invoke()
                 }
                 @Composable
-                fun B(text: String, content: (@Composable () -> Unit)? = null) {
+                fun B(text: String, content: @Composable (() -> Unit)? = null) {
                     when {
                         x -> content?.invoke()
                         else -> content?.invoke()
                     }
                 }
                 @Composable
-                fun C(text: String, content: (@Composable () -> Unit)? = null) {
+                fun C(text: String, content: @Composable (() -> Unit)? = null) {
                     val content1 = remember { movableContentOf { content?.invoke() } }
                     val content2 = remember { movableContentOf { content?.invoke() } }
+                }
+                @Composable
+                fun D(content: Potato? = null) {
+                    if (x) content?.invoke() else content?.invoke()
                 }
             """.trimIndent()
 
         ruleAssertThat(code)
+            .withEditorConfigOverride(treatAsComposableLambda to "Potato", treatAsLambda to "Plum")
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(
                     line = 2,
@@ -112,6 +117,11 @@ class ContentSlotReusedCheckTest {
                 LintViolation(
                     line = 13,
                     col = 21,
+                    detail = ContentSlotReused.ContentSlotsShouldNotBeReused,
+                ),
+                LintViolation(
+                    line = 18,
+                    col = 7,
                     detail = ContentSlotReused.ContentSlotsShouldNotBeReused,
                 ),
             )
@@ -145,6 +155,14 @@ class ContentSlotReusedCheckTest {
                 }
                 fun B(content: Plum, text: String) {
                     if (x) content() else content()
+                }
+                @Composable
+                fun C(content: (() -> Unit)? = null) {
+                    if (x) content?.invoke() else content?.invoke()
+                }
+                @Composable
+                fun D(content: Plum? = null) {
+                    if (x) content?.invoke() else content?.invoke()
                 }
             """.trimIndent()
 


### PR DESCRIPTION
`isComposableLambda` logic was flawed when dealing with nullable types. It was basically letting any lambda to return true (regardless of it actually being composable). I've fixed it and added unit tests around cases that would make it trip.

Fixes #346