### PR TITLE
Update detekt to v2.0.0-alpha.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 kotlin = "2.2.21" # Used for the code of the rules
 ktlint = "1.8.0"
 kotlin-ktlint = "2.2.21" # Update only when ktlint version updates
-detekt = "2.0.0-alpha.1"
-kotlin-detekt = "2.2.20" # Update only when detekt version updates
+detekt = "2.0.0-alpha.2"
+kotlin-detekt = "2.3.0" # Update only when detekt version updates
 junit = "5.14.2"
 junit-platform = "1.14.2"
 

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -5,10 +5,11 @@ package io.nlopez.compose.rules.detekt
 import dev.detekt.api.Config
 import dev.detekt.api.RuleName
 import dev.detekt.api.RuleSet
+import dev.detekt.api.RuleSetId
 import dev.detekt.api.RuleSetProvider
 
 class ComposeRuleSetProvider : RuleSetProvider {
-    override val ruleSetId: RuleSet.Id = RuleSet.Id(CUSTOM_RULE_SET_ID)
+    override val ruleSetId: RuleSetId = RuleSetId(CUSTOM_RULE_SET_ID)
 
     override fun instance(): RuleSet = RuleSet(
         ruleSetId,


### PR DESCRIPTION
## Changes

- Bump detekt from `2.0.0-alpha.1` to `2.0.0-alpha.2`
- Bump `kotlin-detekt` from `2.2.20` to `2.3.0` (required by detekt alpha.2)
- Handle breaking API changes from detekt 2.0.0-alpha.2

### Breaking changes handled
- `RuleSet.Id` → `RuleSetId` rename (import `dev.detekt.api.RuleSetId`)

### Testing
All tests passing:
- ✅ Unit tests
- ✅ Functional tests (DetektFunctionalTest, KtlintFunctionalTest)
- ✅ Kotlin compatibility tests

Supersedes #587 (Renovate PR that only bumps versions without handling breaking changes).