### PR TITLE
Fix #637: make defaults-visibility suppressible at declaration scope

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/ComposeKtVisitor.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/ComposeKtVisitor.kt
@@ -3,6 +3,7 @@
 package io.nlopez.compose.core
 
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 
@@ -15,6 +16,8 @@ interface ComposeKtVisitor {
     fun visitComposable(function: KtFunction, emitter: Emitter, config: ComposeKtConfig) {}
 
     fun visitClass(clazz: KtClass, emitter: Emitter, config: ComposeKtConfig) {}
+
+    fun visitClassOrObject(clazz: KtClassOrObject, emitter: Emitter, config: ComposeKtConfig) {}
 
     fun visitFile(file: KtFile, emitter: Emitter, config: ComposeKtConfig) {}
 }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/DefaultsVisibility.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/DefaultsVisibility.kt
@@ -12,7 +12,6 @@ import io.nlopez.compose.core.util.isInternal
 import io.nlopez.compose.core.util.isPrivate
 import io.nlopez.compose.core.util.isProtected
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtReferenceExpression
@@ -20,59 +19,41 @@ import org.jetbrains.kotlin.psi.psiUtil.isPublic
 
 class DefaultsVisibility : ComposeKtVisitor {
 
-    override fun visitFile(file: KtFile, emitter: Emitter, config: ComposeKtConfig) {
-        val composables = file.findAllChildrenByClass<KtFunction>()
+    override fun visitClassOrObject(clazz: KtClassOrObject, emitter: Emitter, config: ComposeKtConfig) {
+        val defaultObjectName = clazz.name ?: return
+        if (!defaultObjectName.endsWith("Defaults")) return
+
+        val composableName = defaultObjectName.removeSuffix("Defaults")
+        if (composableName.isEmpty()) return
+
+        val mostVisibleComposable = clazz.containingKtFile
+            .findAllChildrenByClass<KtFunction>()
             .filter { it.isComposable }
+            .filter { it.name == composableName }
+            .filter { composable ->
+                val hasReferenceInParameters = composable.valueParameters
+                    .mapNotNull { it.defaultValue }
+                    .flatMap { it.findAllChildrenByClass<KtReferenceExpression>() }
+                    .any { it.text == defaultObjectName }
 
-        val composableNamesForDefaults = composables.mapNotNull { it.name }.map { it + "Defaults" }.toSet()
+                if (hasReferenceInParameters) return@filter true
 
-        // Default holders should be the ones named ${composableName}Defaults and defined in the same .kt file as them,
-        // as they should be co-located. Maybe a possible future rule would be to check for co-location of these.
-        val defaultObjects = file.findAllChildrenByClass<KtClassOrObject>()
-            .filter { it.name in composableNamesForDefaults }
-
-        if (defaultObjects.count() == 0) return
-
-        // We want to obtain the pairing of the default objects to their most visible composable counterparts.
-        // Hold on to your butts.
-        val defaultToMostVisibleComposable = defaultObjects.map { defaultObject ->
-            // Find the matching composables to the default object
-            val mostVisible = composables.filter { it.name + "Defaults" == defaultObject.name }
-                .filter { composable ->
-                    // Now we need to check whether anything from the default object is used either in the params
-                    // or in the code of the composable itself. This should be enough for most cases.
-
-                    // Check parameter defaults first
-                    val hasReferenceInParameters = composable.valueParameters
-                        .mapNotNull { it.defaultValue }
-                        .flatMap { it.findAllChildrenByClass<KtReferenceExpression>() }
-                        .any { it.text == defaultObject.name }
-
-                    if (hasReferenceInParameters) return@filter true
-
-                    // If none found, check the code then.
-                    val body = composable.bodyBlockExpression ?: return@filter false
-                    return@filter body.findAllChildrenByClass<KtReferenceExpression>()
-                        .any { it.text == defaultObject.name }
-                }
-                // Now we want to obtain just the most visible visibility in case there are more than one hit
-                .maxByOrNull { it.visibilityInt }
-
-            defaultObject to mostVisible
-        }
-
-        // If we find a "defaults" object with less visibility than its composable, we report it
-        for ((defaultObject, composable) in defaultToMostVisibleComposable) {
-            if (composable != null && defaultObject.visibilityInt < composable.visibilityInt) {
-                emitter.report(
-                    element = defaultObject,
-                    errorMessage = createMessage(
-                        composableVisibility = composable.visibilityString,
-                        defaultObjectName = defaultObject.name!!,
-                        defaultObjectVisibility = defaultObject.visibilityString,
-                    ),
-                )
+                val body = composable.bodyBlockExpression ?: return@filter false
+                body.findAllChildrenByClass<KtReferenceExpression>()
+                    .any { it.text == defaultObjectName }
             }
+            .maxByOrNull { it.visibilityInt }
+            ?: return
+
+        if (clazz.visibilityInt < mostVisibleComposable.visibilityInt) {
+            emitter.report(
+                element = clazz,
+                errorMessage = createMessage(
+                    composableVisibility = mostVisibleComposable.visibilityString,
+                    defaultObjectName = defaultObjectName,
+                    defaultObjectVisibility = clazz.visibilityString,
+                ),
+            )
         }
     }
 

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/DetektRule.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/DetektRule.kt
@@ -11,6 +11,7 @@ import io.nlopez.compose.core.Decision
 import io.nlopez.compose.core.Emitter
 import io.nlopez.compose.core.util.isComposable
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
@@ -60,6 +61,11 @@ abstract class DetektRule(
     override fun visitClass(klass: KtClass) {
         super<Rule>.visitClass(klass)
         visitClass(klass, emitter, composeConfig)
+    }
+
+    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+        super<Rule>.visitClassOrObject(classOrObject)
+        visitClassOrObject(classOrObject, emitter, composeConfig)
     }
 
     override fun visitKtElement(element: KtElement) {

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/DefaultsVisibilityCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/DefaultsVisibilityCheck.kt
@@ -3,6 +3,7 @@
 package io.nlopez.compose.rules.detekt
 
 import dev.detekt.api.Config
+import dev.detekt.api.RuleName
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DefaultsVisibility
 import io.nlopez.compose.rules.DetektRule
@@ -14,4 +15,7 @@ class DefaultsVisibilityCheck(config: Config) :
         description = "Composable function defaults should have appropriate visibility",
         url = URI("https://mrmans0n.github.io/compose-rules/rules/#defaults-visibility"),
     ),
-    ComposeKtVisitor by DefaultsVisibility()
+    ComposeKtVisitor by DefaultsVisibility() {
+
+    override val ruleName: RuleName get() = RuleName("DefaultsVisibility")
+}

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/DefaultsVisibilityCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/DefaultsVisibilityCheckTest.kt
@@ -68,4 +68,18 @@ class DefaultsVisibilityCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes when defaults object has reduced visibility but it's suppressed on the object`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Suppress("DefaultsVisibility")
+                internal object MyComposableDefaults
+                @Composable
+                fun MyComposable(someParam: Bleh = MyComposableDefaults.someParam) { }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/KtlintRule.kt
+++ b/rules/ktlint/src/main/kotlin/io/nlopez/compose/rules/KtlintRule.kt
@@ -16,6 +16,7 @@ import io.nlopez.compose.core.util.startOffsetFromName
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiNameIdentifierOwner
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
@@ -48,7 +49,13 @@ abstract class KtlintRule(id: String, editorConfigProperties: Set<EditorConfigPr
         when (val psi = node.psi) {
             is KtFile -> visitFile(psi, emit.toEmitter(), config)
 
-            is KtClass -> visitClass(psi, emit.toEmitter(), config)
+            is KtClassOrObject -> {
+                val emitter = emit.toEmitter()
+                visitClassOrObject(psi, emitter, config)
+                if (psi is KtClass) {
+                    visitClass(psi, emitter, config)
+                }
+            }
 
             is KtFunction -> {
                 val emitter = emit.toEmitter()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/DefaultsVisibilityCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/DefaultsVisibilityCheckTest.kt
@@ -65,4 +65,31 @@ class DefaultsVisibilityCheckTest {
             """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when defaults object has reduced visibility but it's suppressed on the object`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Suppress("ktlint:compose:defaults-visibility")
+                internal object MyComposableDefaults
+                @Composable
+                fun MyComposable(someParam: Bleh = MyComposableDefaults.someParam) { }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when defaults object has reduced visibility but file is suppressed`() {
+        @Language("kotlin")
+        val code =
+            """
+                @file:Suppress("ktlint:compose:defaults-visibility")
+
+                internal object MyComposableDefaults
+                @Composable
+                fun MyComposable(someParam: Bleh = MyComposableDefaults.someParam) { }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 }


### PR DESCRIPTION
## Summary

- `DefaultsVisibility` now visits at `KtClassOrObject` instead of `KtFile`, so `@Suppress("DefaultsVisibility")` placed directly on a `Defaults` object is honored by detekt (and on older ktlint hosts that don't already handle cross-scope suppression at the engine level).
- Adds `visitClassOrObject(KtClassOrObject, …)` to `ComposeKtVisitor`, as a broader sibling to the existing `visitClass(KtClass, …)`. Both `KtlintRule` and `DetektRule` dispatch it; `visitClass` continues to fire for classes (same broader/narrower pattern as `visitFunction`/`visitComposable`).
- `DefaultsVisibilityCheck` (detekt) overrides `ruleName` to `"DefaultsVisibility"` so detekt-test's suppression matcher uses the same name users put in `@Suppress` (the provider already registers the rule under that name).
- Same analysis semantics — cross-file context is now derived per object via `containingKtFile`.

## Test plan

- [x] `./gradlew :rules:common:test :rules:ktlint:test :rules:detekt:test` — green, including new regression tests for both object-scope and file-scope suppression on each linter.
- [x] `./gradlew :rules:functional-tests:functionalTest` (after `publishToMavenLocal`) — green.
- [x] `./gradlew build` — green.
- [x] Verified `PreviewAnnotationNamingCheckTest` and `ComposableAnnotationNamingCheckTest` still pass — the broader `visitClassOrObject` does not displace the narrower `visitClass` for classes.

## Notes

- The ktlint side never reproduced the bug in this repo's test harness (ktlint 1.8.0 handles cross-scope suppression at the engine level). The user's original report came via kotlinter-gradle 5.0.1, which pins ktlint 1.5.0 where the bug does reproduce; the smaller visit scope here helps those hosts transitively.
- Other detekt rules in this repo have a latent name mismatch between their provider `RuleName` (e.g. `"ModifierMissing"`) and their default `ruleName` (`"ModifierMissingCheck"`). In production their suppression works (resolution uses `ruleInstance.id` from the provider map), but unit tests written with the public name would not currently filter through `detekt-test`. Worth a follow-up issue to align them; left out of scope here.

Fixes #637