### PR TITLE
Add more mutable*StateOf variants to the appropriate rules

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateParameter.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateParameter.kt
@@ -17,7 +17,15 @@ class MutableStateParameter : ComposeKtVisitor {
     }
 
     companion object {
-        private val MutableStateRegex = "(MutableState<.*>|Mutable(Int|Float|Double|Long)State)\\??".toRegex()
+        private val MutableStateRegex = """
+            (MutableState<.*>|
+            Mutable(Int|Float|Double|Long)State|
+            MutableIntList|MutableLongList|MutableFloatList|
+            MutableIntSet|MutableLongSet|MutableFloatSet|
+            MutableIntIntMap|MutableIntLongMap|MutableIntFloatMap|
+            MutableLongIntMap|MutableLongLongMap|MutableLongFloatMap|
+            MutableFloatIntMap|MutableFloatLongMap|MutableFloatFloatMap)\??
+        """.trimIndent().replace("\n", "").toRegex()
 
         val MutableStateParameterInCompose = """
             MutableState shouldn't be used as a parameter in a @Composable function, as it promotes joint ownership over a state between a component and its user.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberStateMissing.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberStateMissing.kt
@@ -30,10 +30,29 @@ class RememberStateMissing : ComposeKtVisitor {
         private val MethodsThatNeedRemembering = setOf(
             "derivedStateOf",
             "mutableStateOf",
+            // Primitives
             "mutableIntStateOf",
             "mutableFloatStateOf",
             "mutableDoubleStateOf",
             "mutableLongStateOf",
+            // Primitive Lists
+            "mutableIntListOf",
+            "mutableLongListOf",
+            "mutableFloatListOf",
+            // Primitive Sets
+            "mutableIntSetOf",
+            "mutableLongSetOf",
+            "mutableFloatSetOf",
+            // Primitive Maps
+            "mutableIntIntMapOf",
+            "mutableIntLongMapOf",
+            "mutableIntFloatMapOf",
+            "mutableLongIntMapOf",
+            "mutableLongLongMapOf",
+            "mutableLongFloatMapOf",
+            "mutableFloatIntMapOf",
+            "mutableFloatLongMapOf",
+            "mutableFloatFloatMapOf",
         )
         private val MethodsAndErrorsThatNeedRemembering = MethodsThatNeedRemembering.associateWith { errorMessage(it) }
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateParameterCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateParameterCheckTest.kt
@@ -59,6 +59,42 @@ class MutableStateParameterCheckTest {
     }
 
     @Test
+    fun `errors when a Composable has collection-based MutableState parameters`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(
+                    a: MutableIntList,
+                    b: MutableLongList,
+                    c: MutableFloatList,
+                    d: MutableIntSet,
+                    e: MutableLongSet,
+                    f: MutableFloatSet,
+                    g: MutableIntIntMap,
+                    h: MutableLongLongMap,
+                    i: MutableFloatFloatMap
+                ) {}
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(3, 5),
+                SourceLocation(4, 5),
+                SourceLocation(5, 5),
+                SourceLocation(6, 5),
+                SourceLocation(7, 5),
+                SourceLocation(8, 5),
+                SourceLocation(9, 5),
+                SourceLocation(10, 5),
+                SourceLocation(11, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(MutableStateParameter.MutableStateParameterInCompose)
+        }
+    }
+
+    @Test
     fun `no errors when a Composable has valid parameters`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheckTest.kt
@@ -134,4 +134,61 @@ class RememberStateMissingCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `errors when non-remembered collection-based mutableState functions are used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val a = mutableIntListOf()
+                    val b = mutableLongListOf()
+                    val c = mutableFloatListOf()
+                    val d = mutableIntSetOf()
+                    val e = mutableLongSetOf()
+                    val f = mutableFloatSetOf()
+                    val g = mutableIntIntMapOf()
+                    val h = mutableLongLongMapOf()
+                    val i = mutableFloatFloatMapOf()
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasSize(9)
+            .hasStartSourceLocations(
+                SourceLocation(3, 13),
+                SourceLocation(4, 13),
+                SourceLocation(5, 13),
+                SourceLocation(6, 13),
+                SourceLocation(7, 13),
+                SourceLocation(8, 13),
+                SourceLocation(9, 13),
+                SourceLocation(10, 13),
+                SourceLocation(11, 13),
+            )
+        // Just verify the first error message contains the expected pattern
+        assertThat(errors.first()).hasMessage(RememberStateMissing.errorMessage("mutableIntListOf"))
+    }
+
+    @Test
+    fun `passes when remembered collection-based mutableState functions are used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val a = remember { mutableIntListOf() }
+                    val b = remember { mutableLongListOf() }
+                    val c = remember { mutableFloatListOf() }
+                    val d = remember { mutableIntSetOf() }
+                    val e = remember { mutableLongSetOf() }
+                    val f = remember { mutableFloatSetOf() }
+                    val g = remember { mutableIntIntMapOf() }
+                    val h = remember { mutableLongLongMapOf() }
+                    val i = remember { mutableFloatFloatMapOf() }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateParameterCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateParameterCheckTest.kt
@@ -67,6 +67,73 @@ class MutableStateParameterCheckTest {
     }
 
     @Test
+    fun `errors when a Composable has collection-based MutableState parameters`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(
+                    a: MutableIntList,
+                    b: MutableLongList,
+                    c: MutableFloatList,
+                    d: MutableIntSet,
+                    e: MutableLongSet,
+                    f: MutableFloatSet,
+                    g: MutableIntIntMap,
+                    h: MutableLongLongMap,
+                    i: MutableFloatFloatMap
+                ) {}
+            """.trimIndent()
+        mutableParamRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 3,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 4,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 5,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 6,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 7,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 8,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 9,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 10,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+            LintViolation(
+                line = 11,
+                col = 5,
+                detail = MutableStateParameter.MutableStateParameterInCompose,
+            ),
+        )
+    }
+
+    @Test
     fun `no errors when a Composable has valid parameters`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberStateMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberStateMissingCheckTest.kt
@@ -133,4 +133,92 @@ class RememberStateMissingCheckTest {
             """.trimIndent()
         rememberRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `errors when non-remembered collection-based mutableState functions are used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val a = mutableIntListOf()
+                    val b = mutableLongListOf()
+                    val c = mutableFloatListOf()
+                    val d = mutableIntSetOf()
+                    val e = mutableLongSetOf()
+                    val f = mutableFloatSetOf()
+                    val g = mutableIntIntMapOf()
+                    val h = mutableLongLongMapOf()
+                    val i = mutableFloatFloatMapOf()
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 3,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableIntListOf"),
+            ),
+            LintViolation(
+                line = 4,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableLongListOf"),
+            ),
+            LintViolation(
+                line = 5,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableFloatListOf"),
+            ),
+            LintViolation(
+                line = 6,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableIntSetOf"),
+            ),
+            LintViolation(
+                line = 7,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableLongSetOf"),
+            ),
+            LintViolation(
+                line = 8,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableFloatSetOf"),
+            ),
+            LintViolation(
+                line = 9,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableIntIntMapOf"),
+            ),
+            LintViolation(
+                line = 10,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableLongLongMapOf"),
+            ),
+            LintViolation(
+                line = 11,
+                col = 13,
+                detail = RememberStateMissing.errorMessage("mutableFloatFloatMapOf"),
+            ),
+        )
+    }
+
+    @Test
+    fun `passes when remembered collection-based mutableState functions are used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val a = remember { mutableIntListOf() }
+                    val b = remember { mutableLongListOf() }
+                    val c = remember { mutableFloatListOf() }
+                    val d = remember { mutableIntSetOf() }
+                    val e = remember { mutableLongSetOf() }
+                    val f = remember { mutableFloatSetOf() }
+                    val g = remember { mutableIntIntMapOf() }
+                    val h = remember { mutableLongLongMapOf() }
+                    val i = remember { mutableFloatFloatMapOf() }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Some other rules other than the autoboxing one can use the primitive msof permutations.