### PR TITLE
Add test to make sure the detekt default config is correct

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref 
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 
+kaml = "com.charleskorn.kaml:kaml:0.61.0"
+
 junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 assertj = "org.assertj:assertj-core:3.26.3"
@@ -23,6 +25,7 @@ reflections = "org.reflections:reflections:0.10.2"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 mavenPublish = "com.vanniktech.maven.publish:0.29.0"
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
 shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/ComposeKtVisitor.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/ComposeKtVisitor.kt
@@ -7,6 +7,8 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 
 interface ComposeKtVisitor {
+    val isOptIn: Boolean
+        get() = false
 
     fun visitFunction(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {}
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/Material2.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/Material2.kt
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 class Material2 : ComposeKtVisitor {
+    override val isOptIn: Boolean = true
+
     override fun visitFile(file: KtFile, emitter: Emitter, config: ComposeKtConfig) {
         // Allowed elements/apis from material2, in the format of whatever comes after androidx.compose.material
         // For instance, if we want to allow icons, we'll put just `Icons`, or if we only allowed the filled icons,

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNaming.kt
@@ -10,6 +10,7 @@ import io.nlopez.compose.core.util.isPreview
 import org.jetbrains.kotlin.psi.KtFunction
 
 class PreviewNaming : ComposeKtVisitor {
+    override val isOptIn: Boolean = true
 
     override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         if (!function.isPreview) return

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/UnstableCollections.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import java.util.*
 
 class UnstableCollections : ComposeKtVisitor {
+    override val isOptIn: Boolean = true
 
     override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         for (param in function.valueParameters.filter { it.isTypeUnstableCollection }) {

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.shadowJar)
 }
 
@@ -31,4 +32,5 @@ dependencies {
     testImplementation(libs.junit5.params)
     testImplementation(libs.assertj)
     testImplementation(libs.reflections)
+    testImplementation(libs.kaml)
 }

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -11,7 +11,7 @@ Compose:
     active: true
   ContentEmitterReturningValues:
     active: true
-  ContentSlotReusedCheck:
+  ContentSlotReused:
     active: true
   ContentTrailingLambda:
     active: true

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.detekt
 
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlMap
+import com.charleskorn.kaml.YamlScalar
+import com.charleskorn.kaml.yamlMap
 import io.gitlab.arturbosch.detekt.api.Config
 import io.nlopez.compose.rules.DetektRule
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.reflections.Reflections
+import java.io.File
 
 class ComposeRuleSetProviderTest {
 
@@ -31,5 +36,58 @@ class ComposeRuleSetProviderTest {
         assertThat(isOrdered)
             .describedAs("ComposeRuleSetProvider should have the rules in alphabetical order")
             .isTrue()
+    }
+
+    @Test
+    fun `ensure all rules in the package are listed in the default config`() {
+        val rules = ruleSet.rules
+            .asSequence()
+            .filterIsInstance<DetektRule>()
+            .map { it.ruleId to it.isOptIn }
+
+        val optIn = rules.associate { it.first to it.second }
+
+        val ruleIds = rules.map { it.first }.toSet()
+
+        // Grab the config file and read it
+        val defaultConfig = javaClass.classLoader.getResource("config/config.yml")
+        assertThat(defaultConfig).isNotNull()
+        requireNotNull(defaultConfig)
+        val file = File(defaultConfig.toURI())
+
+        // Parse the config file
+        val parsed = Yaml.default.parseToYamlNode(file.readText())
+        val configRules = parsed.yamlMap.get<YamlMap>("Compose")?.entries
+        assertThat(configRules).isNotNull()
+        requireNotNull(configRules)
+
+        // Check that all rules in the package are listed in the config
+        val configRuleIds = configRules.keys.map { it.content }
+        assertThat(configRuleIds)
+            .describedAs { "all rules in the ruleset are listed in the default config" }
+            .containsExactlyInAnyOrderElementsOf(ruleIds)
+
+        // Check that all rules in the package match the active config
+        val ruleIdsWithActiveConfig = configRules
+            .filter { it.value.yamlMap.getKey("active") != null }
+            .mapKeys { it.key.content }
+            .mapValues { it.value.yamlMap.get<YamlScalar>("active")?.toBoolean() }
+
+        assertThat(ruleIdsWithActiveConfig.keys)
+            .describedAs { "all rules in the ruleset are defining whether they are active" }
+            .isEqualTo(ruleIds)
+
+        // Make sure the active config matches the opt-in config of the rule
+        for ((key, value) in ruleIdsWithActiveConfig) {
+            assertThat(optIn).containsKey(key)
+            val isOptIn = optIn[key]!!
+
+            // If it's opt-in, active should be false
+            val shouldBeActive = !isOptIn
+
+            assertThat(value)
+                .describedAs { "Rule $key must be active: $shouldBeActive in the config" }
+                .isEqualTo(shouldBeActive)
+        }
     }
 }


### PR DESCRIPTION
There have been some issues with either forgetting to add stuff to the detekt default config, or screwing up the `active` values (whether they are opt-in or not by default).

I've added a test to prevent this from happening again, which will parse the yaml file and assert that all rules are added to it, and that the active value is correct.