### PR TITLE
Ignore nested functions on block emitter computations

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtFunctions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtFunctions.kt
@@ -5,8 +5,11 @@ package io.nlopez.compose.core.util
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
 
 val KtFunction.returnsValue: Boolean
@@ -44,3 +47,6 @@ val KtFunction.isOperator: Boolean
 
 val KtFunction.definedInInterface: Boolean
     get() = ((parent as? KtClassBody)?.parent as? KtClass)?.isInterface() ?: false
+
+val KtNamedFunction.isNested: Boolean
+    get() = parents.takeWhile { it !is KtFile }.any { it is KtNamedFunction }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -443,4 +443,47 @@ class MultipleContentEmittersCheckTest {
             assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
         }
     }
+
+    @Test
+    fun `passes when it's a valid composable but has a local composable function`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    @Composable
+                    fun Potato() {
+                        Text("1")
+                    }
+                    Potato()
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `fails when a composable uses nested functions to emit multiple pieces of content`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    @Composable
+                    fun Potato() {
+                        Text("1")
+                    }
+                    Potato()
+                    Potato()
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(MultipleContentEmitters.MultipleContentEmittersDetected)
+        }
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -496,4 +496,45 @@ class MultipleContentEmittersCheckTest {
             ),
         )
     }
+
+    @Test
+    fun `passes when it's a valid composable with a nested function`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    @Composable
+                    fun Potato() {
+                        Text("1")
+                    }
+                    Potato()
+                }
+            """.trimIndent()
+        emittersRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `fails when a composable uses nested functions to emit multiple pieces of content`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something() {
+                    @Composable
+                    fun Potato() {
+                        Text("1")
+                    }
+                    Potato()
+                    Potato()
+                }
+            """.trimIndent()
+        emittersRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = MultipleContentEmitters.MultipleContentEmittersDetected,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
Added extra checks to ensure things aren't falling through the cracks when attempting to count excessive content emissions when using local/nested functions.

Fixes #424