### PR TITLE
[WIP] Support separate kotlin compiler versions for detekt and ktlint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Deploy to Sonatype
-        run: ./gradlew clean publish --no-parallel --no-daemon --no-configuration-cache --stacktrace
+        run: ./gradlew clean :rules:ktlint:publish :rules:detekt:publish --no-parallel --no-daemon --no-configuration-cache --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
-kotlin = "2.1.20"
+kotlin = "2.1.20" # Used for the actual coding
 ktlint = "1.5.0"
+kotlin-ktlint = "2.1.0"
 detekt = "1.23.8"
+kotlin-detekt = "2.0.20"
 junit = "5.11.4"
 
 [libraries]
@@ -15,6 +17,8 @@ detekt-core = { module = "io.gitlab.arturbosch.detekt:detekt-core", version.ref 
 detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
+kotlin-compiler-detekt = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-detekt" }
+kotlin-compiler-ktlint = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-ktlint" }
 
 kaml = "com.charleskorn.kaml:kaml:0.81.0"
 

--- a/rules/common-detekt/build.gradle.kts
+++ b/rules/common-detekt/build.gradle.kts
@@ -1,0 +1,23 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+    compileOnlyOrApi(libs.kotlin.compiler.detekt)
+
+    testImplementation(libs.junit5)
+    testImplementation(libs.junit5.params)
+    testImplementation(libs.assertj)
+}
+
+// Include the source code from the main common module
+sourceSets {
+    main {
+        kotlin.srcDirs("../common/src/main/kotlin")
+    }
+    test {
+        kotlin.srcDirs("../common/src/test/kotlin")
+    }
+}

--- a/rules/common-detekt/gradle.properties
+++ b/rules/common-detekt/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=common-detekt
+POM_NAME=Compose rules linter agnostic detectors (Detekt variant) 

--- a/rules/common-ktlint/build.gradle.kts
+++ b/rules/common-ktlint/build.gradle.kts
@@ -1,0 +1,23 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+    compileOnlyOrApi(libs.kotlin.compiler.ktlint)
+
+    testImplementation(libs.junit5)
+    testImplementation(libs.junit5.params)
+    testImplementation(libs.assertj)
+}
+
+// Include the source code from the main common module
+sourceSets {
+    main {
+        kotlin.srcDirs("../common/src/main/kotlin")
+    }
+    test {
+        kotlin.srcDirs("../common/src/test/kotlin")
+    }
+}

--- a/rules/common-ktlint/gradle.properties
+++ b/rules/common-ktlint/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=common-ktlint
+POM_NAME=Compose rules linter agnostic detectors (Ktlint variant) 

--- a/rules/common/gradle.properties
+++ b/rules/common/gradle.properties
@@ -1,2 +1,0 @@
-POM_ARTIFACT_ID=common
-POM_NAME=Compose rules linter agnostic detectors

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.shadowJar {
 
 dependencies {
     api(libs.detekt.core)
-    compileOnlyOrApi(projects.rules.common)
+    compileOnlyOrApi(projects.rules.commonDetekt)
 
     testImplementation(libs.detekt.test)
     testImplementation(libs.junit5)
@@ -34,5 +34,5 @@ dependencies {
     testImplementation(libs.reflections)
     testImplementation(libs.kaml)
     testImplementation(libs.konsist)
-    testImplementation(libs.kotlin.compiler)
+    testImplementation(libs.kotlin.compiler.detekt)
 }

--- a/rules/ktlint/build.gradle.kts
+++ b/rules/ktlint/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.shadowJar {
 dependencies {
     compileOnlyOrApi(libs.ktlint.rule.engine)
     compileOnlyOrApi(libs.ktlint.cli.ruleset.core)
-    api(projects.rules.common)
+    api(projects.rules.commonKtlint)
 
     testImplementation(libs.ktlint.test)
     testImplementation(libs.junit5)
@@ -33,4 +33,5 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.reflections)
     testImplementation(libs.konsist)
+    testImplementation(libs.kotlin.compiler.ktlint)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,8 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "compose-rules"
 include(
     ":rules:common",
+    ":rules:common-detekt",
+    ":rules:common-ktlint",
     ":rules:detekt",
     ":rules:ktlint",
 )


### PR DESCRIPTION
Vibe coding my way onto supporting different kotlin compiler versions in `:rules:detekt` and `:rules:ktlint`, mainly due to detekt being increasingly behind in their supported kotlin versions (and ktlint being fast, which kind of forces my hand to do some releases to support them better).

I want to be able to release versions, so something like this needs to happen. Sadly, my gradle-fu is rusty AF. 