### PR TITLE
Add StateParam rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -146,9 +146,11 @@ Compose:
     # previewNamingStrategy: suffix
   PreviewPublic:
     active: true
+  RememberContentMissing:
+    active: true
   RememberMissing:
     active: true
-  RememberContentMissing:
+  StateParam:
     active: true
   UnstableCollections:
     active: false # Opt-in, disabled by default. Turn on if you want to enforce this (e.g. you have strong skipping disabled)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -20,6 +20,7 @@ In practice, watch out for these common issues:
 
 - Do not pass ViewModels (or objects from DI) down.
 - Do not pass `MutableState<T>` instances down.
+- Do not pass `State<T>` instances down.
 - Do not pass inherently mutable types that cannot be observed.
 
 Instead, pass the relevant data to the function and use lambdas for callbacks.
@@ -114,6 +115,28 @@ More info: [Compose API guidelines](https://android.googlesource.com/platform/fr
 !!! info ""
 
     :material-chevron-right-box: [compose:mutable-state-param-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateParameter.kt) ktlint :material-chevron-right-box: [MutableStateParam](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/MutableStateParameter.kt) detekt
+
+### Do not use State as a parameter
+
+Using `State<T>` as a parameter encourages passing state holders instead of values, which makes components harder to reason about and test.
+
+Instead, pass the snapshot state value and expose callbacks to report changes.
+
+```kotlin
+// ❌ Passing State down
+@Composable
+fun Counter(label: String, count: State<Int>) { /* ... */ }
+
+// ✅ Pass values and events instead
+@Composable
+fun Counter(label: String, count: Int, onCountChange: (Int) -> Unit) { /* ... */ }
+```
+
+More info: [Compose API guidelines](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md#statet-as-a-parameter)
+
+!!! info ""
+
+    :material-chevron-right-box: [compose:state-param-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/StateParameter.kt) ktlint :material-chevron-right-box: [StateParam](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/StateParameter.kt) detekt
 
 ### Be mindful of effect keys
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/StateParameter.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/StateParameter.kt
@@ -1,0 +1,28 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.compose.core.ComposeKtConfig
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.core.Emitter
+import io.nlopez.compose.core.report
+import org.jetbrains.kotlin.psi.KtFunction
+
+class StateParameter : ComposeKtVisitor {
+
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        function.valueParameters
+            .filter { it.typeReference?.text?.matches(StateRegex) == true }
+            .forEach { emitter.report(it, StateParameterInCompose) }
+    }
+
+    companion object {
+        private val StateRegex = "(State<.*>|(Int|Float|Double|Long)State)\\??".toRegex()
+
+        val StateParameterInCompose = """
+            State shouldn't be used as a parameter in a @Composable function, as it encourages components that are not fully stateless.
+            Instead, pass the snapshot state value and provide event callbacks for changes.
+            See https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md#statet-as-a-parameter for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -47,6 +47,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             RuleName("PreviewPublic") to { config: Config -> PreviewPublicCheck(config) },
             RuleName("RememberContentMissing") to { config: Config -> RememberContentMissingCheck(config) },
             RuleName("RememberMissing") to { config: Config -> RememberStateMissingCheck(config) },
+            RuleName("StateParam") to { config: Config -> StateParameterCheck(config) },
             RuleName("UnstableCollections") to { config: Config -> UnstableCollectionsCheck(config) },
             RuleName("ViewModelForwarding") to { config: Config -> ViewModelForwardingCheck(config) },
             RuleName("ViewModelInjection") to { config: Config -> ViewModelInjectionCheck(config) },

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/StateParameterCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/StateParameterCheck.kt
@@ -1,0 +1,17 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.rules.DetektRule
+import io.nlopez.compose.rules.StateParameter
+import java.net.URI
+
+class StateParameterCheck(config: Config) :
+    DetektRule(
+        config = config,
+        description = "Avoid passing State as a parameter",
+        url = URI("https://mrmans0n.github.io/compose-rules/rules/#state-parameter"),
+    ),
+    ComposeKtVisitor by StateParameter()

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -57,6 +57,8 @@ Compose:
     active: true
   RememberMissing:
     active: true
+  StateParam:
+    active: true
   UnstableCollections:
     active: false
   ViewModelForwarding:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/StateParameterCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/StateParameterCheckTest.kt
@@ -1,0 +1,74 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.SourceLocation
+import dev.detekt.test.lint
+import io.nlopez.compose.rules.StateParameter
+import io.nlopez.compose.rules.detekt.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class StateParameterCheckTest {
+
+    private val rule = StateParameterCheck(Config.empty)
+
+    @Test
+    fun `errors when a Composable has a State parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(a: State<String>) {}
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(2, 15),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(StateParameter.StateParameterInCompose)
+        }
+    }
+
+    @Test
+    fun `errors when a Composable has primitive State parameters`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(
+                    a: IntState,
+                    b: FloatState,
+                    c: DoubleState,
+                    d: LongState
+                ) {}
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(3, 5),
+                SourceLocation(4, 5),
+                SourceLocation(5, 5),
+                SourceLocation(6, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(StateParameter.StateParameterInCompose)
+        }
+    }
+
+    @Test
+    fun `no errors when a Composable has valid parameters`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(a: String, b: (Int) -> Unit) {}
+                @Composable
+                fun Something(a: MutableState<String>) {}
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -33,6 +33,7 @@ class ComposeRuleSetProvider :
         RuleProvider { MutableParametersCheck() },
         RuleProvider { MutableStateAutoboxingCheck() },
         RuleProvider { MutableStateParameterCheck() },
+        RuleProvider { StateParameterCheck() },
         RuleProvider { NamingCheck() },
         RuleProvider { ParameterNamingCheck() },
         RuleProvider { ParameterOrderCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/StateParameterCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/StateParameterCheck.kt
@@ -1,0 +1,11 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.rules.KtlintRule
+import io.nlopez.compose.rules.StateParameter
+
+class StateParameterCheck :
+    KtlintRule("compose:state-param-check"),
+    ComposeKtVisitor by StateParameter()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/StateParameterCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/StateParameterCheckTest.kt
@@ -1,0 +1,81 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.StateParameter
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class StateParameterCheckTest {
+
+    private val stateParamRuleAssertThat = assertThatRule { StateParameterCheck() }
+
+    @Test
+    fun `errors when a Composable has a State parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(a: State<String>) {}
+            """.trimIndent()
+        stateParamRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 15,
+                detail = StateParameter.StateParameterInCompose,
+            ),
+        )
+    }
+
+    @Test
+    fun `errors when a Composable has primitive State parameters`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(
+                    a: IntState,
+                    b: FloatState,
+                    c: DoubleState,
+                    d: LongState
+                ) {}
+            """.trimIndent()
+        stateParamRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 3,
+                col = 5,
+                detail = StateParameter.StateParameterInCompose,
+            ),
+            LintViolation(
+                line = 4,
+                col = 5,
+                detail = StateParameter.StateParameterInCompose,
+            ),
+            LintViolation(
+                line = 5,
+                col = 5,
+                detail = StateParameter.StateParameterInCompose,
+            ),
+            LintViolation(
+                line = 6,
+                col = 5,
+                detail = StateParameter.StateParameterInCompose,
+            ),
+        )
+    }
+
+    @Test
+    fun `no errors when a Composable has valid parameters`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(a: String, b: (Int) -> Unit) {}
+                @Composable
+                fun Something(a: MutableState<String>) {}
+            """.trimIndent()
+        stateParamRuleAssertThat(code).hasNoLintViolations()
+    }
+}

--- a/samples/detekt-sample/detekt.yml
+++ b/samples/detekt-sample/detekt.yml
@@ -87,9 +87,11 @@ Compose:
     active: false
   PreviewPublic:
     active: true
+  RememberContentMissing:
+    active: true
   RememberMissing:
     active: true
-  RememberContentMissing:
+  StateParam:
     active: true
   UnstableCollections:
     active: false


### PR DESCRIPTION
[Compose API Guidelines for components](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-component-api-guidelines.md#statet-as-a-parameter) states that:

### State\<T\> as a parameter

Parameters of type `State<T> `are discouraged since it unnecessarily narrows the type of objects that can be passed in the function. Given `param: State<Float>`, there are two better alternatives available, depending on the use case:

1. `param: Float`. If the parameter doesn’t change often, or is being read immediately in the component (composition), developers can provide just a plain parameter and recompose the component when it changes.
2. `param: () -> Float`. To delay reading the value until a later time via `param.invoke()`, lambda might be provided as a parameter. This allows the developers of the component to read the value only when/if it is needed and avoid unnecessary work. For example, if the value is only read during drawing operation, [only redraw will occur](https://developer.android.com/jetpack/compose/phases#state-reads). This leaves the flexibility to the user to provide any expression, including the `State<T>`’s read:
    1. `param = { myState.value }` - read the `State<T>`’s value
    2. `param = { justValueWithoutState }` - plain value not backed by the `State<T>`
    3. `param = { myObject.offset }` - user can have a custom state object where the field (e.g. ``offset``) is backed by the `mutableStateOf()`

**DON’T**
```
fun Badge(position: State<Dp>) {}

// not possible since only State<T> is allowed
Badge(position = scrollState.offset) // DOES NOT COMPILE
```

**Do:**
```
fun Badge(position: () -> Dp) {}

// works ok
Badge(position = { scrollState.offset })
```