### PR TITLE
Fix parameter order handling to allow lambdas with default values before required params in composables

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -45,6 +45,9 @@ Compose:
     active: true
     # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)
     # treatAsLambda: MyLambdaType
+    # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically).
+    # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
+    # treatAsComposableLambda: MyComposableLambdaType
   CompositionLocalAllowlist:
     active: true
     # -- You can optionally define a list of CompositionLocals that are allowed here
@@ -63,10 +66,10 @@ Compose:
     # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
     # treatAsComposableLambda: MyComposableLambdaType
   ContentSlotReused:
-      active: true
-      # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically).
-      # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
-      # treatAsComposableLambda: MyComposableLambdaType
+    active: true
+    # -- You can optionally have a list of types to be treated as composable lambdas (e.g. typedefs or fun interfaces not picked up automatically).
+    # -- The difference with treatAsLambda is that those need `@Composable` MyLambdaType in the definition, while these won't.
+    # treatAsComposableLambda: MyComposableLambdaType
   DefaultsVisibility:
     active: true
   LambdaParameterEventTrailing:

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheck.kt
@@ -9,6 +9,6 @@ import io.nlopez.compose.rules.ParameterOrder
 class ParameterOrderCheck :
     KtlintRule(
         id = "compose:param-order-check",
-        editorConfigProperties = setOf(treatAsLambda),
+        editorConfigProperties = setOf(treatAsLambda, treatAsComposableLambda),
     ),
     ComposeKtVisitor by ParameterOrder()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ParameterOrderCheckTest.kt
@@ -63,6 +63,58 @@ class ParameterOrderCheckTest {
     }
 
     @Test
+    fun `no errors when non-composable lambda with default value comes before required params - issue 416`() {
+        @Language("kotlin")
+        val code = """
+            @Composable
+            fun Foo(
+              onSelect: (Foo) -> Unit,
+              displayMapper: (Foo) -> String = { it.name },
+              title: String,
+            ) { }
+
+            @Composable
+            fun Bar(
+              onClick: () -> Unit,
+              formatter: (String) -> String = { it },
+              text: String,
+              count: Int,
+            ) { }
+
+            @Composable
+            fun Baz(
+              modifier: Modifier = Modifier,
+              onValueChange: (Int) -> Unit = {},
+              value: Int,
+            ) { }
+        """.trimIndent()
+        orderingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `error when composable lambda with default value comes before required params`() {
+        @Language("kotlin")
+        val code = """
+            @Composable
+            fun Foo(
+              onClick: () -> Unit,
+              content: @Composable () -> Unit = {},
+              title: String,
+            ) { }
+        """.trimIndent()
+        orderingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = ParameterOrder.createErrorMessage(
+                    currentOrder = "onClick: () -> Unit, content: @Composable () -> Unit = {}, title: String",
+                    properOrder = "onClick: () -> Unit, title: String, content: @Composable () -> Unit = {}",
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `errors found when ordering is wrong`() {
         @Language("kotlin")
         val code = """


### PR DESCRIPTION
Allows a bit of leniency for special cases where actually moving a (non-`@Composable`) lambda to after the required values would make it a trailing lambda, which wouldn't be desirable either. Basically, going with the lesser of two evils approach here. 

Basically, it makes the ParameterOrder rule be mindful of https://mrmans0n.github.io/compose-rules/rules/#avoid-trailing-lambdas-for-event-handlers

Fixes #416 