### PR TITLE
Add real world samples for ktlint and detekt and use as integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,34 @@ jobs:
             **/build/test-results/*
             **/build/reports/*
 
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+            distribution: 'zulu'
+            java-version: 24
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - uses: gradle/actions/setup-gradle@v5
+
+      - name: Build rule artifacts
+        run: ./gradlew :rules:detekt:assemble :rules:ktlint:assemble
+
+      - name: Test detekt sample
+        run: ./scripts/test-detekt-sample.sh
+
+      - name: Test ktlint sample
+        run: ./scripts/test-ktlint-sample.sh
+
   deploy:
     if: github.event_name == 'push' && github.repository == 'mrmans0n/compose-rules'
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,14 @@ allprojects {
         val ktlintVersion = libs.versions.ktlint.get()
         kotlin {
             target("**/*.kt")
+            targetExclude("**/samples/**/*.kt")
             ktlint(ktlintVersion)
 
             licenseHeaderFile(rootProject.file("spotless/copyright.txt"))
         }
         kotlinGradle {
             target("*.kts")
+            targetExclude("**/samples/**/*.kts")
             ktlint(ktlintVersion)
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,9 @@ kotlin-detekt = "2.0.20" # Update only when detekt version updates
 junit = "5.14.1"
 junit-platform = "1.14.1"
 
+# Compose BOM (for samples)
+compose-bom = "2024.12.01"
+
 [libraries]
 ktlint-core = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
 ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint" }
@@ -23,6 +26,12 @@ kotlin-compiler-ktlint = { module = "org.jetbrains.kotlin:kotlin-compiler-embedd
 
 kaml = "com.charleskorn.kaml:kaml:0.102.0"
 
+# Compose libraries (for samples - versions managed by BOM)
+compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+compose-runtime = { module = "androidx.compose.runtime:runtime" }
+compose-foundation = { module = "androidx.compose.foundation:foundation" }
+compose-material3 = { module = "androidx.compose.material3:material3" }
+
 junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
@@ -34,6 +43,8 @@ reflections = "org.reflections:reflections:0.10.2"
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 mavenPublish = "com.vanniktech.maven.publish:0.35.0"
 spotless = { id = "com.diffplug.spotless", version = "8.1.0" }
 shadowJar = { id = "com.gradleup.shadow", version = "9.0.2" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,0 +1,8 @@
+# Build outputs
+**/build/
+**/.gradle/
+
+# IDE
+**/.idea/
+**/*.iml
+

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,83 @@
+# Sample Projects
+
+This directory contains sample projects used to verify that the compose-rules work correctly with both detekt and ktlint/spotless in CI.
+
+## Structure
+
+- **detekt-sample/** - A minimal project configured to use detekt with compose-rules
+- **ktlint-sample/** - A minimal project configured to use spotless/ktlint with compose-rules
+
+Each sample contains separate files for different intentional violations to ensure each rule type is tested.
+
+## Intentional Violations
+
+Each sample project contains separate violation files:
+
+| File | Rule | Description |
+|------|------|-------------|
+| `ModifierMissingViolation.kt` | ModifierMissing | Public composable without a Modifier parameter |
+| `RememberMissingViolation.kt` | RememberMissing | Using `mutableStateOf` without `remember` |
+| `MutableParamsViolation.kt` | MutableParams | Using mutable `ArrayList` as a parameter |
+| `NamingViolation.kt` | ComposableNaming | Composable returning a value with uppercase name |
+| `ParameterNamingViolation.kt` | ParameterNaming | Lambda parameter with past tense (`onClicked` vs `onClick`) |
+| `MultipleEmittersViolation.kt` | MultipleEmitters | Multiple content emitters in one composable |
+
+**Note:** Due to a limitation in Spotless, the ktlint sample only reports one lint error per file. By splitting violations into separate files, we ensure each rule type is validated.
+
+## Testing Locally
+
+The samples use the root project's Gradle wrapper and version catalog.
+
+### Using Validation Scripts (Recommended)
+
+The `scripts/` directory contains validation scripts that run the samples and verify the expected rule violations are detected:
+
+```bash
+# Test detekt sample
+./scripts/test-detekt-sample.sh
+
+# Test ktlint sample
+./scripts/test-ktlint-sample.sh
+```
+
+These scripts return exit code 0 only if all expected compose-rules violations are found, making them suitable for CI.
+
+### Manual Testing
+
+#### Detekt Sample
+
+```bash
+cd samples/detekt-sample
+../../gradlew check
+```
+
+This should fail with compose-rules violations detected (plus some standard detekt violations).
+
+#### Ktlint Sample
+
+```bash
+cd samples/ktlint-sample
+../../gradlew spotlessCheck
+```
+
+This should fail with compose-rules violations detected (6 lint errors, one per file).
+
+## CI Integration
+
+The validation scripts in `scripts/` can be used in CI:
+
+```yaml
+- name: Test detekt sample
+  run: ./scripts/test-detekt-sample.sh
+
+- name: Test ktlint sample
+  run: ./scripts/test-ktlint-sample.sh
+```
+
+These scripts:
+1. Run the appropriate Gradle task on the sample project
+2. Parse the output to verify specific rule IDs are present
+3. Return exit code 0 only if all expected violations are detected
+4. Return non-zero if rules are missing or if the build passes unexpectedly
+
+This approach ensures that CI distinguishes between "rules working correctly" and other failures (compilation errors, configuration issues, etc.).

--- a/samples/detekt-sample/build.gradle.kts
+++ b/samples/detekt-sample/build.gradle.kts
@@ -1,0 +1,46 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+import java.util.Properties
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.detekt)
+}
+
+// Get compose-rules version from root project's gradle.properties
+val composeRulesVersion: String by lazy {
+    val props = Properties()
+    file("../../gradle.properties").inputStream().use { props.load(it) }
+    props.getProperty("VERSION_NAME")
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.runtime)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.material3)
+
+    // Add compose-rules detekt plugin
+    detektPlugins("io.nlopez.compose.rules:detekt:$composeRulesVersion")
+}
+
+detekt {
+    config.setFrom(files("detekt.yml"))
+    buildUponDefaultConfig = true
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+}

--- a/samples/detekt-sample/detekt.yml
+++ b/samples/detekt-sample/detekt.yml
@@ -1,0 +1,101 @@
+# Detekt configuration for testing compose-rules
+# All Compose rules are enabled to catch violations
+
+# Recommended detekt configuration for Compose projects
+# See: https://detekt.dev/docs/introduction/compose
+
+naming:
+  FunctionNaming:
+    # Allow PascalCase for @Composable functions that return Unit
+    ignoreAnnotated:
+      - 'Composable'
+  TopLevelPropertyNaming:
+    # Compose style: PascalCase for top-level constants (e.g., FooPadding instead of FOO_PADDING)
+    constantPattern: '[A-Z][A-Za-z0-9]*'
+
+complexity:
+  LongParameterList:
+    # Composables often have many parameters with default values
+    ignoreDefaultParameters: true
+    functionThreshold: 10
+  TooManyFunctions:
+    # Don't count @Preview functions toward the limit
+    ignoreAnnotatedFunctions:
+      - 'Preview'
+
+style:
+  MagicNumber:
+    # Allow Color(0xFFEA6D7E) style declarations
+    ignorePropertyDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+  UnusedPrivateMember:
+    # Don't flag @Preview composables as unused
+    ignoreAnnotated:
+      - 'Preview'
+
+Compose:
+  ComposableAnnotationNaming:
+    active: true
+  ComposableNaming:
+    active: true
+  ComposableParamOrder:
+    active: true
+  CompositionLocalAllowlist:
+    active: true
+  CompositionLocalNaming:
+    active: true
+  ContentEmitterReturningValues:
+    active: true
+  ContentTrailingLambda:
+    active: true
+  ContentSlotReused:
+    active: true
+  DefaultsVisibility:
+    active: true
+  LambdaParameterEventTrailing:
+    active: true
+  LambdaParameterInRestartableEffect:
+    active: true
+  Material2:
+    active: false
+  ModifierClickableOrder:
+    active: true
+  ModifierComposed:
+    active: true
+  ModifierMissing:
+    active: true
+  ModifierNaming:
+    active: true
+  ModifierNotUsedAtRoot:
+    active: true
+  ModifierReused:
+    active: true
+  ModifierWithoutDefault:
+    active: true
+  MultipleEmitters:
+    active: true
+  MutableParams:
+    active: true
+  MutableStateAutoboxing:
+    active: true
+  MutableStateParam:
+    active: true
+  ParameterNaming:
+    active: true
+  PreviewAnnotationNaming:
+    active: true
+  PreviewNaming:
+    active: false
+  PreviewPublic:
+    active: true
+  RememberMissing:
+    active: true
+  RememberContentMissing:
+    active: true
+  UnstableCollections:
+    active: false
+  ViewModelForwarding:
+    active: true
+  ViewModelInjection:
+    active: true
+

--- a/samples/detekt-sample/gradle.properties
+++ b/samples/detekt-sample/gradle.properties
@@ -1,0 +1,3 @@
+# Turn on parallel compilation and caching
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/samples/detekt-sample/settings.gradle.kts
+++ b/samples/detekt-sample/settings.gradle.kts
@@ -1,0 +1,32 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        google()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+    // Use the version catalog from the root project
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "detekt-sample"
+
+// Include the parent project as a composite build to reference the rules
+includeBuild("../..") {
+    dependencySubstitution {
+        substitute(module("io.nlopez.compose.rules:detekt")).using(project(":rules:detekt"))
+    }
+}

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/ModifierMissingViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/ModifierMissingViolation.kt
@@ -1,0 +1,14 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+// Violation: Missing Modifier parameter (ModifierMissing)
+// Public composables should have a Modifier parameter
+@Composable
+fun ViolationMissingModifier() {
+    Text("Hello World")
+}
+

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/MultipleEmittersViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/MultipleEmittersViolation.kt
@@ -1,0 +1,20 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+// Violation: Multiple content emitters (MultipleEmitters)
+// A composable should emit content only once
+@Composable
+fun ViolationMultipleEmitters(modifier: Modifier = Modifier) {
+    Text("First emitter")
+    Text("Second emitter")
+    Column(modifier = modifier) {
+        Text("Third emitter")
+    }
+}
+

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/MutableParamsViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/MutableParamsViolation.kt
@@ -1,0 +1,20 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+// Violation: Mutable parameter (MutableParams)
+// Using ArrayList which is mutable
+@Composable
+fun ViolationMutableParameter(items: ArrayList<String>, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        items.forEach { item ->
+            Text(item)
+        }
+    }
+}
+

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/NamingViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/NamingViolation.kt
@@ -1,0 +1,14 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.runtime.Composable
+
+// Violation: Uppercase composable returning value (ComposableNaming)
+// Composables that return values should be lowercase
+@Composable
+fun ComputedValue(): Int {
+    val result = 42
+    return result
+}
+

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/ParameterNamingViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/ParameterNamingViolation.kt
@@ -1,0 +1,21 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+// Violation: Past-tense lambda parameter (ParameterNaming)
+// Lambda parameters should use present tense (onClick, not onClicked)
+@Composable
+fun ViolationPastTenseLambda(
+    onClicked: () -> Unit, // Should be: onClick
+    modifier: Modifier = Modifier,
+) {
+    Button(onClick = onClicked, modifier = modifier) {
+        Text("Click me")
+    }
+}
+

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/RememberMissingViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/RememberMissingViolation.kt
@@ -1,0 +1,19 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+
+// Violation: Missing remember for mutableStateOf (RememberMissing)
+@Composable
+fun ViolationMissingRemember(modifier: Modifier = Modifier) {
+    val count = mutableStateOf(0) // Should be: remember { mutableStateOf(0) }
+    Button(onClick = { count.value++ }) {
+        Text("Count: ${count.value}")
+    }
+}
+

--- a/samples/ktlint-sample/.editorconfig
+++ b/samples/ktlint-sample/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig configuration for testing compose-rules with ktlint
+root = true
+
+[*.{kt,kts}]
+# Disable the standard function-naming rule for Composables
+ktlint_function_naming_ignore_when_annotated_with = Composable
+
+# Compose-specific configurations can be added here if needed
+# For example:
+# compose_content_emitters = MyCustomComposable
+# compose_allowed_composable_function_names = .*Presenter
+

--- a/samples/ktlint-sample/build.gradle.kts
+++ b/samples/ktlint-sample/build.gradle.kts
@@ -1,0 +1,52 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+import java.util.Properties
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.spotless)
+}
+
+// Get compose-rules version from root project's gradle.properties
+val composeRulesVersion: String by lazy {
+    val props = Properties()
+    file("../../gradle.properties").inputStream().use { props.load(it) }
+    props.getProperty("VERSION_NAME")
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.runtime)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.material3)
+}
+
+spotless {
+    kotlin {
+        target("**/*.kt")
+        ktlint(libs.versions.ktlint.get())
+            .setEditorConfigPath("${project.rootDir}/.editorconfig")
+            .customRuleSets(
+                listOf(
+                    // Add compose-rules ktlint ruleset
+                    "io.nlopez.compose.rules:ktlint:$composeRulesVersion"
+                )
+            )
+    }
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+}

--- a/samples/ktlint-sample/gradle.properties
+++ b/samples/ktlint-sample/gradle.properties
@@ -1,0 +1,3 @@
+# Turn on parallel compilation and caching
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/samples/ktlint-sample/settings.gradle.kts
+++ b/samples/ktlint-sample/settings.gradle.kts
@@ -1,0 +1,32 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        google()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+    // Use the version catalog from the root project
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "ktlint-sample"
+
+// Include the parent project as a composite build to reference the rules
+includeBuild("../..") {
+    dependencySubstitution {
+        substitute(module("io.nlopez.compose.rules:ktlint")).using(project(":rules:ktlint"))
+    }
+}

--- a/samples/ktlint-sample/src/main/kotlin/com/example/violations/ModifierMissingViolation.kt
+++ b/samples/ktlint-sample/src/main/kotlin/com/example/violations/ModifierMissingViolation.kt
@@ -1,0 +1,14 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+// Violation: Missing Modifier parameter (ModifierMissing)
+// Public composables should have a Modifier parameter
+@Composable
+fun ViolationMissingModifier() {
+    Text("Hello World")
+}
+

--- a/samples/ktlint-sample/src/main/kotlin/com/example/violations/MultipleEmittersViolation.kt
+++ b/samples/ktlint-sample/src/main/kotlin/com/example/violations/MultipleEmittersViolation.kt
@@ -1,0 +1,20 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+// Violation: Multiple content emitters (MultipleEmitters)
+// A composable should emit content only once
+@Composable
+fun ViolationMultipleEmitters(modifier: Modifier = Modifier) {
+    Text("First emitter")
+    Text("Second emitter")
+    Column(modifier = modifier) {
+        Text("Third emitter")
+    }
+}
+

--- a/samples/ktlint-sample/src/main/kotlin/com/example/violations/MutableParamsViolation.kt
+++ b/samples/ktlint-sample/src/main/kotlin/com/example/violations/MutableParamsViolation.kt
@@ -1,0 +1,20 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+// Violation: Mutable parameter (MutableParameters)
+// Using ArrayList which is mutable
+@Composable
+fun ViolationMutableParameter(items: ArrayList<String>, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        items.forEach { item ->
+            Text(item)
+        }
+    }
+}
+

--- a/samples/ktlint-sample/src/main/kotlin/com/example/violations/NamingViolation.kt
+++ b/samples/ktlint-sample/src/main/kotlin/com/example/violations/NamingViolation.kt
@@ -1,0 +1,13 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.runtime.Composable
+
+// Violation: Uppercase composable returning value (Naming)
+// Composables that return values should be lowercase
+@Composable
+fun ComputedValue(): Int {
+    val result = 42
+    return result
+}

--- a/samples/ktlint-sample/src/main/kotlin/com/example/violations/ParameterNamingViolation.kt
+++ b/samples/ktlint-sample/src/main/kotlin/com/example/violations/ParameterNamingViolation.kt
@@ -1,0 +1,21 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+// Violation: Past-tense lambda parameter (ParameterNaming)
+// Lambda parameters should use present tense (onClick, not onClicked)
+@Composable
+fun ViolationPastTenseLambda(
+    onClicked: () -> Unit, // Should be: onClick
+    modifier: Modifier = Modifier,
+) {
+    Button(onClick = onClicked, modifier = modifier) {
+        Text("Click me")
+    }
+}
+

--- a/samples/ktlint-sample/src/main/kotlin/com/example/violations/RememberMissingViolation.kt
+++ b/samples/ktlint-sample/src/main/kotlin/com/example/violations/RememberMissingViolation.kt
@@ -1,0 +1,19 @@
+// Copyright 2024 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+
+// Violation: Missing remember for mutableStateOf (RememberStateMissing)
+@Composable
+fun ViolationMissingRemember(modifier: Modifier = Modifier) {
+    val count = mutableStateOf(0) // Should be: remember { mutableStateOf(0) }
+    Button(onClick = { count.value++ }) {
+        Text("Count: ${count.value}")
+    }
+}
+

--- a/scripts/test-detekt-sample.sh
+++ b/scripts/test-detekt-sample.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nacho Lopez
+# SPDX-License-Identifier: Apache-2.0
+#
+# Script to validate that the detekt sample project correctly detects compose-rules violations.
+# Returns 0 if all expected violations are found, non-zero otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SAMPLE_DIR="$ROOT_DIR/samples/detekt-sample"
+
+echo "=== Testing detekt sample ==="
+echo "Running detekt check on sample project..."
+
+# Run detekt and capture output (expecting it to fail with violations)
+set +e
+OUTPUT=$("$ROOT_DIR/gradlew" -p "$SAMPLE_DIR" check 2>&1)
+EXIT_CODE=$?
+set -e
+
+# Expected compose-rules violations (rule IDs that should appear in output)
+EXPECTED_RULES=(
+    "ModifierMissing"
+    "RememberMissing"
+    "MutableParams"
+    "ComposableNaming"
+    "ParameterNaming"
+    "MultipleEmitters"
+    "MutableStateAutoboxing"
+)
+
+echo ""
+echo "Validating expected rule violations..."
+
+MISSING_RULES=()
+FOUND_RULES=()
+
+for rule in "${EXPECTED_RULES[@]}"; do
+    if echo "$OUTPUT" | grep -q "\[$rule\]"; then
+        FOUND_RULES+=("$rule")
+        echo "  ✓ Found: $rule"
+    else
+        MISSING_RULES+=("$rule")
+        echo "  ✗ Missing: $rule"
+    fi
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Found ${#FOUND_RULES[@]}/${#EXPECTED_RULES[@]} expected rule violations"
+
+if [[ ${#MISSING_RULES[@]} -gt 0 ]]; then
+    echo ""
+    echo "ERROR: The following expected rules were NOT detected:"
+    for rule in "${MISSING_RULES[@]}"; do
+        echo "  - $rule"
+    done
+    echo ""
+    echo "This could indicate:"
+    echo "  1. A rule is broken or disabled"
+    echo "  2. The sample violation file was modified"
+    echo "  3. The rule ID changed"
+    echo ""
+    echo "Full output:"
+    echo "----------------------------------------"
+    echo "$OUTPUT"
+    echo "----------------------------------------"
+    exit 1
+fi
+
+# Also verify the build actually failed (not a false positive from a passing build)
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo ""
+    echo "ERROR: The detekt check passed unexpectedly!"
+    echo "The sample project should fail with compose-rules violations."
+    exit 1
+fi
+
+echo ""
+echo "SUCCESS: All expected compose-rules violations were detected!"
+exit 0
+

--- a/scripts/test-ktlint-sample.sh
+++ b/scripts/test-ktlint-sample.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nacho Lopez
+# SPDX-License-Identifier: Apache-2.0
+#
+# Script to validate that the ktlint sample project correctly detects compose-rules violations.
+# Returns 0 if all expected violations are found, non-zero otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SAMPLE_DIR="$ROOT_DIR/samples/ktlint-sample"
+
+echo "=== Testing ktlint sample ==="
+echo "Running spotless check on sample project..."
+
+# Run spotless and capture output (expecting it to fail with violations)
+set +e
+OUTPUT=$("$ROOT_DIR/gradlew" -p "$SAMPLE_DIR" spotlessKotlinCheck 2>&1)
+EXIT_CODE=$?
+set -e
+
+# Expected compose-rules violations (rule IDs that should appear in output)
+# Note: Spotless only reports one error per file, so we check for the rules
+# that should be triggered based on our separate violation files
+EXPECTED_RULES=(
+    "compose:modifier-missing-check"
+    "compose:multiple-emitters-check"
+    "compose:mutable-params-check"
+    "compose:naming-check"
+    "compose:parameter-naming"
+    "compose:mutable-state-autoboxing"
+)
+
+echo ""
+echo "Validating expected rule violations..."
+
+MISSING_RULES=()
+FOUND_RULES=()
+
+for rule in "${EXPECTED_RULES[@]}"; do
+    if echo "$OUTPUT" | grep -q "$rule"; then
+        FOUND_RULES+=("$rule")
+        echo "  ✓ Found: $rule"
+    else
+        MISSING_RULES+=("$rule")
+        echo "  ✗ Missing: $rule"
+    fi
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Found ${#FOUND_RULES[@]}/${#EXPECTED_RULES[@]} expected rule violations"
+
+if [[ ${#MISSING_RULES[@]} -gt 0 ]]; then
+    echo ""
+    echo "ERROR: The following expected rules were NOT detected:"
+    for rule in "${MISSING_RULES[@]}"; do
+        echo "  - $rule"
+    done
+    echo ""
+    echo "This could indicate:"
+    echo "  1. A rule is broken or disabled"
+    echo "  2. The sample violation file was modified"
+    echo "  3. The rule ID changed"
+    echo ""
+    echo "Full output:"
+    echo "----------------------------------------"
+    echo "$OUTPUT"
+    echo "----------------------------------------"
+    exit 1
+fi
+
+# Also verify the build actually failed (not a false positive from a passing build)
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo ""
+    echo "ERROR: The spotless check passed unexpectedly!"
+    echo "The sample project should fail with compose-rules violations."
+    exit 1
+fi
+
+# Verify we got the expected number of lint errors (6 files = 6 errors)
+if echo "$OUTPUT" | grep -q "There were 6 lint error"; then
+    echo "✓ Verified: 6 lint errors detected (one per violation file)"
+else
+    echo ""
+    echo "WARNING: Expected '6 lint error(s)' but got different count."
+    echo "This might indicate a configuration issue."
+fi
+
+echo ""
+echo "SUCCESS: All expected compose-rules violations were detected!"
+exit 0
+


### PR DESCRIPTION
Added real world samples running the most up-to-date rules to the repository. I also put it a new workflow in CI. The idea is to have certainty that updates aren't breaking real world usages, and it'll also be useful when dealing with massive breaking changes in the linters (e.g. detekt 2). 