### PR TITLE
Add tests to make sure rules have tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ kaml = "com.charleskorn.kaml:kaml:0.61.0"
 junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 assertj = "org.assertj:assertj-core:3.26.3"
+konsist = "com.lemonappdev:konsist:0.16.1"
 reflections = "org.reflections:reflections:0.10.2"
 
 [plugins]

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -33,4 +33,5 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.reflections)
     testImplementation(libs.kaml)
+    testImplementation(libs.konsist)
 }

--- a/rules/ktlint/build.gradle.kts
+++ b/rules/ktlint/build.gradle.kts
@@ -32,4 +32,5 @@ dependencies {
     testImplementation(libs.junit5.params)
     testImplementation(libs.assertj)
     testImplementation(libs.reflections)
+    testImplementation(libs.konsist)
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProviderTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProviderTest.kt
@@ -2,10 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.ktlint
 
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
+import com.lemonappdev.konsist.api.verify.assertTrue
+import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.KtlintRule
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.reflections.Reflections
+import org.reflections.scanners.Scanners
+import org.reflections.util.ConfigurationBuilder
 
 class ComposeRuleSetProviderTest {
 
@@ -34,5 +40,33 @@ class ComposeRuleSetProviderTest {
         assertThat(isOrdered)
             .describedAs("ComposeRuleSetProvider should have the rules in alphabetical order")
             .isTrue()
+    }
+
+    @Test
+    fun `ensure all available rules have a ktlint rule`() {
+        val ktlintRuleNames = ruleClassesInPackage.map { it.simpleName }
+
+        val commonRulesReflections = Reflections(
+            ConfigurationBuilder()
+                .setClassLoaders(arrayOf(ComposeKtVisitor::class.java.classLoader))
+                .setScanners(Scanners.SubTypes),
+        )
+        val ruleNames = commonRulesReflections.getSubTypesOf(ComposeKtVisitor::class.java).map { it.simpleName }
+
+        for (ruleName in ruleNames) {
+            assertThat(ktlintRuleNames)
+                .describedAs { "$ruleName should have a ktlint rule named ${ruleName}Check" }
+                .contains("${ruleName}Check")
+        }
+    }
+
+    @Test
+    fun `ensure all ktlint rules have a unit test`() {
+        Konsist.scopeFromProduction()
+            .classes()
+            .withAllParentsOf(KtlintRule::class)
+            .assertTrue { clazz ->
+                clazz.testClasses { it.hasNameContaining(clazz.name) }.isNotEmpty()
+            }
     }
 }


### PR DESCRIPTION
This is to make sure external contributors don't forget to add the detekt/ktlint version of the rules (I've had some instances of this, people typically forget to include the ktlint version), and that all rules in both detekt/ktlint have unit tests. 

This would make working in this repo more straightforward, as tools would yell at you if you forget something. It's a lot, and it's getting hard to track, I know 😆 