### PR TITLE
Providing list of allowed Lambda Names for ParameterNaming

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -130,6 +130,8 @@ Compose:
     active: true
     # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
     # treatAsLambda: MyLambdaType
+    # -- You can optionally add your allowed lambda names (e.g., usages from the past found in the official Compose code)
+    # allowedLambda: onSizeChanged, onGloballyPositioned
   PreviewAnnotationNaming:
     active: true
   PreviewNaming:

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -131,7 +131,7 @@ Compose:
     # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
     # treatAsLambda: MyLambdaType
     # -- You can optionally add your allowed lambda names (e.g., usages from the past found in the official Compose code)
-    # allowedLambda: onSizeChanged, onGloballyPositioned
+    # allowedLambdaParameterNames: onSizeChanged, onGloballyPositioned
   PreviewAnnotationNaming:
     active: true
   PreviewNaming:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -92,7 +92,7 @@ compose_allowed_composition_locals = LocalSomething,LocalSomethingElse
 
 ### Providing a list of allowed Composable Lambda Names
 
-For `parameter-naming` rule you can define a list of `Lambda`s that are allowed in your codebase. For example, usages from the past found in the official Compose code.
+For `parameter-naming` rule you can define a list of parameter names for function types that are allowed in your codebase. For example, usages from the past found in the official Compose code.
 
 ```editorconfig
 [*.{kt,kts}]

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -90,6 +90,15 @@ For `compositionlocal-allowlist` rule you can define a list of `CompositionLocal
 compose_allowed_composition_locals = LocalSomething,LocalSomethingElse
 ```
 
+### Providing a list of allowed Composable Lambda Names
+
+For `parameter-naming` rule you can define a list of `Lambda`s that are allowed in your codebase. For example, usages from the past found in the official Compose code.
+
+```editorconfig
+[*.{kt,kts}]
+compose_allowed_composable_lambda_names = onSizeChanged,onGloballyPositioned
+```
+
 ### Ignore annotated functions with specific annotations for missing Modifier checks
 
 In the `modifier-missing-check` rule, you can define a list of annotations that, if present, will make it so the function is exempt from this rule.

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -96,7 +96,7 @@ For `parameter-naming` rule you can define a list of `Lambda`s that are allowed 
 
 ```editorconfig
 [*.{kt,kts}]
-compose_allowed_lambda = onSizeChanged,onGloballyPositioned
+compose_allowed_lambda_parameter_names = onSizeChanged,onGloballyPositioned
 ```
 
 ### Ignore annotated functions with specific annotations for missing Modifier checks

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -96,7 +96,7 @@ For `parameter-naming` rule you can define a list of `Lambda`s that are allowed 
 
 ```editorconfig
 [*.{kt,kts}]
-compose_allowed_composable_lambda_names = onSizeChanged,onGloballyPositioned
+compose_allowed_lambda = onSizeChanged,onGloballyPositioned
 ```
 
 ### Ignore annotated functions with specific annotations for missing Modifier checks

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
@@ -17,16 +17,20 @@ class ParameterNaming : ComposeKtVisitor {
         // E.g. onClick, onTextChange, onValueChange, and a myriad of other examples in the compose foundation code.
 
         val lambdaTypes = function.containingKtFile.lambdaTypes(config)
+        val allowed = config.getSet("allowedLambda", emptySet())
 
         val errors = function.valueParameters
+            .asSequence()
             .filter { it.typeReference?.isLambda(lambdaTypes) == true }
             .filter {
                 // As per why not force lambdas to all start with `on`, we cannot really know when they are used for
                 // lazy initialization purposes -- and also don't want to be overly annoying.
                 it.name?.startsWith("on") == true
             }
+            .filterNot { it.name in allowed }
             .filterNot { it.name in ExceptionsInCompose }
             .filter { it.name?.isPastTense == true }
+            .toList()
 
         for (error in errors) {
             emitter.report(error, LambdaParametersInPresentTense)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ParameterNaming.kt
@@ -17,7 +17,7 @@ class ParameterNaming : ComposeKtVisitor {
         // E.g. onClick, onTextChange, onValueChange, and a myriad of other examples in the compose foundation code.
 
         val lambdaTypes = function.containingKtFile.lambdaTypes(config)
-        val allowed = config.getSet("allowedLambda", emptySet())
+        val allowed = config.getSet("allowedLambdaParameterNames", emptySet())
 
         val errors = function.valueParameters
             .asSequence()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheckTest.kt
@@ -14,6 +14,7 @@ class ParameterNamingCheckTest {
 
     private val testConfig = TestConfig(
         "treatAsLambda" to listOf("Potato"),
+        "allowedLambda" to listOf("onGloballyPositioned", "onSizeChanged"),
     )
     private val rule = ParameterNamingCheck(testConfig)
 
@@ -71,6 +72,22 @@ class ParameterNamingCheckTest {
                     onFocusChanged: () -> Unit,
                     onPlaced: (LayoutCoordinates) -> Unit,
                     onValueChangeFinished: () -> Unit,
+                ) {}
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when a param lambda is in the past tense but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(
+                    onSizeChanged: (Int) -> Unit,
+                    onGloballyPositioned: () -> Unit,
                 ) {}
             """.trimIndent()
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ParameterNamingCheckTest.kt
@@ -14,7 +14,7 @@ class ParameterNamingCheckTest {
 
     private val testConfig = TestConfig(
         "treatAsLambda" to listOf("Potato"),
-        "allowedLambda" to listOf("onGloballyPositioned", "onSizeChanged"),
+        "allowedLambdaParameterNames" to listOf("onGloballyPositioned", "onSizeChanged"),
     )
     private val rule = ParameterNamingCheck(testConfig)
 

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -259,7 +259,7 @@ val disallowMaterial2: EditorConfigProperty<Boolean> =
 val allowedLambda: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
-            "compose_allowed_composable_lambda_names",
+            "compose_allowed_lambda",
             "A comma separated list of lambda name that are allowed",
             PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -256,10 +256,10 @@ val disallowMaterial2: EditorConfigProperty<Boolean> =
         defaultValue = false,
     )
 
-val allowedLambda: EditorConfigProperty<String> =
+val allowedLambdaParameterNames: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
-            "compose_allowed_lambda",
+            "compose_allowed_lambda_parameter_names",
             "A comma separated list of lambda name that are allowed",
             PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -259,7 +259,7 @@ val disallowMaterial2: EditorConfigProperty<Boolean> =
 val allowedLambda: EditorConfigProperty<String> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
-            "compose_allowed_lambda",
+            "compose_allowed_composable_lambda_names",
             "A comma separated list of lambda name that are allowed",
             PropertyValueParser.IDENTITY_VALUE_PARSER,
             emptySet(),

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -256,6 +256,24 @@ val disallowMaterial2: EditorConfigProperty<Boolean> =
         defaultValue = false,
     )
 
+val allowedLambda: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_allowed_lambda",
+            "A comma separated list of lambda name that are allowed",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> ""
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs()
+            }
+        },
+    )
+
 val disallowUnstableCollections: EditorConfigProperty<Boolean> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.compose.rules.ParameterNaming
 class ParameterNamingCheck :
     KtlintRule(
         id = "compose:parameter-naming",
-        editorConfigProperties = setOf(treatAsLambda, allowedLambda),
+        editorConfigProperties = setOf(treatAsLambda, allowedLambdaParameterNames),
     ),
     ComposeKtVisitor by ParameterNaming()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.compose.rules.ParameterNaming
 class ParameterNamingCheck :
     KtlintRule(
         id = "compose:parameter-naming",
-        editorConfigProperties = setOf(treatAsLambda),
+        editorConfigProperties = setOf(treatAsLambda, allowedLambda),
     ),
     ComposeKtVisitor by ParameterNaming()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
@@ -88,4 +88,23 @@ class ParameterNamingCheckTest {
             )
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when a param lambda is in the past tense but it's in the allowlist`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun A(
+                    onSizeChanged: (Int) -> Unit,
+                ) {}
+            """.trimIndent()
+
+        ruleAssertThat(code)
+            .withEditorConfigOverride(
+                treatAsLambda to "Potato",
+                allowedLambda to "onSizeChanged",
+            )
+            .hasNoLintViolations()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
@@ -96,14 +96,15 @@ class ParameterNamingCheckTest {
             """
                 @Composable
                 fun A(
-                    onSizeChanged: (Int) -> Unit,
+                    onSizeChanged: () -> Unit,
+                    onGloballyPositioned: () -> Unit,
                 ) {}
             """.trimIndent()
 
         ruleAssertThat(code)
             .withEditorConfigOverride(
                 treatAsLambda to "Potato",
-                allowedLambda to "onSizeChanged",
+                allowedLambda to "onSizeChanged,onGloballyPositioned",
             )
             .hasNoLintViolations()
     }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterNamingCheckTest.kt
@@ -104,7 +104,7 @@ class ParameterNamingCheckTest {
         ruleAssertThat(code)
             .withEditorConfigOverride(
                 treatAsLambda to "Potato",
-                allowedLambda to "onSizeChanged,onGloballyPositioned",
+                allowedLambdaParameterNames to "onSizeChanged,onGloballyPositioned",
             )
             .hasNoLintViolations()
     }


### PR DESCRIPTION
Compose contains too many names that use past verbs, so I decided to allow these names.

Maybe it's worth renaming the new field; I'm open to suggestions :)