### PR TITLE
Ignore lambdas that dont return Unit in ContentSlotReused

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallableDeclarations.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallableDeclarations.kt
@@ -52,5 +52,5 @@ fun KtCallableDeclaration.contentSlots(
     treatAsComposableLambdaTypes: Set<String>,
 ): Sequence<KtParameter> = valueParameters.asSequence()
     .filter { parameter ->
-        parameter.typeReference?.isComposableLambda(treatAsLambdaTypes, treatAsComposableLambdaTypes) == true
+        parameter.typeReference?.isComposableUiEmitterLambda(treatAsLambdaTypes, treatAsComposableLambdaTypes) == true
     }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ContentSlotReusedCheckTest.kt
@@ -144,4 +144,24 @@ class ContentSlotReusedCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes when content does not return Unit`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(text: String, content: @Composable () -> String) {
+                    if (x) content() else content()
+                }
+                @Composable
+                fun B(text: String, content: @Composable (() -> String)?) {
+                    if (x) content() else content()
+                }
+
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ContentSlotReusedCheckTest.kt
@@ -170,4 +170,23 @@ class ContentSlotReusedCheckTest {
             .withEditorConfigOverride(treatAsComposableLambda to "Potato", treatAsLambda to "Plum")
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when content does not return Unit`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(text: String, content: @Composable () -> String) {
+                    if (x) content() else content()
+                }
+                @Composable
+                fun B(text: String, content: @Composable (() -> String)?) {
+                    if (x) content() else content()
+                }
+
+            """.trimIndent()
+
+        ruleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Composables that don't return Unit shouldn't be counted as emitting content. `contentSlots` helper will filter them out now, which in turn fixes some `ContentSlotReused` false positives.

Fixes #376 