### PR TITLE
Add new default ViewModel factories

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelInjection.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ViewModelInjection.kt
@@ -157,6 +157,10 @@ class ViewModelInjection : ComposeKtVisitor {
                 "mavericksViewModel",
                 // Tangle (Anvil extensions)
                 "tangleViewModel",
+                // Metro (expected name)
+                "metroViewModel",
+                // Anvil (expected name)
+                "anvilViewModel",
             )
         }
 


### PR DESCRIPTION
A couple new names I've seen in the wild, even though I don't think they belong to a specific library, they are typical names.