### PR TITLE
Treat retain the same as remember in all rules

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
@@ -356,4 +356,7 @@ private val RestartableEffects by lazy {
 fun KtCallExpression.isRemembered(stopAt: PsiElement): Boolean = parents
     .takeWhile { it != stopAt }
     .filterIsInstance<KtCallExpression>()
-    .any { it.calleeExpression?.text?.startsWith("remember") == true }
+    .map { it.calleeExpression?.text }
+    .any { name ->
+        name != null && (name.startsWith("remember") || name == "retain")
+    }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberContentMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberContentMissingCheckTest.kt
@@ -65,4 +65,60 @@ class RememberContentMissingCheckTest {
             assertThat(error).hasMessage(RememberContentMissing.MovableContentWithReceiverOfNotRemembered)
         }
     }
+
+    @Test
+    fun `passes when a remembered movableContentOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = remember { movableContentOf { Text("X") } }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when a remembered movableContentWithReceiverOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = remember { movableContentWithReceiverOf { Text("X") } }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when a retain movableContentOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = retain { movableContentOf { Text("X") } }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when a retain movableContentWithReceiverOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = retain { movableContentWithReceiverOf { Text("X") } }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/RememberStateMissingCheckTest.kt
@@ -191,4 +191,60 @@ class RememberStateMissingCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes when a retain mutableStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable(
+                    something: State<String> = retain { mutableStateOf("X") }
+                ) {
+                    val something = retain { mutableStateOf("X") }
+                    val something2 by retain { mutableStateOf("Y") }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when a retain derivedStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable(
+                    something: State<String> = retain { derivedStateOf { "X" } }
+                ) {
+                    val something = retain { derivedStateOf { "X" } }
+                    val something2 by retain { derivedStateOf { "Y" } }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when retained collection-based mutableState functions are used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val a = retain { mutableIntListOf() }
+                    val b = retain { mutableLongListOf() }
+                    val c = retain { mutableFloatListOf() }
+                    val d = retain { mutableIntSetOf() }
+                    val e = retain { mutableLongSetOf() }
+                    val f = retain { mutableFloatSetOf() }
+                    val g = retain { mutableIntIntMapOf() }
+                    val h = retain { mutableLongLongMapOf() }
+                    val i = retain { mutableFloatFloatMapOf() }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberContentMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberContentMissingCheckTest.kt
@@ -59,4 +59,56 @@ class RememberContentMissingCheckTest {
             ),
         )
     }
+
+    @Test
+    fun `passes when a remembered movableContentOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = remember { movableContentOf { Text("X") } }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when a remembered movableContentWithReceiverOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = remember { movableContentWithReceiverOf { Text("X") } }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when a retain movableContentOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = retain { movableContentOf { Text("X") } }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when a retain movableContentWithReceiverOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val something = retain { movableContentWithReceiverOf { Text("X") } }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberStateMissingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/RememberStateMissingCheckTest.kt
@@ -221,4 +221,57 @@ class RememberStateMissingCheckTest {
             """.trimIndent()
         rememberRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when a retain mutableStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable(
+                    something: State<String> = retain { mutableStateOf("X") }
+                ) {
+                    val something = retain { mutableStateOf("X") }
+                    val something2 by retain { mutableStateOf("Y") }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when a retain derivedStateOf is used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable(
+                    something: State<String> = retain { derivedStateOf { "X" } }
+                ) {
+                    val something = retain { derivedStateOf { "X" } }
+                    val something2 by retain { derivedStateOf { "Y" } }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when retained collection-based mutableState functions are used in a Composable`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun MyComposable() {
+                    val a = retain { mutableIntListOf() }
+                    val b = retain { mutableLongListOf() }
+                    val c = retain { mutableFloatListOf() }
+                    val d = retain { mutableIntSetOf() }
+                    val e = retain { mutableLongSetOf() }
+                    val f = retain { mutableFloatSetOf() }
+                    val g = retain { mutableIntIntMapOf() }
+                    val h = retain { mutableLongLongMapOf() }
+                    val i = retain { mutableFloatFloatMapOf() }
+                }
+            """.trimIndent()
+        rememberRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
Support `retain` https://issuetracker.google.com/issues/177562901 as if it were a `remember`, in the remember-related rules.