### PR TITLE
Revert Kotlin to 2.0.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.1.0"
-ktlint = "1.5.0"
+kotlin = "2.0.21"
+ktlint = "1.4.1"
 detekt = "1.23.7"
 junit = "5.11.3"
 


### PR DESCRIPTION
Should fix #396.

Moving back ktlint as well so I can do a release, before bumping it again.