### PR TITLE
Fix explicit types in CompositionLocal tests

### DIFF
--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalAllowlistCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalAllowlistCheckTest.kt
@@ -23,11 +23,11 @@ class CompositionLocalAllowlistCheckTest {
         val code =
             """
                 private val LocalApple = staticCompositionLocalOf<String> { "Apple" }
-                internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
+                internal val LocalPlum: ProvidableCompositionLocal<String> = staticCompositionLocalOf { "Plum" }
                 val LocalPrune = compositionLocalOf { "Prune" }
-                private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
+                private val LocalKiwi: ProvidableCompositionLocal<String> = compositionLocalOf { "Kiwi" }
                 private val LocalLemon = compositionLocalWithComputedDefaultOf { "Lemon" }
-                private val LocalApricot: String = compositionLocalWithComputedDefaultOf { "Apricot" }
+                private val LocalApricot: ProvidableCompositionLocal<String> = compositionLocalWithComputedDefaultOf { "Apricot" }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/CompositionLocalNamingCheckTest.kt
@@ -20,7 +20,7 @@ class CompositionLocalNamingCheckTest {
         val code =
             """
                 val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
-                val Plum: String = staticCompositionLocalOf { "Plum" }
+                val Plum: ProvidableCompositionLocal<String> = staticCompositionLocalOf { "Plum" }
                 private val Lemon = compositionLocalWithComputedDefaultOf { "Lemon" }
             """.trimIndent()
         val errors = rule.lint(code)

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalAllowlistCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalAllowlistCheckTest.kt
@@ -18,11 +18,11 @@ class CompositionLocalAllowlistCheckTest {
         val code =
             """
                 private val LocalApple = staticCompositionLocalOf<String> { "Apple" }
-                internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
+                internal val LocalPlum: ProvidableCompositionLocal<String> = staticCompositionLocalOf { "Plum" }
                 val LocalPrune = compositionLocalOf { "Prune" }
-                private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
+                private val LocalKiwi: ProvidableCompositionLocal<String> = compositionLocalOf { "Kiwi" }
                 private val LocalLemon = compositionLocalWithComputedDefaultOf { "Lemon" }
-                private val LocalApricot: String = compositionLocalWithComputedDefaultOf { "Apricot" }
+                private val LocalApricot: ProvidableCompositionLocal<String> = compositionLocalWithComputedDefaultOf { "Apricot" }
             """.trimIndent()
         allowlistRuleAssertThat(code)
             .hasLintViolationsWithoutAutoCorrect(

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/CompositionLocalNamingCheckTest.kt
@@ -18,7 +18,7 @@ class CompositionLocalNamingCheckTest {
         val code =
             """
                 val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
-                val Plum: String = staticCompositionLocalOf { "Plum" }
+                val Plum: ProvidableCompositionLocal<String> = staticCompositionLocalOf { "Plum" }
                 private val Lemon = compositionLocalWithComputedDefaultOf { "Lemon" }
             """.trimIndent()
         ruleAssertThat(code)


### PR DESCRIPTION
This updates the `CompositionLocal` test cases to use the correct explicit types. It keeps the test intent unchanged while making the examples align with Compose APIs.