### PR TITLE
kotlin-compiler-embeddable dependencies should be compileOnly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ allprojects {
             when {
                 name == "api" && project.hasProperty("uberJar") -> extendsFrom(this@create)
                 name == "compileOnly" -> extendsFrom(this@create)
+                name == "testImplementation" -> extendsFrom(this@create)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,18 @@ allprojects {
     if (project != rootProject) {
         pluginManager.apply(libs.plugins.mavenPublish.get().pluginId)
     }
+
+    project.configurations.create("compileOnlyOrApi") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+
+        project.configurations.configureEach {
+            when {
+                name == "api" && project.hasProperty("uberJar") -> extendsFrom(this@create)
+                name == "compileOnly" -> extendsFrom(this@create)
+            }
+        }
+    }
 }
 
 tasks.register("printVersion") {

--- a/rules/common/build.gradle.kts
+++ b/rules/common/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.compiler)
+    compileOnlyOrApi(libs.kotlin.compiler)
 
     testImplementation(libs.junit5)
     testImplementation(libs.junit5.params)

--- a/rules/common/build.gradle.kts
+++ b/rules/common/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api(libs.kotlin.compiler)
+    compileOnly(libs.kotlin.compiler)
 
     testImplementation(libs.junit5)
     testImplementation(libs.junit5.params)

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -24,8 +24,8 @@ tasks.shadowJar {
 }
 
 dependencies {
-    api(libs.detekt.core)
-    api(projects.rules.common)
+    compileOnlyOrApi(libs.detekt.core)
+    compileOnlyOrApi(projects.rules.common)
 
     testImplementation(libs.detekt.test)
     testImplementation(libs.junit5)

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.shadowJar {
 }
 
 dependencies {
-    compileOnlyOrApi(libs.detekt.core)
+    api(libs.detekt.core)
     compileOnlyOrApi(projects.rules.common)
 
     testImplementation(libs.detekt.test)
@@ -34,4 +34,5 @@ dependencies {
     testImplementation(libs.reflections)
     testImplementation(libs.kaml)
     testImplementation(libs.konsist)
+    testImplementation(libs.kotlin.compiler)
 }

--- a/rules/ktlint/build.gradle.kts
+++ b/rules/ktlint/build.gradle.kts
@@ -23,8 +23,8 @@ tasks.shadowJar {
 }
 
 dependencies {
-    compileOnly(libs.ktlint.rule.engine)
-    compileOnly(libs.ktlint.cli.ruleset.core)
+    compileOnlyOrApi(libs.ktlint.rule.engine)
+    compileOnlyOrApi(libs.ktlint.cli.ruleset.core)
     api(projects.rules.common)
 
     testImplementation(libs.ktlint.test)

--- a/rules/ktlint/build.gradle.kts
+++ b/rules/ktlint/build.gradle.kts
@@ -23,8 +23,8 @@ tasks.shadowJar {
 }
 
 dependencies {
-    api(libs.ktlint.rule.engine)
-    api(libs.ktlint.cli.ruleset.core)
+    compileOnly(libs.ktlint.rule.engine)
+    compileOnly(libs.ktlint.cli.ruleset.core)
     api(projects.rules.common)
 
     testImplementation(libs.ktlint.test)


### PR DESCRIPTION
After upgrading kotlin version to `2.1.0` kotlin gradle plugin raises warning if `kotlin-compiler-embeddable` is present in the classpath:
```
w: The artifact `org.jetbrains.kotlin:kotlin-compiler-embeddable` is present in the build classpath along Kotlin Gradle plugin.
This may lead to unpredictable and inconsistent behavior.
For more details, see: https://kotl.in/gradle/internal-compiler-symbols
```

According to the output of `buildEnvironment` Gradle task compose-rules add kotlin-compiler-embeddable to the classpath:
```
\--- io.nlopez.compose.rules:ktlint:0.4.22
     +--- com.pinterest.ktlint:ktlint-rule-engine:1.4.1
     |    +--- com.pinterest.ktlint:ktlint-logger:1.4.1
     |    |    +--- dev.drewhamilton.poko:poko-annotations:0.17.2
     |    |    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.17.2
     |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
     |    |    +--- io.github.oshai:kotlin-logging-jvm:7.0.0
     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.0 -> 2.1.0 (*)
     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
     |    +--- dev.drewhamilton.poko:poko-annotations:0.17.2 (*)
     |    +--- com.pinterest.ktlint:ktlint-rule-engine-core:1.4.1
     |    |    +--- com.pinterest.ktlint:ktlint-logger:1.4.1 (*)
     |    |    +--- dev.drewhamilton.poko:poko-annotations:0.17.2 (*)
     |    |    +--- org.jetbrains.kotlin:kotlin-compiler-embeddable:2.0.21
     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
     |    |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:2.0.21
     |    |    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.6.10 -> 1.9.24 (*)
     |    |    |    +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.0.21
     |    |    |    +--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
     |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
     |    |    +--- org.ec4j.core:ec4j-core:1.1.0
     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
     |    +--- org.jetbrains.kotlin:kotlin-compiler-embeddable:2.0.21 (*)
     |    +--- org.ec4j.core:ec4j-core:1.1.0
     |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
     +--- com.pinterest.ktlint:ktlint-cli-ruleset-core:1.4.1
     |    +--- dev.drewhamilton.poko:poko-annotations:0.17.2 (*)
     |    +--- com.pinterest.ktlint:ktlint-rule-engine-core:1.4.1 (*)
     |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
     +--- io.nlopez.compose.rules:common:0.4.22
     |    +--- org.jetbrains.kotlin:kotlin-compiler-embeddable:2.0.21 (*)
     |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
     \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.1.0 (*)
```

after proposed changes:
```
\--- io.nlopez.compose.rules:ktlint:0.4.23-compile-only
     +--- io.nlopez.compose.rules:common:0.4.23-compile-only
     |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 (*)
     \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 (*)
```