### PR TITLE
Avoid contributing kotlin-compiler-embeddable for ktlint artifacts

### DIFF
--- a/rules/common-ktlint/build.gradle.kts
+++ b/rules/common-ktlint/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    api(libs.kotlin.compiler.ktlint)
+    compileOnly(libs.kotlin.compiler.ktlint)
 
     testImplementation(libs.junit5)
     testImplementation(libs.junit5.params)

--- a/rules/ktlint/build.gradle.kts
+++ b/rules/ktlint/build.gradle.kts
@@ -38,5 +38,4 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.reflections)
     testImplementation(libs.konsist)
-    testImplementation(libs.kotlin.compiler.ktlint)
 }


### PR DESCRIPTION
The kotlin-compiler-embeddable seems to be already be transitively available via ktlint's artifact [ktlint-rule-engine-core](https://github.com/pinterest/ktlint/blob/master/ktlint-rule-engine-core/build.gradle.kts). But we shouldn't add fuel to the fire ourselves if possible. It's not needed for tests either as `ktlint-test` is also providing it transitively.

Should address #569, at least for what these rules are concerned.