### PR TITLE
Add verify-fat-jar workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,10 +71,32 @@ jobs:
       - name: Test ktlint sample
         run: ./scripts/test-ktlint-sample.sh
 
+  verify-fat-jars:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+            distribution: 'zulu'
+            java-version: 24
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - uses: gradle/actions/setup-gradle@v5
+
+      - name: Build fat jars
+        run: ./gradlew :rules:ktlint:shadowJar :rules:detekt:shadowJar -PuberJar
+
   deploy:
     if: github.event_name == 'push' && github.repository == 'mrmans0n/compose-rules'
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ build, verify-fat-jars ]
     timeout-minutes: 30
     env:
       TERM: dumb


### PR DESCRIPTION
As shadowjar updates are like a russian roulette when upgrading (they have been prone lately to cause issues), and we would only catch this after a maven central deploy while releasing (which is quite a hassle), I'm adding a new step on CI to build them and see if anything fails. At least now we'll be able to be sure that the build goes through on renovate updates to shadowjar like #530 