### PR TITLE
Add `StaleRememberUpdatedStateInRemember` detekt rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ google-services.json
 # MkDocs site
 site/
 
+# Local planning docs
+docs/superpowers/
+
 # Python virtual environment
 .venv/
 

--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -152,6 +152,8 @@ Compose:
     active: true
   RememberMissing:
     active: true
+  StaleRememberUpdatedStateInRemember:
+    active: true
   StateParam:
     active: true
   UnstableCollections:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -499,6 +499,45 @@ These need to persist across compositions; if detached from the composition, the
 
     :material-chevron-right-box: [compose:remember-content-missing-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberContentMissing.kt) ktlint :material-chevron-right-box: [RememberContentMissing](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberContentMissing.kt) detekt
 
+### Do not eagerly read rememberUpdatedState in remember
+
+`rememberUpdatedState` keeps a stable state object while updating its value across recompositions. If you read a delegated `rememberUpdatedState(...)` value directly inside a `remember { }`, `rememberSaveable { }`, or `retain { }` initializer, the remembered value captures only the value from the composition that created it. Later source changes update the `rememberUpdatedState`, but they do not re-run the initializer unless the `remember` call is keyed on that source value.
+
+```kotlin
+// ❌ The Action keeps the first onDismiss value.
+@Composable
+fun DialogActions(onDismiss: () -> Unit) {
+    val latestOnDismiss by rememberUpdatedState(onDismiss)
+    val dismissAction = remember {
+        Action(onDismiss = latestOnDismiss)
+    }
+}
+
+// ✅ Defer reading the latest value until the callback runs.
+@Composable
+fun DialogActions(onDismiss: () -> Unit) {
+    val latestOnDismiss by rememberUpdatedState(onDismiss)
+    val dismissAction = remember {
+        { latestOnDismiss() }
+    }
+}
+
+// ✅ Or key remember when eager recomputation is intended.
+@Composable
+fun DialogActions(onDismiss: () -> Unit) {
+    val latestOnDismiss by rememberUpdatedState(onDismiss)
+    val dismissAction = remember(onDismiss) {
+        Action(onDismiss = latestOnDismiss)
+    }
+}
+```
+
+This rule is detekt-only and uses detekt's analysis API.
+
+!!! info ""
+
+    :material-chevron-right-box: [StaleRememberUpdatedStateInRemember](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/StaleRememberUpdatedStateInRememberCheck.kt) detekt
+
 ### Make dependencies explicit
 
 #### ViewModels

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ ktlint-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktli
 
 detekt-core = { module = "dev.detekt:detekt-core", version.ref = "detekt" }
 detekt-test = { module = "dev.detekt:detekt-test", version.ref = "detekt" }
+detekt-test-utils = { module = "dev.detekt:detekt-test-utils", version.ref = "detekt" }
 detekt-psi-utils = { module = "dev.detekt:detekt-psi-utils", version.ref = "detekt" }
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }

--- a/rules/detekt/build.gradle.kts
+++ b/rules/detekt/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     api(projects.rules.commonDetekt)
 
     testImplementation(libs.detekt.test)
+    testImplementation(libs.detekt.test.utils)
     testImplementation(libs.junit5)
     testImplementation(libs.junit5.params)
     testImplementation(libs.junit5.engine)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
@@ -1,0 +1,56 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotated
+import org.jetbrains.kotlin.analysis.api.components.expectedType
+import org.jetbrains.kotlin.analysis.api.components.functionType
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KaAnnotatedSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.symbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import io.nlopez.compose.core.util.isComposable as hasComposableAnnotationText
+
+internal fun KtElement.isInsideComposableScope(): Boolean {
+    var current = parent
+    while (current != null) {
+        when (current) {
+            is KtNamedFunction -> return current.isComposable()
+            is KtPropertyAccessor -> return current.isComposable()
+            is KtLambdaExpression -> if (current.isComposable()) return true
+        }
+        current = current.parent
+    }
+    return false
+}
+
+private fun KtNamedFunction.isComposable(): Boolean = hasComposableAnnotationText ||
+    runCatching {
+        analyze(this) {
+            this@isComposable.symbol.hasComposableAnnotation()
+        }
+    }.getOrDefault(false)
+
+private fun KtPropertyAccessor.isComposable(): Boolean = hasComposableAnnotationText ||
+    runCatching {
+        analyze(this) {
+            this@isComposable.symbol.hasComposableAnnotation()
+        }
+    }.getOrDefault(false)
+
+private fun KtLambdaExpression.isComposable(): Boolean = runCatching {
+    analyze(this) {
+        functionLiteral.functionType.hasComposableAnnotation() ||
+            this@isComposable.expectedType?.hasComposableAnnotation() == true
+    }
+}.getOrDefault(false)
+
+private fun KaAnnotatedSymbol.hasComposableAnnotation(): Boolean =
+    annotations.any { it.classId == ClassId.topLevel(ComposeFqNames.Composable) }
+
+private fun KaAnnotated.hasComposableAnnotation(): Boolean =
+    annotations.any { it.classId == ClassId.topLevel(ComposeFqNames.Composable) }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
@@ -1,0 +1,24 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.name.FqName
+
+internal object ComposeFqNames {
+    internal var runtime: FqName = FqName("androidx.compose.runtime")
+    internal var runtimeSaveable: FqName = FqName("androidx.compose.runtime.saveable")
+    internal var runtimeRetain: FqName = FqName("androidx.compose.runtime.retain")
+
+    val Composable: FqName
+        get() = runtime.child("Composable")
+    val Remember: FqName
+        get() = runtime.child("remember")
+    val RememberUpdatedState: FqName
+        get() = runtime.child("rememberUpdatedState")
+    val RememberSaveable: FqName
+        get() = runtimeSaveable.child("rememberSaveable")
+    val Retain: FqName
+        get() = runtimeRetain.child("retain")
+
+    private fun FqName.child(name: String): FqName = FqName("${asString()}.$name")
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -48,6 +48,9 @@ class ComposeRuleSetProvider : RuleSetProvider {
             RuleName("PreviewPublic") to { config: Config -> PreviewPublicCheck(config) },
             RuleName("RememberContentMissing") to { config: Config -> RememberContentMissingCheck(config) },
             RuleName("RememberMissing") to { config: Config -> RememberStateMissingCheck(config) },
+            RuleName("StaleRememberUpdatedStateInRemember") to { config: Config ->
+                StaleRememberUpdatedStateInRememberCheck(config)
+            },
             RuleName("StateParam") to { config: Config -> StateParameterCheck(config) },
             RuleName("UnstableCollections") to { config: Config -> UnstableCollectionsCheck(config) },
             RuleName("ViewModelForwarding") to { config: Config -> ViewModelForwardingCheck(config) },

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
@@ -1,0 +1,37 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.resolveCall
+import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+
+@OptIn(KaExperimentalApi::class)
+internal fun KtCallExpression.isResolvedCallToAnyOf(fqNames: Set<FqName>): Boolean = runCatching {
+    analyze(this) {
+        val call = this@isResolvedCallToAnyOf.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        call.signature.symbol.callableId?.asSingleFqName() in fqNames
+    }
+}.getOrDefault(false)
+
+internal fun KtCallExpression.isRememberUpdatedStateCall(): Boolean =
+    isResolvedCallToAnyOf(setOf(ComposeFqNames.RememberUpdatedState))
+
+internal fun KtCallExpression.isMemoizingComposableCall(): Boolean = isResolvedCallToAnyOf(
+    setOf(
+        ComposeFqNames.Remember,
+        ComposeFqNames.RememberSaveable,
+        ComposeFqNames.Retain,
+    ),
+)
+
+@OptIn(KaExperimentalApi::class)
+internal fun KtCallExpression.isResolvedCallToAnyNamed(fqNames: Set<String>): Boolean = runCatching {
+    analyze(this) {
+        val call = this@isResolvedCallToAnyNamed.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        call.signature.symbol.callableId?.asSingleFqName()?.asString() in fqNames
+    }
+}.getOrDefault(false)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtExpressions.analysis.kt
@@ -1,0 +1,58 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.resolveToCall
+import org.jetbrains.kotlin.analysis.api.components.resolveToSymbol
+import org.jetbrains.kotlin.analysis.api.resolution.KaVariableAccessCall
+import org.jetbrains.kotlin.analysis.api.symbols.sourcePsiSafe
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+
+internal fun KtExpression.isSameResolvedValueAs(other: KtExpression): Boolean = runCatching {
+    analyze(this) {
+        val resolver = object {
+            fun KtExpression.resolvedValueKey(): ResolvedValueKey? {
+                val symbol = when (this) {
+                    is KtSimpleNameExpression -> mainReference.resolveToSymbol()
+
+                    is KtQualifiedExpression -> (selectorExpression as? KtSimpleNameExpression)
+                        ?.mainReference
+                        ?.resolveToSymbol()
+
+                    else -> (resolveToCall() as? KaVariableAccessCall)?.signature?.symbol
+                } ?: return null
+                val symbolKey = symbol.sourcePsiSafe<KtElement>() ?: symbol
+
+                val receiverKey = when (this) {
+                    is KtQualifiedExpression -> receiverExpression.resolvedReceiverKey() ?: return null
+                    else -> null
+                }
+                return ResolvedValueKey(symbolKey, receiverKey)
+            }
+
+            private fun KtExpression.resolvedReceiverKey(): Any? = when (this) {
+                is KtSimpleNameExpression -> {
+                    val symbol = mainReference.resolveToSymbol() ?: return null
+                    symbol.sourcePsiSafe<KtElement>() ?: symbol
+                }
+
+                is KtQualifiedExpression -> resolvedValueKey()
+
+                else -> null
+            }
+        }
+
+        with(resolver) {
+            val left = this@isSameResolvedValueAs.resolvedValueKey()
+            val right = other.resolvedValueKey()
+            left != null && right != null && left == right
+        }
+    }
+}.getOrDefault(false)
+
+private data class ResolvedValueKey(val symbolKey: Any, val receiverKey: Any?)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
@@ -1,0 +1,38 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.resolveToCall
+import org.jetbrains.kotlin.analysis.api.components.resolveToSymbol
+import org.jetbrains.kotlin.analysis.api.resolution.KaVariableAccessCall
+import org.jetbrains.kotlin.analysis.api.symbols.sourcePsiSafe
+import org.jetbrains.kotlin.analysis.api.symbols.symbol
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+
+internal fun KtSimpleNameExpression.isResolvedReadOf(property: KtProperty): Boolean = runCatching {
+    analyze(this) {
+        val propertySymbol = property.symbol
+        val referenceSymbol = this@isResolvedReadOf.mainReference.resolveToSymbol()
+        if (referenceSymbol == propertySymbol || referenceSymbol?.sourcePsiSafe<KtProperty>() == property) {
+            return@analyze true
+        }
+
+        val read = this@isResolvedReadOf.resolveToCall() as? KaVariableAccessCall ?: return@analyze false
+        read.signature.symbol == propertySymbol || read.signature.symbol.sourcePsiSafe<KtProperty>() == property
+    }
+}.getOrDefault(false)
+
+internal fun KtSimpleNameExpression.resolvedPropertyInitializer(): KtExpression? =
+    resolvedLocalImmutableProperty()?.initializer
+
+internal fun KtSimpleNameExpression.resolvedLocalImmutableProperty(): KtProperty? = runCatching {
+    analyze(this) {
+        mainReference.resolveToSymbol()
+            ?.sourcePsiSafe<KtProperty>()
+            ?.takeIf { property -> property.isLocal && !property.isVar }
+    }
+}.getOrNull()

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/StaleRememberUpdatedStateInRememberCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/StaleRememberUpdatedStateInRememberCheck.kt
@@ -1,0 +1,359 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.psi.KtValueArgument
+import java.net.URI
+import java.util.ArrayDeque
+
+class StaleRememberUpdatedStateInRememberCheck(config: Config) :
+    Rule(
+        config = config,
+        description = "rememberUpdatedState values should not be read eagerly in remember initializers",
+        url = URI("https://mrmans0n.github.io/compose-rules/rules/#stale-rememberupdatedstate-in-remember"),
+    ),
+    RequiresAnalysisApi {
+
+    override val ruleName: RuleName = RuleName("StaleRememberUpdatedStateInRemember")
+
+    private val propertyScopes = ArrayDeque<MutableList<RememberUpdatedStateProperty>>()
+    private var memoizingCalculationDepth = 0
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        withPropertyScope {
+            super.visitNamedFunction(function)
+        }
+    }
+
+    override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+        withPropertyScope {
+            super.visitPropertyAccessor(accessor)
+        }
+    }
+
+    override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+        withPropertyScope {
+            super.visitLambdaExpression(lambdaExpression)
+        }
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        if (memoizingCalculationDepth == 0) {
+            property.toRememberUpdatedStateProperty()?.let { propertyScopes.peekLast()?.add(it) }
+        }
+        super.visitProperty(property)
+    }
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        if (expression.isInsideComposableScope() && expression.isMemoizingComposableCall()) {
+            reportStaleReads(expression)
+            memoizingCalculationDepth++
+            super.visitCallExpression(expression)
+            memoizingCalculationDepth--
+        } else {
+            super.visitCallExpression(expression)
+        }
+    }
+
+    private fun withPropertyScope(block: () -> Unit) {
+        propertyScopes.addLast(mutableListOf())
+        try {
+            block()
+        } finally {
+            propertyScopes.removeLast()
+        }
+    }
+
+    private fun KtProperty.toRememberUpdatedStateProperty(): RememberUpdatedStateProperty? {
+        if (!isInsideComposableScope()) return null
+        val readKind = if (hasDelegate()) {
+            RememberUpdatedStateReadKind.DelegatedValue
+        } else {
+            RememberUpdatedStateReadKind.StateValue
+        }
+        val rememberUpdatedStateCall = (delegateExpression ?: initializer)?.rememberUpdatedStateCall() ?: return null
+        if (!rememberUpdatedStateCall.isRememberUpdatedStateCall()) return null
+        val name = name ?: return null
+
+        return RememberUpdatedStateProperty(
+            property = this,
+            name = name,
+            readKind = readKind,
+            sourceExpressions = rememberUpdatedStateCall.argumentExpressions(),
+        )
+    }
+
+    private fun reportStaleReads(expression: KtCallExpression) {
+        val keyExpressions = expression.keyExpressions()
+        val properties = propertyScopes
+            .flatMap { it }
+            .filterNot { property -> property.isKeyedBy(keyExpressions) }
+        if (properties.isEmpty()) return
+
+        val propertiesByName = properties.groupBy { it.name }
+        val calculation = expression.calculationLambda() ?: return
+        calculation.bodyExpression?.accept(
+            object : KtTreeVisitorVoid() {
+                override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+                    if (lambdaExpression == calculation || lambdaExpression.isEagerScopeFunctionLambda()) {
+                        super.visitLambdaExpression(lambdaExpression)
+                    }
+                }
+
+                override fun visitNamedFunction(function: KtNamedFunction) {
+                    // Local functions defer reads until invocation.
+                }
+
+                override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+                    // Property getters defer reads until invocation.
+                }
+
+                override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
+                    if (expression.isPropertyDeclarationName()) return
+                    if (propertiesByName[expression.getReferencedName()]
+                            .orEmpty()
+                            .any { property -> property.isStaleRead(expression) }
+                    ) {
+                        report(
+                            Finding(
+                                entity = Entity.from(expression),
+                                message = StaleRememberUpdatedStateInRemember,
+                            ),
+                        )
+                    }
+                    super.visitSimpleNameExpression(expression)
+                }
+            },
+        )
+    }
+
+    private fun KtCallExpression.calculationLambda(): KtLambdaExpression? = valueArguments
+        .firstOrNull { argument -> argument.argumentName().isInitializerArgumentName() }
+        ?.getArgumentExpression() as? KtLambdaExpression
+        ?: lambdaArguments.lastOrNull()?.getLambdaExpression()
+        ?: valueArguments.lastOrNull()?.getArgumentExpression() as? KtLambdaExpression
+
+    private fun RememberUpdatedStateProperty.isKeyedBy(keyExpressions: List<KtExpression>): Boolean =
+        keyExpressions.any { keyExpression ->
+            when (readKind) {
+                RememberUpdatedStateReadKind.DelegatedValue ->
+                    (keyExpression as? KtSimpleNameExpression)?.isResolvedReadOf(property) == true
+
+                RememberUpdatedStateReadKind.StateValue -> keyExpression.isStateValueReadOf(property)
+            } ||
+                sourceExpressions.any { sourceExpression -> keyExpression.isSameResolvedValueAs(sourceExpression) }
+        }
+
+    private fun RememberUpdatedStateProperty.isStaleRead(expression: KtSimpleNameExpression): Boolean =
+        expression.isResolvedReadOf(property) &&
+            when (readKind) {
+                RememberUpdatedStateReadKind.DelegatedValue -> true
+                RememberUpdatedStateReadKind.StateValue -> expression.isStateValueReceiver()
+            }
+
+    private fun KtCallExpression.keyExpressions(): List<KtExpression> =
+        if (isResolvedCallToAnyOf(setOf(ComposeFqNames.RememberSaveable))) {
+            rememberSaveableKeyExpressions()
+        } else {
+            rememberOrRetainKeyExpressions()
+        }
+
+    private fun KtCallExpression.rememberOrRetainKeyExpressions(): List<KtExpression> =
+        valueArguments.flatMap { argument ->
+            val expression = argument.getArgumentExpression() ?: return@flatMap emptyList()
+            if (expression is KtLambdaExpression || argument.argumentName() == "calculation") {
+                emptyList()
+            } else {
+                argument.flattenedKeyExpressions()
+            }
+        }
+
+    private fun KtCallExpression.rememberSaveableKeyExpressions(): List<KtExpression> =
+        valueArguments.flatMap { argument ->
+            val expression = argument.getArgumentExpression() ?: return@flatMap emptyList()
+            if (expression is KtLambdaExpression) return@flatMap emptyList()
+
+            when (argument.argumentName()) {
+                null, "inputs" -> argument.flattenedKeyExpressions()
+                else -> emptyList()
+            }
+        }
+
+    private fun KtValueArgument.flattenedKeyExpressions(): List<KtExpression> {
+        val expression = getArgumentExpression() ?: return emptyList()
+        return expression.flattenKeyExpression(
+            containingCall = containingCallExpression(),
+            shouldFlattenArrayInitializer = getSpreadElement() != null || argumentName().isArrayContainerArgumentName(),
+        )
+    }
+
+    private fun KtValueArgument.containingCallExpression(): KtCallExpression? = generateSequence(parent) { element ->
+        element.parent
+    }.filterIsInstance<KtCallExpression>().firstOrNull()
+
+    private fun KtExpression.flattenKeyExpression(
+        containingCall: KtCallExpression? = null,
+        shouldFlattenArrayInitializer: Boolean = false,
+    ): List<KtExpression> = when {
+        this is KtCallExpression && isArrayOfCall() -> argumentExpressions()
+
+        shouldFlattenArrayInitializer && this is KtSimpleNameExpression -> resolvedPropertyInitializer()
+            ?.takeUnless { containingCall != null && isMutatedBefore(containingCall) }
+            ?.flattenKeyExpression(containingCall = containingCall, shouldFlattenArrayInitializer = true)
+            ?: listOf(this)
+
+        else -> listOf(this)
+    }
+
+    private fun KtSimpleNameExpression.isMutatedBefore(containingCall: KtCallExpression): Boolean {
+        val property = resolvedLocalImmutableProperty() ?: return true
+        val scanRoot = property.parent ?: return true
+        var isMutated = false
+        scanRoot.accept(
+            object : KtTreeVisitorVoid() {
+                override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+                    if (lambdaExpression.isEagerScopeFunctionLambda()) {
+                        super.visitLambdaExpression(lambdaExpression)
+                    }
+                }
+
+                override fun visitNamedFunction(function: KtNamedFunction) {
+                    // Local functions defer writes until invocation.
+                }
+
+                override fun visitCallExpression(expression: KtCallExpression) {
+                    if (expression.textOffset >= containingCall.textOffset) return
+                    if (expression.isSetCallOn(property)) {
+                        isMutated = true
+                        return
+                    }
+                    super.visitCallExpression(expression)
+                }
+
+                override fun visitBinaryExpression(expression: KtBinaryExpression) {
+                    if (expression.textOffset >= containingCall.textOffset) return
+                    if (expression.operationToken == KtTokens.EQ &&
+                        (expression.left as? KtArrayAccessExpression)
+                            ?.arrayExpression
+                            ?.let { arrayExpression -> arrayExpression as? KtSimpleNameExpression }
+                            ?.isReadOfArrayAlias(property) == true
+                    ) {
+                        isMutated = true
+                        return
+                    }
+                    super.visitBinaryExpression(expression)
+                }
+
+                override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                    if (expression.textOffset >= containingCall.textOffset) return
+                    if ((expression.receiverExpression as? KtSimpleNameExpression)?.isReadOfArrayAlias(
+                            property,
+                        ) == true &&
+                        (expression.selectorExpression as? KtCallExpression)?.calleeExpression?.text == "set"
+                    ) {
+                        isMutated = true
+                        return
+                    }
+                    super.visitDotQualifiedExpression(expression)
+                }
+            },
+        )
+
+        return isMutated
+    }
+
+    private fun KtCallExpression.isSetCallOn(property: KtProperty): Boolean = calleeExpression?.text == "set" &&
+        (parent as? KtDotQualifiedExpression)
+            ?.receiverExpression
+            ?.let { receiver -> receiver as? KtSimpleNameExpression }
+            ?.isReadOfArrayAlias(property) == true
+
+    private fun KtSimpleNameExpression.isReadOfArrayAlias(property: KtProperty): Boolean = isResolvedReadOf(property)
+
+    private fun KtCallExpression.isArrayOfCall(): Boolean = calleeExpression?.text == "arrayOf"
+
+    private fun KtCallExpression.argumentExpressions(): List<KtExpression> = valueArguments
+        .mapNotNull { argument -> argument.getArgumentExpression() }
+
+    private fun KtExpression.rememberUpdatedStateCall(): KtCallExpression? = when (this) {
+        is KtCallExpression -> this
+        is KtDotQualifiedExpression -> selectorExpression as? KtCallExpression
+        else -> null
+    }
+
+    private fun KtValueArgument.argumentName(): String? = getArgumentName()?.asName?.asString()
+
+    private fun String?.isInitializerArgumentName(): Boolean = this == "calculation" || this == "init"
+
+    private fun String?.isArrayContainerArgumentName(): Boolean = this == "keys" || this == "inputs"
+
+    private fun KtSimpleNameExpression.isPropertyDeclarationName(): Boolean =
+        (parent as? KtProperty)?.nameIdentifier == this
+
+    private fun KtSimpleNameExpression.isStateValueReceiver(): Boolean =
+        (parent as? KtDotQualifiedExpression)?.isStateValueReadOf(this) == true
+
+    private fun KtExpression.isStateValueReadOf(property: KtProperty): Boolean =
+        (this as? KtDotQualifiedExpression)?.let { qualifiedExpression ->
+            (qualifiedExpression.receiverExpression as? KtSimpleNameExpression)?.isResolvedReadOf(property) == true &&
+                qualifiedExpression.selectorExpression?.text == "value"
+        } == true
+
+    private fun KtDotQualifiedExpression.isStateValueReadOf(receiver: KtSimpleNameExpression): Boolean =
+        receiverExpression == receiver && selectorExpression?.text == "value"
+
+    private fun KtLambdaExpression.isEagerScopeFunctionLambda(): Boolean {
+        val callExpression = generateSequence(parent) { element -> element.parent }
+            .filterIsInstance<KtCallExpression>()
+            .firstOrNull()
+
+        return callExpression?.isResolvedCallToAnyNamed(EagerScopeFunctions) == true
+    }
+
+    internal companion object {
+        private val EagerScopeFunctions = setOf(
+            "kotlin.run",
+            "kotlin.with",
+            "kotlin.let",
+            "kotlin.also",
+            "kotlin.apply",
+            "kotlin.takeIf",
+            "kotlin.takeUnless",
+        )
+
+        val StaleRememberUpdatedStateInRemember = """
+            Reading a `rememberUpdatedState` value directly inside `remember { }`, `rememberSaveable { }`, or `retain { }` captures the initial value only.
+            Key the call on the source value or defer the read in a lambda.
+        """.trimIndent()
+    }
+}
+
+private data class RememberUpdatedStateProperty(
+    val property: KtProperty,
+    val name: String,
+    val readKind: RememberUpdatedStateReadKind,
+    val sourceExpressions: List<KtExpression>,
+)
+
+private enum class RememberUpdatedStateReadKind {
+    DelegatedValue,
+    StateValue,
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -57,6 +57,8 @@ Compose:
     active: true
   RememberMissing:
     active: true
+  StaleRememberUpdatedStateInRemember:
+    active: true
   StateParam:
     active: true
   UnstableCollections:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
@@ -1,0 +1,99 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.test.lintWithContext
+import dev.detekt.test.utils.createEnvironment
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.name.FqName
+
+internal fun <T> T.lintWithAnalysisApi(
+    @Language("kotlin") content: String,
+    vararg dependencyContents: String,
+    allowCompilationErrors: Boolean = false,
+): List<Finding> where T : Rule, T : RequiresAnalysisApi {
+    val previousRuntime = ComposeFqNames.runtime
+    val previousRuntimeSaveable = ComposeFqNames.runtimeSaveable
+    val previousRuntimeRetain = ComposeFqNames.runtimeRetain
+
+    return try {
+        val fakeComposeFqName = FqName("com.example.compose.fake")
+        ComposeFqNames.runtime = fakeComposeFqName
+        ComposeFqNames.runtimeSaveable = fakeComposeFqName
+        ComposeFqNames.runtimeRetain = fakeComposeFqName
+
+        val environment = createEnvironment()
+        lintWithContext(
+            environment = environment,
+            content = content,
+            dependencyContents = arrayOf(fakeComposeRuntime(), *dependencyContents),
+            allowCompilationErrors = allowCompilationErrors,
+        )
+    } finally {
+        ComposeFqNames.runtime = previousRuntime
+        ComposeFqNames.runtimeSaveable = previousRuntimeSaveable
+        ComposeFqNames.runtimeRetain = previousRuntimeRetain
+    }
+}
+
+@Language("kotlin")
+internal fun codeWithFakeCompose(@Language("kotlin") code: String): String = """
+    package com.example.compose.fake
+
+    $code
+""".trimIndent()
+
+@Language("kotlin")
+private fun fakeComposeRuntime(): String = codeWithFakeCompose(
+    """
+    @Target(
+        AnnotationTarget.FUNCTION,
+        AnnotationTarget.TYPE,
+        AnnotationTarget.TYPE_PARAMETER,
+        AnnotationTarget.PROPERTY_GETTER
+    )
+    annotation class Composable
+
+    @Composable
+    fun <T> remember(vararg keys: Any?, calculation: () -> T): T = calculation()
+
+    @Composable
+    fun <T> remember(calculation: () -> T): T = calculation()
+
+    @Composable
+    fun <T> rememberSaveable(vararg keys: Any?, calculation: () -> T): T = calculation()
+
+    @Composable
+    fun <T> rememberSaveable(key: String?, calculation: () -> T): T = calculation()
+
+    @Composable
+    fun <T> rememberSaveable(inputs: Array<Any?>, init: () -> T): T = init()
+
+    @Composable
+    fun <T> rememberSaveable(key: String?, init: () -> T): T = init()
+
+    @Composable
+    fun <T> rememberSaveable(calculation: () -> T): T = calculation()
+
+    @Composable
+    fun <T> retain(vararg keys: Any?, calculation: () -> T): T = calculation()
+
+    @Composable
+    fun <T> retain(calculation: () -> T): T = calculation()
+
+    interface State<T> {
+        val value: T
+    }
+
+    @Composable
+    fun <T> rememberUpdatedState(newValue: T): State<T> = object : State<T> {
+        override val value: T get() = newValue
+    }
+
+    @Composable
+    operator fun <T> State<T>.getValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>): T = value
+    """,
+)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProviderTest.kt
@@ -10,6 +10,7 @@ import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
 import com.lemonappdev.konsist.api.verify.assertTrue
 import dev.detekt.api.Config
+import dev.detekt.api.Rule
 import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.rules.DetektRule
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
@@ -19,6 +20,7 @@ import org.reflections.Reflections
 import org.reflections.scanners.Scanners
 import org.reflections.util.ConfigurationBuilder
 import java.io.File
+import java.lang.reflect.Modifier
 import kotlin.jvm.java
 
 class ComposeRuleSetProviderTest {
@@ -29,7 +31,9 @@ class ComposeRuleSetProviderTest {
     @Test
     fun `ensure all rules in the package are represented in the ruleset`() {
         val reflections = Reflections(ruleSetProvider.javaClass.packageName)
-        val ruleClassesInPackage = reflections.getSubTypesOf(DetektRule::class.java)
+        val ruleClassesInPackage = reflections.getSubTypesOf(Rule::class.java)
+            .filterNot { Modifier.isAbstract(it.modifiers) }
+            .toSet()
         val ruleClassesInRuleSet = ruleSet.rules.values
             .map { it(Config.empty)::class.java }
             .toSet()
@@ -52,9 +56,10 @@ class ComposeRuleSetProviderTest {
         val rules = ruleSet.rules
             .asSequence()
             .map { (name, factory) ->
-                val rule = factory(Config.empty) as DetektRule
-                name.value to rule.isOptIn
+                val rule = factory(Config.empty)
+                name.value to ((rule as? DetektRule)?.isOptIn ?: false)
             }
+            .toList()
 
         val optIn = rules.associate { it }
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/StaleRememberUpdatedStateInRememberCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/StaleRememberUpdatedStateInRememberCheckTest.kt
@@ -1,0 +1,946 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.SourceLocation
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class StaleRememberUpdatedStateInRememberCheckTest {
+
+    private val rule = StaleRememberUpdatedStateInRememberCheck(Config.empty)
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read directly inside remember`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports rememberUpdatedState state value read directly inside remember`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss = rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    Holder(latestOnDismiss.value)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `does not report rememberUpdatedState state object passed inside remember`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss = rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: State<() -> Unit>)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report rememberUpdatedState state value when remember is keyed by source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss = rememberUpdatedState(onDismiss)
+                val holder = remember(onDismiss) {
+                    Holder(latestOnDismiss.value)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report rememberUpdatedState state value when remember is keyed by state value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss = rememberUpdatedState(onDismiss)
+                val holder = remember(latestOnDismiss.value) {
+                    Holder(latestOnDismiss.value)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports fully qualified rememberUpdatedState delegated value read directly inside remember`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by com.example.compose.fake.rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read inside named remember calculation`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit, other: Any) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember(calculation = {
+                    Holder(latestOnDismiss)
+                }, keys = arrayOf(other))
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read directly inside rememberSaveable and retain`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit, onConfirm: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val latestOnConfirm by rememberUpdatedState(onConfirm)
+                val dismissHolder = rememberSaveable {
+                    Holder(latestOnDismiss)
+                }
+                val confirmHolder = retain {
+                    Holder(latestOnConfirm)
+                }
+            }
+
+            class Holder(val callback: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(2)
+            .hasStartSourceLocations(
+                SourceLocation(9, 24),
+                SourceLocation(12, 24),
+            )
+        for (finding in findings) {
+            assertThat(finding)
+                .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+        }
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read when rememberSaveable key is not an input`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(key: String, onDismiss: () -> Unit) {
+                val latestKey by rememberUpdatedState(key)
+                val holder = rememberSaveable(key = key, calculation = {
+                    Holder(latestKey.length)
+                })
+            }
+
+            class Holder(val length: Int)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read inside named rememberSaveable init`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(key: String, onDismiss: () -> Unit) {
+                val latestKey by rememberUpdatedState(key)
+                val holder = rememberSaveable(init = {
+                    Holder(latestKey.length)
+                }, key = key)
+            }
+
+            class Holder(val length: Int)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports read when nested out-of-scope rememberUpdatedState property has the same name`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit, other: () -> Unit, condition: Boolean) {
+                val latest by rememberUpdatedState(onDismiss)
+                if (condition) {
+                    val latest by rememberUpdatedState(other)
+                }
+                val holder = remember {
+                    Holder(latest)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(11, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `does not report when remember is keyed by the rememberUpdatedState source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember(onDismiss) {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when remember is keyed by named array containing rememberUpdatedState source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember(keys = arrayOf(onDismiss), calculation = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when remember is keyed by array variable containing source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val keys = arrayOf(onDismiss)
+                val holder = remember(keys = keys, calculation = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports when remember key array variable is mutable`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                var keys = arrayOf(onDismiss)
+                keys = arrayOf(Unit)
+                val holder = remember(keys = keys, calculation = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(10, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports when remember key array variable contents are mutated`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val keys = arrayOf(onDismiss)
+                keys[0] = {}
+                val holder = remember(keys = keys, calculation = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(10, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports when remember key array variable contents are mutated from eager run lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val keys = arrayOf(onDismiss)
+                run {
+                    keys[0] = {}
+                }
+                val holder = remember(keys = keys, calculation = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(12, 24))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `does not report when remember key array variable is mutated only from a deferred lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val keys = arrayOf(onDismiss)
+                val mutateLater = { keys[0] = {} }
+                val holder = remember(keys = keys, calculation = {
+                    Holder(latestOnDismiss)
+                })
+                mutateLater()
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when shadowed key array variable contents are mutated before remember`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val keys = arrayOf(onDismiss)
+                run {
+                    val keys = arrayOf(Unit)
+                    keys[0] = Unit
+                }
+                val holder = remember(keys = keys, calculation = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when rememberSaveable is keyed by inputs containing rememberUpdatedState source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = rememberSaveable(inputs = arrayOf(onDismiss), init = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when rememberSaveable is keyed by inputs variable containing source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val inputs = arrayOf(onDismiss)
+                val holder = rememberSaveable(inputs = inputs, init = {
+                    Holder(latestOnDismiss)
+                })
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when retain is keyed by spread array containing rememberUpdatedState source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val keys = arrayOf(onDismiss)
+                val holder = retain(*keys) {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read inside eager run lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    run {
+                        Holder(latestOnDismiss)
+                    }
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(9, 28))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read inside eager let lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    onDismiss.let {
+                        Holder(latestOnDismiss)
+                    }
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(9, 28))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value read inside eager takeIf and takeUnless lambdas`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: (() -> Unit)?) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    val enabled = onDismiss.takeIf { latestOnDismiss != null }
+                    val disabled = onDismiss.takeUnless { latestOnDismiss != null }
+                    Holder(enabled, disabled)
+                }
+            }
+
+            class Holder(val enabled: (() -> Unit)?, val disabled: (() -> Unit)?)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(2)
+            .hasStartSourceLocations(
+                SourceLocation(8, 50),
+                SourceLocation(9, 55),
+            )
+        for (finding in findings) {
+            assertThat(finding)
+                .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+        }
+    }
+
+    @Test
+    fun `reports rememberUpdatedState delegated value copied to local property inside remember`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    val captured = latestOnDismiss
+                    Holder(captured)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 32))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `does not report rememberUpdatedState read inside custom deferred run lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            class Scheduler {
+                fun run(block: () -> Unit) {}
+            }
+
+            @Composable
+            fun Example(onDismiss: () -> Unit, scheduler: Scheduler) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    scheduler.run {
+                        latestOnDismiss()
+                    }
+                    Holder(onDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports when remember key shadows rememberUpdatedState source name`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    val onDismiss = {}
+                    remember(onDismiss) {
+                        Holder(latestOnDismiss)
+                    }
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(10, 28))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `does not report when remember is keyed by qualified rememberUpdatedState source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            class Model(val onDismiss: () -> Unit)
+
+            @Composable
+            fun Example(model: Model) {
+                val latestOnDismiss by rememberUpdatedState(model.onDismiss)
+                val holder = remember(model.onDismiss) {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report when remember is keyed by nested qualified rememberUpdatedState source value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            class Model(val callbacks: Callbacks)
+            class Callbacks(val onDismiss: () -> Unit)
+
+            @Composable
+            fun Example(model: Model) {
+                val latestOnDismiss by rememberUpdatedState(model.callbacks.onDismiss)
+                val holder = remember(model.callbacks.onDismiss) {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports when qualified remember key receiver shadows source receiver`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            class Model(val onDismiss: () -> Unit)
+
+            @Composable
+            fun Example(model: Model, other: Model) {
+                val latestOnDismiss by rememberUpdatedState(model.onDismiss)
+                val holder = remember {
+                    val model = other
+                    remember(model.onDismiss) {
+                        Holder(latestOnDismiss)
+                    }
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(12, 28))
+            .hasMessage(StaleRememberUpdatedStateInRememberCheck.StaleRememberUpdatedStateInRemember)
+    }
+
+    @Test
+    fun `does not report deferred reads inside nested lambdas`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    Holder(onDismiss = { latestOnDismiss() })
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report shadowed rememberUpdatedState name inside remember`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    val latestOnDismiss = onDismiss
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report deferred reads inside nested functions`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    fun invokeLater() {
+                        latestOnDismiss()
+                    }
+                    Holder(::invokeLater)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report deferred reads inside property getters`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            interface Callback {
+                val isEnabled: Boolean
+            }
+
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val callback = remember {
+                    object : Callback {
+                        override val isEnabled: Boolean
+                            get() = latestOnDismiss.hashCode() > 0
+                    }
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report rememberUpdatedState property declaration itself`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(onDismiss: () -> Unit) {
+                val holder = remember {
+                    val latestOnDismiss by rememberUpdatedState(onDismiss)
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report outside composable scope`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            fun Example(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val holder = remember {
+                    Holder(latestOnDismiss)
+                }
+            }
+
+            class Holder(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code, allowCompilationErrors = true)
+
+        assertThat(findings).isEmpty()
+    }
+}

--- a/rules/functional-tests/src/functionalTest/kotlin/io/nlopez/compose/rules/functional/DetektFunctionalTest.kt
+++ b/rules/functional-tests/src/functionalTest/kotlin/io/nlopez/compose/rules/functional/DetektFunctionalTest.kt
@@ -106,6 +106,41 @@ class DetektFunctionalTest {
     }
 
     @Test
+    fun `Analysis API backed rules are detected via detekt`() {
+        setupDetektProject()
+
+        projectDir.writeFile(
+            "src/main/kotlin/com/example/StaleRememberUpdatedState.kt",
+            """
+            package com.example
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.getValue
+            import androidx.compose.runtime.remember
+            import androidx.compose.runtime.rememberUpdatedState
+
+            @Composable
+            fun StaleRememberUpdatedState(onDismiss: () -> Unit) {
+                val latestOnDismiss by rememberUpdatedState(onDismiss)
+                val callbacks = remember {
+                    DialogCallbacks(latestOnDismiss)
+                }
+                callbacks.hashCode()
+            }
+
+            private class DialogCallbacks(val onDismiss: () -> Unit)
+            """,
+        )
+
+        val result = createGradleRunner(
+            projectDir = projectDir,
+            arguments = listOf("detektMain"),
+        ).buildAndFail()
+
+        result.assertOutputContains("[StaleRememberUpdatedStateInRemember]")
+    }
+
+    @Test
     fun `clean code passes detekt checks`() {
         setupDetektProject()
 

--- a/samples/detekt-sample/detekt.yml
+++ b/samples/detekt-sample/detekt.yml
@@ -91,6 +91,8 @@ Compose:
     active: true
   RememberMissing:
     active: true
+  StaleRememberUpdatedStateInRemember:
+    active: true
   StateParam:
     active: true
   UnstableCollections:

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/StaleRememberUpdatedStateViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/StaleRememberUpdatedStateViolation.kt
@@ -1,0 +1,20 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+
+// Violation: rememberUpdatedState read eagerly in remember (StaleRememberUpdatedStateInRemember)
+@Composable
+fun StaleRememberUpdatedStateViolation(onDismiss: () -> Unit) {
+    val latestOnDismiss by rememberUpdatedState(onDismiss)
+    val dialogCallbacks = remember {
+        DialogCallbacks(onDismiss = latestOnDismiss)
+    }
+    dialogCallbacks.hashCode()
+}
+
+private class DialogCallbacks(val onDismiss: () -> Unit)

--- a/scripts/test-detekt-sample.sh
+++ b/scripts/test-detekt-sample.sh
@@ -21,23 +21,24 @@ else
     echo "Using existing JAR files (skipping build)..."
 fi
 
-echo "Running detekt check on sample project..."
+echo "Running detektMain check on sample project..."
 
 # Run detekt and capture output (expecting it to fail with violations)
 set +e
-OUTPUT=$("$ROOT_DIR/gradlew" -p "$SAMPLE_DIR" check 2>&1)
+OUTPUT=$("$ROOT_DIR/gradlew" -p "$SAMPLE_DIR" detektMain 2>&1)
 EXIT_CODE=$?
 set -e
 
 # Expected compose-rules violations (rule IDs that should appear in output)
 EXPECTED_RULES=(
-    "ModifierMissing"
-    "RememberMissing"
-    "MutableParams"
     "ComposableNaming"
-    "ParameterNaming"
+    "ModifierMissing"
     "MultipleEmitters"
+    "MutableParams"
     "MutableStateAutoboxing"
+    "ParameterNaming"
+    "RememberMissing"
+    "StaleRememberUpdatedStateInRemember"
 )
 
 echo ""


### PR DESCRIPTION
## Summary
- Adds a new detekt-only rule that detects eager reads of `rememberUpdatedState`-delegated values inside `remember { }`, `rememberSaveable { }`, or `retain { }` initializers, where the captured value becomes stale after the first composition.
- Implements the rule using detekt's Analysis API for accurate symbol resolution, including key-expression awareness (direct, array, spread, and named-input forms) and correct handling of deferred-read patterns (lambdas, local functions, property getters).
- Registers the rule in the provider and default configs, adds documentation with before/after examples, and ships a functional test and detekt sample violation.

## Testing
- 798-line unit test suite (`StaleRememberUpdatedStateInRememberCheckTest`) covering true-positive and true-negative cases: keyed calls, mutable key arrays, eager scope functions (`run`/`let`/`with`), shadowed names, qualified sources, deferred lambdas, nested functions, and property getters.
- New functional test (`DetektFunctionalTest`) verifies end-to-end detection via a Gradle `detektMain` run against real Compose imports.
- `test-detekt-sample.sh` updated to run `detektMain` and assert `StaleRememberUpdatedStateInRemember` appears in the violation output.