### PR TITLE
Switch shadow to com.gradleup.shadow

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,4 +36,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 mavenPublish = "com.vanniktech.maven.publish:0.34.0"
 spotless = { id = "com.diffplug.spotless", version = "7.2.1" }
-shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+shadowJar = { id = "com.gradleup.shadow", version = "9.0.0-rc3" }


### PR DESCRIPTION
Old shadow plugin versions won't work for gradle 9. Updating to https://github.com/GradleUp/shadow