### PR TITLE
Add Material 3 NavigationBar and NavigationBarItem as content emitters

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Composables.kt
@@ -304,6 +304,8 @@ private val ComposableEmittersList by lazy {
         "HorizontalDivider",
         "InputField",
         "ModalBottomSheet",
+        "NavigationBar",
+        "NavigationBarItem",
         "PlainTooltip",
         "RichTooltip",
         "SearchBar",


### PR DESCRIPTION
Add Material 3 `NavigationBar` and `NavigationBarItem` to `ComposableEmittersList`. These are the Material 3 equivalents of `NavigationRail` / `NavigationRailItem` (already listed in the Material 2 section) and the Material 2 `BottomNavigation` (already listed in the Accompanist section). Mirrors the shape of #613, which added the Material 3 dividers.

Without these entries, `MultipleContentEmitters` and `ModifierNotUsedAtRoot` rely on the `containsComposablesWithModifiers()` fallback in `KtCallExpression.emitsContent` — which only matches when the call site passes a `modifier` argument. Calls like `NavigationBar { … }` (no explicit modifier forwarded) currently slip through. Adding the names to the emitters list closes that gap.
