### PR TITLE
Support compositionLocalWithComputedDefaultOf in CompositionLocal rules

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
@@ -334,6 +334,7 @@ private val CompositionLocalReferenceExpressions by lazy {
     setOf(
         "staticCompositionLocalOf",
         "compositionLocalOf",
+        "compositionLocalWithComputedDefaultOf",
     )
 }
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalAllowlistCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalAllowlistCheckTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 class CompositionLocalAllowlistCheckTest {
 
     private val testConfig = TestConfig(
-        "allowedCompositionLocals" to listOf("LocalBanana", "LocalPotato"),
+        "allowedCompositionLocals" to listOf("LocalBanana", "LocalPotato", "LocalPeach"),
     )
     private val rule = CompositionLocalAllowlistCheck(testConfig)
 
@@ -26,6 +26,8 @@ class CompositionLocalAllowlistCheckTest {
                 internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
                 val LocalPrune = compositionLocalOf { "Prune" }
                 private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
+                private val LocalLemon = compositionLocalWithComputedDefaultOf { "Lemon" }
+                private val LocalApricot: String = compositionLocalWithComputedDefaultOf { "Apricot" }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors)
@@ -34,6 +36,8 @@ class CompositionLocalAllowlistCheckTest {
                 SourceLocation(2, 14),
                 SourceLocation(3, 5),
                 SourceLocation(4, 13),
+                SourceLocation(5, 13),
+                SourceLocation(6, 13),
             )
         for (error in errors) {
             assertThat(error).hasMessage(CompositionLocalAllowlist.CompositionLocalNotInAllowlist)
@@ -47,6 +51,7 @@ class CompositionLocalAllowlistCheckTest {
             """
                 val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
                 val LocalPotato = compositionLocalOf { "Potato" }
+                val LocalPeach = compositionLocalWithComputedDefaultOf { "Peach" }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheckTest.kt
@@ -21,12 +21,14 @@ class CompositionLocalNamingCheckTest {
             """
                 val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
                 val Plum: String = staticCompositionLocalOf { "Plum" }
+                private val Lemon = compositionLocalWithComputedDefaultOf { "Lemon" }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors)
             .hasStartSourceLocations(
                 SourceLocation(1, 5),
                 SourceLocation(2, 5),
+                SourceLocation(3, 13),
             )
         for (error in errors) {
             assertThat(error).hasMessage(CompositionLocalNaming.CompositionLocalNeedsLocalPrefix)
@@ -40,6 +42,7 @@ class CompositionLocalNamingCheckTest {
             """
                 val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
                 val LocalPotato = compositionLocalOf { "Potato" }
+                val LocalPeach = compositionLocalWithComputedDefaultOf { "Peach" }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalAllowlistCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalAllowlistCheckTest.kt
@@ -21,6 +21,8 @@ class CompositionLocalAllowlistCheckTest {
                 internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
                 val LocalPrune = compositionLocalOf { "Prune" }
                 private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
+                private val LocalLemon = compositionLocalWithComputedDefaultOf { "Lemon" }
+                private val LocalApricot: String = compositionLocalWithComputedDefaultOf { "Apricot" }
             """.trimIndent()
         allowlistRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
@@ -44,6 +46,16 @@ class CompositionLocalAllowlistCheckTest {
                     col = 13,
                     detail = CompositionLocalAllowlist.CompositionLocalNotInAllowlist,
                 ),
+                LintViolation(
+                    line = 5,
+                    col = 13,
+                    detail = CompositionLocalAllowlist.CompositionLocalNotInAllowlist,
+                ),
+                LintViolation(
+                    line = 6,
+                    col = 13,
+                    detail = CompositionLocalAllowlist.CompositionLocalNotInAllowlist,
+                ),
             )
     }
 
@@ -54,10 +66,11 @@ class CompositionLocalAllowlistCheckTest {
             """
                 val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
                 val LocalPotato = compositionLocalOf { "Potato" }
+                val LocalPeach = compositionLocalWithComputedDefaultOf { "Peach" }
             """.trimIndent()
         allowlistRuleAssertThat(code)
             .withEditorConfigOverride(
-                compositionLocalAllowlistProperty to "LocalPotato,LocalBanana",
+                compositionLocalAllowlistProperty to "LocalPotato,LocalBanana,LocalPeach",
             )
             .hasNoLintViolations()
     }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheckTest.kt
@@ -19,6 +19,7 @@ class CompositionLocalNamingCheckTest {
             """
                 val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
                 val Plum: String = staticCompositionLocalOf { "Plum" }
+                private val Lemon = compositionLocalWithComputedDefaultOf { "Lemon" }
             """.trimIndent()
         ruleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(
@@ -32,6 +33,11 @@ class CompositionLocalNamingCheckTest {
                     col = 5,
                     detail = CompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
                 ),
+                LintViolation(
+                    line = 3,
+                    col = 13,
+                    detail = CompositionLocalNaming.CompositionLocalNeedsLocalPrefix,
+                ),
             )
     }
 
@@ -42,6 +48,7 @@ class CompositionLocalNamingCheckTest {
             """
                 val LocalBanana = staticCompositionLocalOf<String> { "Banana" }
                 val LocalPotato = compositionLocalOf { "Potato" }
+                val LocalPeach = compositionLocalWithComputedDefaultOf { "Peach" }
             """.trimIndent()
         ruleAssertThat(code).hasNoLintViolations()
     }


### PR DESCRIPTION
## Summary

Added support for the `compositionLocalWithComputedDefaultOf` introduced in Compose 1.7.0.

## Changes

- Added compositionLocalWithComputedDefaultOf to the core utilities.
- Updated `CompositionLocal` naming and allowlist tests to cover the `compositionLocalWithComputedDefaultOf`.