### PR TITLE
Add ComposableNestingDepth rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -43,6 +43,10 @@ Compose:
     active: true
     # -- You can optionally disable the checks in this rule for regex matches against the composable name (e.g. molecule presenters)
     # allowedComposableFunctionNames: .*Presenter,.*MoleculePresenter
+  ComposableNestingDepth:
+    active: true
+    # -- Maximum nesting depth allowed for content emitters inside a single @Composable function. Defaults to 3.
+    # composableNestingDepthThreshold: 3
   ComposableParamOrder:
     active: true
     # -- You can optionally have a list of types to be treated as lambdas (e.g. typedefs or fun interfaces not picked up automatically)

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -44,7 +44,7 @@ Compose:
     # -- You can optionally disable the checks in this rule for regex matches against the composable name (e.g. molecule presenters)
     # allowedComposableFunctionNames: .*Presenter,.*MoleculePresenter
   ComposableNestingDepth:
-    active: true
+    active: false # Opt-in, disabled by default. Turn on if you want to enforce a maximum nesting depth in your composables.
     # -- Maximum nesting depth allowed for content emitters inside a single @Composable function. Defaults to 3.
     # composableNestingDepthThreshold: 3
   ComposableParamOrder:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -190,6 +190,15 @@ The `content-trailing-lambda` rule identifies `@Composable` trailing lambdas aut
 compose_treat_as_composable_lambda = MyLambdaComposableType,MyOtherComposableLambdaType
 ```
 
+### Configure the maximum nesting depth for composables
+
+The `composable-nesting-depth-check` rule flags `@Composable` functions whose content emitters are nested more deeply than a threshold. The default threshold is 3 enclosing content emitters. To tune it:
+
+```editorconfig
+[*.{kt,kts}]
+compose_composable_nesting_depth_threshold = 4
+```
+
 ### Enabling the Material 2 detector
 
 The `material-two` rule flags Material 2 API usage. Disabled by default; enable it in your `.editorconfig` file:

--- a/docs/ktlint.md
+++ b/docs/ktlint.md
@@ -190,12 +190,20 @@ The `content-trailing-lambda` rule identifies `@Composable` trailing lambdas aut
 compose_treat_as_composable_lambda = MyLambdaComposableType,MyOtherComposableLambdaType
 ```
 
-### Configure the maximum nesting depth for composables
+### Enabling and configuring the nesting depth detector
 
-The `composable-nesting-depth-check` rule flags `@Composable` functions whose content emitters are nested more deeply than a threshold. The default threshold is 3 enclosing content emitters. To tune it:
+The `composable-nesting-depth-check` rule flags `@Composable` functions whose content emitters are nested more deeply than a threshold. Disabled by default; enable it in your `.editorconfig` file:
 
 ```editorconfig
 [*.{kt,kts}]
+compose_composable_nesting_depth_enabled = true
+```
+
+The default threshold is 3 enclosing content emitters. To tune it:
+
+```editorconfig
+[*.{kt,kts}]
+compose_composable_nesting_depth_enabled = true
 compose_composable_nesting_depth_threshold = 4
 ```
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -280,55 +280,6 @@ This effectively ties the function to be called from a Column, but is still not 
 
 > **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
 
-### Avoid deeply nested composables
-
-Deeply nested content emitters inside a single `@Composable` make the function structure hard to scan and reason about. Extract inner sections into private `@Composable` functions so each function stays focused on one layout responsibility.
-
-```kotlin
-// ❌ Too deeply nested
-@Composable
-fun Foo() {
-    Box {
-        Box {
-            Box {
-                Box {
-                    Box {
-                        Text("hello")
-                    }
-                }
-            }
-        }
-    }
-}
-
-// ✅ Inner sections extracted to a private composable
-@Composable
-fun Foo() {
-    Box {
-        Box {
-            Box {
-                Bar()
-            }
-        }
-    }
-}
-
-@Composable
-private fun Bar() {
-    Box {
-        Box {
-            Text("hello")
-        }
-    }
-}
-```
-
-The threshold defaults to `3` (i.e., the deepest nested content emitter in a function may have at most 3 enclosing content emitters). It can be tuned via `composableNestingDepthThreshold` in Detekt or `compose_composable_nesting_depth_threshold` in your `.editorconfig` for ktlint.
-
-!!! info ""
-
-    :material-chevron-right-box: [compose:composable-nesting-depth-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) ktlint :material-chevron-right-box: [ComposableNestingDepth](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) detekt
-
 ### Slots for main content should be the trailing lambda
 
 Content slots (typically `content: @Composable () -> Unit` or nullable variants) should always be the last parameter so they can be written as a trailing lambda. This makes the UI flow more natural and easier to read.
@@ -829,3 +780,52 @@ By default, this rule requires `Preview` as a suffix. You can change this via th
 !!! info ""
 
     :material-chevron-right-box: [compose:preview-naming](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNaming.kt) ktlint :material-chevron-right-box: [PreviewNaming](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/PreviewNaming.kt) detekt
+
+### Avoid deeply nested composables
+
+Deeply nested content emitters inside a single `@Composable` make the function structure hard to scan and reason about. Extract inner sections into private `@Composable` functions so each function stays focused on one layout responsibility.
+
+```kotlin
+// ❌ Too deeply nested
+@Composable
+fun Foo() {
+    Box {
+        Box {
+            Box {
+                Box {
+                    Box {
+                        Text("hello")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ✅ Inner sections extracted to a private composable
+@Composable
+fun Foo() {
+    Box {
+        Box {
+            Box {
+                Bar()
+            }
+        }
+    }
+}
+
+@Composable
+private fun Bar() {
+    Box {
+        Box {
+            Text("hello")
+        }
+    }
+}
+```
+
+The threshold defaults to `3` (i.e., the deepest nested content emitter in a function may have at most 3 enclosing content emitters). It can be tuned via `composableNestingDepthThreshold` in Detekt or `compose_composable_nesting_depth_threshold` in your `.editorconfig` for ktlint.
+
+!!! info ""
+
+    :material-chevron-right-box: [compose:composable-nesting-depth-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) ktlint :material-chevron-right-box: [ComposableNestingDepth](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) detekt

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -280,6 +280,55 @@ This effectively ties the function to be called from a Column, but is still not 
 
 > **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
 
+### Avoid deeply nested composables
+
+Deeply nested content emitters inside a single `@Composable` make the function structure hard to scan and reason about. Extract inner sections into private `@Composable` functions so each function stays focused on one layout responsibility.
+
+```kotlin
+// ❌ Too deeply nested
+@Composable
+fun Foo() {
+    Box {
+        Box {
+            Box {
+                Box {
+                    Box {
+                        Text("hello")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ✅ Inner sections extracted to a private composable
+@Composable
+fun Foo() {
+    Box {
+        Box {
+            Box {
+                Bar()
+            }
+        }
+    }
+}
+
+@Composable
+private fun Bar() {
+    Box {
+        Box {
+            Text("hello")
+        }
+    }
+}
+```
+
+The threshold defaults to `3` (i.e., the deepest nested content emitter in a function may have at most 3 enclosing content emitters). It can be tuned via `composableNestingDepthThreshold` in Detekt or `compose_composable_nesting_depth_threshold` in your `.editorconfig` for ktlint.
+
+!!! info ""
+
+    :material-chevron-right-box: [compose:composable-nesting-depth-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) ktlint :material-chevron-right-box: [ComposableNestingDepth](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) detekt
+
 ### Slots for main content should be the trailing lambda
 
 Content slots (typically `content: @Composable () -> Unit` or nullable variants) should always be the last parameter so they can be written as a trailing lambda. This makes the UI flow more natural and easier to read.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -826,6 +826,8 @@ private fun Bar() {
 
 The threshold defaults to `3` (i.e., the deepest nested content emitter in a function may have at most 3 enclosing content emitters). It can be tuned via `composableNestingDepthThreshold` in Detekt or `compose_composable_nesting_depth_threshold` in your `.editorconfig` for ktlint.
 
+Enabling: [ktlint](https://mrmans0n.github.io/compose-rules/ktlint/#enabling-and-configuring-the-nesting-depth-detector), [detekt](https://mrmans0n.github.io/compose-rules/detekt/#enabling-rules)
+
 !!! info ""
 
     :material-chevron-right-box: [compose:composable-nesting-depth-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) ktlint :material-chevron-right-box: [ComposableNestingDepth](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt) detekt

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
@@ -1,0 +1,44 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules
+
+import io.nlopez.compose.core.ComposeKtConfig
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.core.Emitter
+import io.nlopez.compose.core.report
+import io.nlopez.compose.core.util.emitsContent
+import io.nlopez.compose.core.util.findAllChildrenByClass
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.psiUtil.parents
+
+class ComposableNestingDepth : ComposeKtVisitor {
+
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        val body = function.bodyBlockExpression ?: return
+        val threshold = config.getInt("composableNestingDepthThreshold", 3)
+
+        // For each content-emitting call in this function, count how many enclosing content-emitting
+        // calls it has (its nesting level). Top-level emitters have nesting 0.
+        val deepest = body.findAllChildrenByClass<KtCallExpression>()
+            .filter { it.emitsContent(config) }
+            .maxOfOrNull { call ->
+                call.parents
+                    .takeWhile { it != body }
+                    .filterIsInstance<KtCallExpression>()
+                    .count { it.emitsContent(config) }
+            } ?: return
+
+        if (deepest > threshold) {
+            emitter.report(function, ComposableTooDeeplyNested)
+        }
+    }
+
+    companion object {
+
+        val ComposableTooDeeplyNested = """
+            This @Composable function nests content emitters more deeply than the configured threshold. Extract inner sections into dedicated private @Composable functions to keep the structure readable.
+            See https://mrmans0n.github.io/compose-rules/rules/#avoid-deeply-nested-composables for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
@@ -9,7 +9,9 @@ import io.nlopez.compose.core.report
 import io.nlopez.compose.core.util.emitsContent
 import io.nlopez.compose.core.util.findAllChildrenByClass
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
 class ComposableNestingDepth : ComposeKtVisitor {
@@ -19,9 +21,15 @@ class ComposableNestingDepth : ComposeKtVisitor {
         val body = function.bodyBlockExpression ?: return
         val threshold = config.getInt("composableNestingDepthThreshold", 3)
 
-        // For each content-emitting call in this function, count how many enclosing content-emitting
+        // Exclude calls that live inside a nested function or class dec, then
+        // For each content-emitting call in this function, count how many enclosing content-emitting,
         // calls it has (its nesting level). Top-level emitters have nesting 0.
         val deepest = body.findAllChildrenByClass<KtCallExpression>()
+            .filter { call ->
+                call.parents
+                    .takeWhile { it != body }
+                    .none { it is KtNamedFunction || it is KtClassOrObject }
+            }
             .filter { it.emitsContent(config) }
             .maxOfOrNull { call ->
                 call.parents

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
@@ -18,8 +18,9 @@ class ComposableNestingDepth : ComposeKtVisitor {
     override val isOptIn: Boolean = true
 
     override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
-        val body = function.bodyBlockExpression ?: return
+        val body = function.bodyExpression ?: return
         val threshold = config.getInt("composableNestingDepthThreshold", 3)
+        val bodyBaseDepth = if ((body as? KtCallExpression)?.emitsContent(config) == true) 1 else 0
 
         // Exclude calls that live inside a nested function or class dec, then
         // For each content-emitting call in this function, count how many enclosing content-emitting,
@@ -32,7 +33,7 @@ class ComposableNestingDepth : ComposeKtVisitor {
             }
             .filter { it.emitsContent(config) }
             .maxOfOrNull { call ->
-                call.parents
+                bodyBaseDepth + call.parents
                     .takeWhile { it != body }
                     .filterIsInstance<KtCallExpression>()
                     .count { it.emitsContent(config) }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ComposableNestingDepth.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
 class ComposableNestingDepth : ComposeKtVisitor {
+    override val isOptIn: Boolean = true
 
     override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
         val body = function.bodyBlockExpression ?: return

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheck.kt
@@ -1,0 +1,17 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.rules.ComposableNestingDepth
+import io.nlopez.compose.rules.DetektRule
+import java.net.URI
+
+class ComposableNestingDepthCheck(config: Config) :
+    DetektRule(
+        config = config,
+        description = "Limit how deeply content emitters can be nested inside a @Composable",
+        url = URI("https://mrmans0n.github.io/compose-rules/rules/#avoid-deeply-nested-composables"),
+    ),
+    ComposeKtVisitor by ComposableNestingDepth()

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -16,6 +16,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
         mapOf(
             RuleName("ComposableAnnotationNaming") to { config: Config -> ComposableAnnotationNamingCheck(config) },
             RuleName("ComposableNaming") to { config: Config -> NamingCheck(config) },
+            RuleName("ComposableNestingDepth") to { config: Config -> ComposableNestingDepthCheck(config) },
             RuleName("ComposableParamOrder") to { config: Config -> ParameterOrderCheck(config) },
             RuleName("CompositionLocalAllowlist") to { config: Config -> CompositionLocalAllowlistCheck(config) },
             RuleName("CompositionLocalNaming") to { config: Config -> CompositionLocalNamingCheck(config) },

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -4,7 +4,7 @@ Compose:
   ComposableNaming:
     active: true
   ComposableNestingDepth:
-    active: true
+    active: false
   ComposableParamOrder:
     active: true
   CompositionLocalAllowlist:

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -3,6 +3,8 @@ Compose:
     active: true
   ComposableNaming:
     active: true
+  ComposableNestingDepth:
+    active: true
   ComposableParamOrder:
     active: true
   CompositionLocalAllowlist:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheckTest.kt
@@ -172,4 +172,31 @@ class ComposableNestingDepthCheckTest {
             """.trimIndent()
         assertThat(rule.lint(code)).isEmpty()
     }
+
+    @Test
+    fun `does not count nesting inside a locally-declared composable toward the outer function`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Outer() {
+                    @Composable
+                    fun Inner() {
+                        Box {
+                            Box {
+                                Box {
+                                    Box {
+                                        Text("hi")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Inner()
+                }
+            """.trimIndent()
+        // Outer's body only calls Inner() (not an emitter), so it must not be flagged.
+        // Inner itself has 4 nested Boxes around Text, so it should be flagged on its own.
+        assertThat(rule.lint(code)).hasStartSourceLocations(SourceLocation(4, 9))
+    }
 }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheckTest.kt
@@ -1,0 +1,175 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.SourceLocation
+import dev.detekt.test.TestConfig
+import dev.detekt.test.lint
+import io.nlopez.compose.rules.ComposableNestingDepth
+import io.nlopez.compose.rules.detekt.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposableNestingDepthCheckTest {
+
+    private val rule = ComposableNestingDepthCheck(Config.empty)
+
+    @Test
+    fun `passes when there is no nesting`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Plain() {
+                    Text("hello")
+                }
+            """.trimIndent()
+        assertThat(rule.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `passes at the default threshold`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun WithinLimit() {
+                    Box {
+                        Box {
+                            Box {
+                                Bar()
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        assertThat(rule.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `errors when nesting exceeds the default threshold`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun TooDeep() {
+                    Box {
+                        Box {
+                            Box {
+                                Box {
+                                    Box {
+                                        Text("")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).hasStartSourceLocations(SourceLocation(2, 5))
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposableNestingDepth.ComposableTooDeeplyNested)
+        }
+    }
+
+    @Test
+    fun `errors per function in the file`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun TooDeepA() {
+                    Box { Box { Box { Box { Text("a") } } } }
+                }
+                @Composable
+                fun ShallowB() {
+                    Box { Text("b") }
+                }
+                @Composable
+                fun TooDeepC() {
+                    Column { Row { Box { Box { Text("c") } } } }
+                }
+            """.trimIndent()
+        assertThat(rule.lint(code)).hasStartSourceLocations(
+            SourceLocation(2, 5),
+            SourceLocation(10, 5),
+        )
+    }
+
+    @Test
+    fun `respects a custom threshold via config`() {
+        val customConfig = TestConfig("composableNestingDepthThreshold" to 1)
+        val customRule = ComposableNestingDepthCheck(customConfig)
+
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun BarelyOk() {
+                    Box {
+                        Box {
+                            Text("hello")
+                        }
+                    }
+                }
+            """.trimIndent()
+        assertThat(customRule.lint(code)).hasStartSourceLocations(SourceLocation(2, 5))
+    }
+
+    @Test
+    fun `passes when threshold is raised to allow deep nesting`() {
+        val customConfig = TestConfig("composableNestingDepthThreshold" to 10)
+        val customRule = ComposableNestingDepthCheck(customConfig)
+
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun PreviouslyTooDeep() {
+                    Box {
+                        Box {
+                            Box {
+                                Box {
+                                    Text("hello")
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        assertThat(customRule.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `does not count non-Composable control flow toward nesting`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun WithControlFlow(items: List<String>, cond: Boolean) {
+                    Box {
+                        if (cond) {
+                            for (item in items) {
+                                Box {
+                                    Text(item)
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        assertThat(rule.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `does not flag functions without a block body`() {
+        @Language("kotlin")
+        val code =
+            """
+                val Content: @Composable () -> Unit = { Text("hi") }
+            """.trimIndent()
+        assertThat(rule.lint(code)).isEmpty()
+    }
+}

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposableNestingDepthCheckTest.kt
@@ -199,4 +199,19 @@ class ComposableNestingDepthCheckTest {
         // Inner itself has 4 nested Boxes around Text, so it should be flagged on its own.
         assertThat(rule.lint(code)).hasStartSourceLocations(SourceLocation(4, 9))
     }
+
+    @Test
+    fun `analyzes expression-bodied composables for nesting depth`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun TooDeep() = Box { Box { Box { Box { Text("x") } } } }
+                @Composable
+                fun WithinLimit() = Box { Box { Box { Text("x") } } }
+            """.trimIndent()
+        // TooDeep nests 4 emitters around Text (> threshold) and is flagged.
+        // WithinLimit nests 3 (== threshold) and is intentionally absent from the expected locations.
+        assertThat(rule.lint(code)).hasStartSourceLocations(SourceLocation(2, 5))
+    }
 }

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/KtlintComposeKtConfig.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/KtlintComposeKtConfig.kt
@@ -22,7 +22,13 @@ internal class KtlintComposeKtConfig(
     @Suppress("UNCHECKED_CAST")
     private fun <T : Any> getValueAsOrPut(key: String, value: () -> T?): T? = cache.getOrPut(key) { value() } as? T
 
-    override fun getInt(key: String, default: Int): Int = getValueAsOrPut(key) { find<String>(key)?.toInt() } ?: default
+    override fun getInt(key: String, default: Int): Int = getValueAsOrPut(key) {
+        when (val raw = find<Any>(key)) {
+            is Int -> raw
+            is String -> raw.toIntOrNull()
+            else -> null
+        }
+    } ?: default
 
     override fun getString(key: String, default: String?): String? = getValueAsOrPut(key) { find(key) } ?: default
 

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheck.kt
@@ -2,17 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.ktlint
 
+import io.nlopez.compose.core.ComposeKtConfig
 import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.core.Emitter
 import io.nlopez.compose.rules.ComposableNestingDepth
 import io.nlopez.compose.rules.KtlintRule
+import org.jetbrains.kotlin.psi.KtFunction
 
 class ComposableNestingDepthCheck :
     KtlintRule(
         id = "compose:composable-nesting-depth-check",
         editorConfigProperties = setOf(
+            composableNestingDepthEnabled,
             composableNestingDepthThreshold,
             contentEmittersProperty,
             contentEmittersDenylist,
         ),
     ),
-    ComposeKtVisitor by ComposableNestingDepth()
+    ComposeKtVisitor {
+
+    private val visitor = ComposableNestingDepth()
+
+    override fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {
+        // ktlint allows all rules by default, so we'll add an extra param to make sure it's disabled by default
+        if (config.getBoolean("composableNestingDepthEnabled", false)) {
+            visitor.visitComposable(function, emitter, config)
+        }
+    }
+}

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheck.kt
@@ -9,6 +9,10 @@ import io.nlopez.compose.rules.KtlintRule
 class ComposableNestingDepthCheck :
     KtlintRule(
         id = "compose:composable-nesting-depth-check",
-        editorConfigProperties = setOf(composableNestingDepthThreshold),
+        editorConfigProperties = setOf(
+            composableNestingDepthThreshold,
+            contentEmittersProperty,
+            contentEmittersDenylist,
+        ),
     ),
     ComposeKtVisitor by ComposableNestingDepth()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheck.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheck.kt
@@ -1,0 +1,14 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import io.nlopez.compose.core.ComposeKtVisitor
+import io.nlopez.compose.rules.ComposableNestingDepth
+import io.nlopez.compose.rules.KtlintRule
+
+class ComposableNestingDepthCheck :
+    KtlintRule(
+        id = "compose:composable-nesting-depth-check",
+        editorConfigProperties = setOf(composableNestingDepthThreshold),
+    ),
+    ComposeKtVisitor by ComposableNestingDepth()

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/ComposeRuleSetProvider.kt
@@ -13,6 +13,7 @@ class ComposeRuleSetProvider :
 
     override fun getRuleProviders(): Set<RuleProvider> = setOf(
         RuleProvider { ComposableAnnotationNamingCheck() },
+        RuleProvider { ComposableNestingDepthCheck() },
         RuleProvider { CompositionLocalAllowlistCheck() },
         RuleProvider { CompositionLocalNamingCheck() },
         RuleProvider { ContentEmitterReturningValuesCheck() },

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -332,20 +332,13 @@ val composePreviewNamingStrategy: EditorConfigProperty<String> =
         },
     )
 
-val composableNestingDepthThreshold: EditorConfigProperty<String> =
+val composableNestingDepthThreshold: EditorConfigProperty<Int> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(
             "compose_composable_nesting_depth_threshold",
             "Maximum nesting depth allowed for content emitters inside a single @Composable function.",
-            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
             emptySet(),
         ),
-        defaultValue = "3",
-        propertyMapper = { property, _ ->
-            when {
-                property?.isUnset == true -> "3"
-                property?.getValueAs<String>() != null -> property.getValueAs<String>()
-                else -> property?.getValueAs() ?: "3"
-            }
-        },
+        defaultValue = 3,
     )

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -332,6 +332,17 @@ val composePreviewNamingStrategy: EditorConfigProperty<String> =
         },
     )
 
+val composableNestingDepthEnabled: EditorConfigProperty<Boolean> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_composable_nesting_depth_enabled",
+            "When enabled, @Composable functions that nest content emitters too deeply will be flagged.",
+            PropertyValueParser.BOOLEAN_VALUE_PARSER,
+            setOf(true.toString(), false.toString()),
+        ),
+        defaultValue = false,
+    )
+
 val composableNestingDepthThreshold: EditorConfigProperty<Int> =
     EditorConfigProperty(
         type = PropertyType.LowerCasingPropertyType(

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/ktlint/EditorConfigProperties.kt
@@ -331,3 +331,21 @@ val composePreviewNamingStrategy: EditorConfigProperty<String> =
             }
         },
     )
+
+val composableNestingDepthThreshold: EditorConfigProperty<String> =
+    EditorConfigProperty(
+        type = PropertyType.LowerCasingPropertyType(
+            "compose_composable_nesting_depth_threshold",
+            "Maximum nesting depth allowed for content emitters inside a single @Composable function.",
+            PropertyValueParser.IDENTITY_VALUE_PARSER,
+            emptySet(),
+        ),
+        defaultValue = "3",
+        propertyMapper = { property, _ ->
+            when {
+                property?.isUnset == true -> "3"
+                property?.getValueAs<String>() != null -> property.getValueAs<String>()
+                else -> property?.getValueAs() ?: "3"
+            }
+        },
+    )

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
@@ -1,0 +1,186 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import com.pinterest.ktlint.test.LintViolation
+import io.nlopez.compose.rules.ComposableNestingDepth
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class ComposableNestingDepthCheckTest {
+
+    private val nestingRuleAssertThat = assertThatRule { ComposableNestingDepthCheck() }
+
+    @Test
+    fun `passes when there is no nesting`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Plain() {
+                    Text("hello")
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes at the default threshold`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun WithinLimit() {
+                    Box {
+                        Box {
+                            Box {
+                                Bar()
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `errors when nesting exceeds the default threshold`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun TooDeep() {
+                    Box {
+                        Box {
+                            Box {
+                                Box {
+                                    Box {
+                                        Text("")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+            ),
+        )
+    }
+
+    @Test
+    fun `errors per function in the file`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun TooDeepA() {
+                    Box { Box { Box { Box { Text("a") } } } }
+                }
+                @Composable
+                fun ShallowB() {
+                    Box { Text("b") }
+                }
+                @Composable
+                fun TooDeepC() {
+                    Column { Row { Box { Box { Text("c") } } } }
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+            ),
+            LintViolation(
+                line = 10,
+                col = 5,
+                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+            ),
+        )
+    }
+
+    @Test
+    fun `respects a custom threshold via editorconfig`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun BarelyOk() {
+                    Box {
+                        Box {
+                            Text("hello")
+                        }
+                    }
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthThreshold to "1")
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+                ),
+            )
+    }
+
+    @Test
+    fun `passes when threshold is raised to allow deep nesting`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun PreviouslyTooDeep() {
+                    Box {
+                        Box {
+                            Box {
+                                Box {
+                                    Text("hello")
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthThreshold to "10")
+            .hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not count non-Composable control flow toward nesting`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun WithControlFlow(items: List<String>, cond: Boolean) {
+                    Box {
+                        if (cond) {
+                            for (item in items) {
+                                Box {
+                                    Text(item)
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `does not flag functions without a block body`() {
+        @Language("kotlin")
+        val code =
+            """
+                val Content: @Composable () -> Unit = { Text("hi") }
+            """.trimIndent()
+        nestingRuleAssertThat(code).hasNoLintViolations()
+    }
+}

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
@@ -183,4 +183,37 @@ class ComposableNestingDepthCheckTest {
             """.trimIndent()
         nestingRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `does not count nesting inside a locally-declared composable toward the outer function`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Outer() {
+                    @Composable
+                    fun Inner() {
+                        Box {
+                            Box {
+                                Box {
+                                    Box {
+                                        Text("hi")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Inner()
+                }
+            """.trimIndent()
+        // Outer's body only calls Inner() (not an emitter), so it must not be flagged.
+        // Inner itself has 4 nested Boxes around Text, so it should be flagged on its own.
+        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 4,
+                col = 9,
+                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+            ),
+        )
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
@@ -120,7 +120,7 @@ class ComposableNestingDepthCheckTest {
                 }
             """.trimIndent()
         nestingRuleAssertThat(code)
-            .withEditorConfigOverride(composableNestingDepthThreshold to "1")
+            .withEditorConfigOverride(composableNestingDepthThreshold to 1)
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(
                     line = 2,
@@ -149,7 +149,7 @@ class ComposableNestingDepthCheckTest {
                 }
             """.trimIndent()
         nestingRuleAssertThat(code)
-            .withEditorConfigOverride(composableNestingDepthThreshold to "10")
+            .withEditorConfigOverride(composableNestingDepthThreshold to 10)
             .hasNoLintViolations()
     }
 

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
@@ -13,6 +13,29 @@ class ComposableNestingDepthCheckTest {
     private val nestingRuleAssertThat = assertThatRule { ComposableNestingDepthCheck() }
 
     @Test
+    fun `disabled by default`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun TooDeep() {
+                    Box {
+                        Box {
+                            Box {
+                                Box {
+                                    Box {
+                                        Text("")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent()
+        nestingRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `passes when there is no nesting`() {
         @Language("kotlin")
         val code =
@@ -22,7 +45,9 @@ class ComposableNestingDepthCheckTest {
                     Text("hello")
                 }
             """.trimIndent()
-        nestingRuleAssertThat(code).hasNoLintViolations()
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasNoLintViolations()
     }
 
     @Test
@@ -41,7 +66,9 @@ class ComposableNestingDepthCheckTest {
                     }
                 }
             """.trimIndent()
-        nestingRuleAssertThat(code).hasNoLintViolations()
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasNoLintViolations()
     }
 
     @Test
@@ -64,13 +91,15 @@ class ComposableNestingDepthCheckTest {
                     }
                 }
             """.trimIndent()
-        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
-            ),
-        )
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+                ),
+            )
     }
 
     @Test
@@ -91,18 +120,20 @@ class ComposableNestingDepthCheckTest {
                     Column { Row { Box { Box { Text("c") } } } }
                 }
             """.trimIndent()
-        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
-            ),
-            LintViolation(
-                line = 10,
-                col = 5,
-                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
-            ),
-        )
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+                ),
+                LintViolation(
+                    line = 10,
+                    col = 5,
+                    detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+                ),
+            )
     }
 
     @Test
@@ -120,7 +151,10 @@ class ComposableNestingDepthCheckTest {
                 }
             """.trimIndent()
         nestingRuleAssertThat(code)
-            .withEditorConfigOverride(composableNestingDepthThreshold to 1)
+            .withEditorConfigOverride(
+                composableNestingDepthEnabled to true,
+                composableNestingDepthThreshold to 1,
+            )
             .hasLintViolationsWithoutAutoCorrect(
                 LintViolation(
                     line = 2,
@@ -149,7 +183,10 @@ class ComposableNestingDepthCheckTest {
                 }
             """.trimIndent()
         nestingRuleAssertThat(code)
-            .withEditorConfigOverride(composableNestingDepthThreshold to 10)
+            .withEditorConfigOverride(
+                composableNestingDepthEnabled to true,
+                composableNestingDepthThreshold to 10,
+            )
             .hasNoLintViolations()
     }
 
@@ -171,7 +208,9 @@ class ComposableNestingDepthCheckTest {
                     }
                 }
             """.trimIndent()
-        nestingRuleAssertThat(code).hasNoLintViolations()
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasNoLintViolations()
     }
 
     @Test
@@ -181,7 +220,9 @@ class ComposableNestingDepthCheckTest {
             """
                 val Content: @Composable () -> Unit = { Text("hi") }
             """.trimIndent()
-        nestingRuleAssertThat(code).hasNoLintViolations()
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasNoLintViolations()
     }
 
     @Test
@@ -208,13 +249,15 @@ class ComposableNestingDepthCheckTest {
             """.trimIndent()
         // Outer's body only calls Inner() (not an emitter), so it must not be flagged.
         // Inner itself has 4 nested Boxes around Text, so it should be flagged on its own.
-        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 4,
-                col = 9,
-                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
-            ),
-        )
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 4,
+                    col = 9,
+                    detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+                ),
+            )
     }
 
     @Test
@@ -229,12 +272,14 @@ class ComposableNestingDepthCheckTest {
             """.trimIndent()
         // TooDeep nests 4 emitters around Text (> threshold) and is flagged.
         // WithinLimit nests 3 (== threshold) and is intentionally absent from the expected violations.
-        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 2,
-                col = 5,
-                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
-            ),
-        )
+        nestingRuleAssertThat(code)
+            .withEditorConfigOverride(composableNestingDepthEnabled to true)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 2,
+                    col = 5,
+                    detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+                ),
+            )
     }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ComposableNestingDepthCheckTest.kt
@@ -216,4 +216,25 @@ class ComposableNestingDepthCheckTest {
             ),
         )
     }
+
+    @Test
+    fun `analyzes expression-bodied composables for nesting depth`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun TooDeep() = Box { Box { Box { Box { Text("x") } } } }
+                @Composable
+                fun WithinLimit() = Box { Box { Box { Text("x") } } }
+            """.trimIndent()
+        // TooDeep nests 4 emitters around Text (> threshold) and is flagged.
+        // WithinLimit nests 3 (== threshold) and is intentionally absent from the expected violations.
+        nestingRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 2,
+                col = 5,
+                detail = ComposableNestingDepth.ComposableTooDeeplyNested,
+            ),
+        )
+    }
 }

--- a/samples/detekt-sample/detekt.yml
+++ b/samples/detekt-sample/detekt.yml
@@ -38,7 +38,7 @@ Compose:
   ComposableNaming:
     active: true
   ComposableNestingDepth:
-    active: true
+    active: false
   ComposableParamOrder:
     active: true
   CompositionLocalAllowlist:

--- a/samples/detekt-sample/detekt.yml
+++ b/samples/detekt-sample/detekt.yml
@@ -37,6 +37,8 @@ Compose:
     active: true
   ComposableNaming:
     active: true
+  ComposableNestingDepth:
+    active: true
   ComposableParamOrder:
     active: true
   CompositionLocalAllowlist:


### PR DESCRIPTION
Closes #617.

Adds a `ComposableNestingDepth` rule that flags `@Composable` functions whose content emitters are nested more deeply than a configurable threshold. Encourages extracting inner sections into private composables for readability.

```kotlin
// ❌ Flagged at the default threshold of 3
@Composable
fun Foo() {
    Box { Box { Box { Box { Box { Text("") } } } } }
}

// ✅ Passes — inner section extracted
@Composable
fun Foo() {
    Box { Box { Box { Bar() } } }
}
```

Threshold is tunable via `composableNestingDepthThreshold` in detekt or `compose_composable_nesting_depth_threshold` in `.editorconfig` for ktlint.

Non-Composable control flow (`if`, `for`, `when`, etc.) doesn't count toward depth. Reuses the existing `KtCallExpression.emitsContent` helper so the configured `contentEmitters` / `contentEmittersDenylist` keep working transparently.
