### PR TITLE
Revert "Add shadowJar relocate rule for compatibility with Ktlint IntelliJ Plugin 0.30.2 (#580)"

### DIFF
--- a/rules/ktlint/build.gradle.kts
+++ b/rules/ktlint/build.gradle.kts
@@ -18,12 +18,11 @@ if (!project.hasProperty("uberJar")) {
 
 tasks.shadowJar {
     // Relocate packages that may conflict with the ones IntelliJ IDEA provides as well.
-    // See https://github.com/nbadal/ktlint-intellij-plugin/blob/main/ktlint-lib/build.gradle.kts
+    // See https://github.com/nbadal/ktlint-intellij-plugin/blob/main/lib/build.gradle.kts
     relocate("org.jetbrains.concurrency", "shadow.org.jetbrains.concurrency")
     relocate("org.jetbrains.kotlin.psi.KtPsiFactory", "shadow.org.jetbrains.kotlin.psi.KtPsiFactory")
     relocate("org.jetbrains.kotlin.psi.psiUtil", "shadow.org.jetbrains.kotlin.psi.psiUtil")
     relocate("org.jetbrains.org", "shadow.org.jetbrains.org")
-    relocate("org.jetbrains.kotlin", "shadow.org.jetbrains.kotlin")
 }
 
 dependencies {


### PR DESCRIPTION

This reverts commit 2884444cd48fb2b118ae4f90c50c3f924cae0e97.