### PR TITLE
Treat context params the same as context receivers in MultipleContentEmitters

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtFunctions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtFunctions.kt
@@ -50,3 +50,16 @@ val KtFunction.definedInInterface: Boolean
 
 val KtNamedFunction.isNested: Boolean
     get() = parents.takeWhile { it !is KtFile }.any { it is KtNamedFunction }
+
+/**
+ * Returns true if the function has any context receivers or context parameters.
+ *
+ * Context receivers use the old syntax: `context(ColumnScope)`
+ * Context parameters use the new syntax: `context(columnScope: ColumnScope)`
+ */
+val KtNamedFunction.hasAnyContextArguments: Boolean
+    get() {
+        val contextReceiverList = contextReceiverList ?: return false
+        return contextReceiverList.contextReceivers().isNotEmpty() ||
+            contextReceiverList.contextParameters().isNotEmpty()
+    }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MultipleContentEmittersCheckTest.kt
@@ -81,6 +81,28 @@ class MultipleContentEmittersCheckTest {
     }
 
     @Test
+    fun `passes when the composable has a context parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                context(columnScope: ColumnScope)
+                @Composable
+                fun Something() {
+                    Text("Hi")
+                    Text("Hola")
+                }
+                context(rowScope: RowScope)
+                @Composable
+                fun Something() {
+                    Spacer()
+                    Text("Hola")
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
     fun `errors when a Composable function has more than one UI emitter at the top level`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MultipleContentEmittersCheckTest.kt
@@ -72,6 +72,27 @@ class MultipleContentEmittersCheckTest {
     }
 
     @Test
+    fun `passes when the composable has a context parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                context(columnScope: ColumnScope)
+                @Composable
+                fun Something() {
+                    Text("Hi")
+                    Text("Hola")
+                }
+                context(rowScope: RowScope)
+                @Composable
+                fun Something() {
+                    Spacer()
+                    Text("Hola")
+                }
+            """.trimIndent()
+        emittersRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `errors when a Composable function has more than one UI emitter at the top level`() {
         @Language("kotlin")
         val code =


### PR DESCRIPTION
They are basically the same for these usages, so it's only fair we treat them the same.