### PR TITLE
Add invalid read-only composable detekt rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -78,6 +78,8 @@ Compose:
     # treatAsComposableLambda: MyComposableLambdaType
   DefaultsVisibility:
     active: true
+  InvalidReadOnlyComposable:
+    active: true
   LambdaParameterEventTrailing:
     active: true
     # -- You can optionally add your own composables here

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -499,6 +499,30 @@ These need to persist across compositions; if detached from the composition, the
 
     :material-chevron-right-box: [compose:remember-content-missing-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberContentMissing.kt) ktlint :material-chevron-right-box: [RememberContentMissing](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberContentMissing.kt) detekt
 
+### Do not mark composables that emit content as read-only
+
+`@ReadOnlyComposable` promises that a composable only reads composition data and does not emit UI, call effects, or otherwise change the composition. A function or property getter marked with `@ReadOnlyComposable` should only call other composables that are also `@ReadOnlyComposable`.
+
+```kotlin
+// ❌ This function emits UI, so it is not read-only.
+@ReadOnlyComposable
+@Composable
+fun AvatarLabel(name: String) {
+    Text(name)
+}
+
+// ✅ Only read composition data in read-only composables.
+@ReadOnlyComposable
+@Composable
+fun currentDensity(): Density = LocalDensity.current
+```
+
+This rule is detekt-only and uses detekt's analysis API.
+
+!!! info ""
+
+    :material-chevron-right-box: [InvalidReadOnlyComposable](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheck.kt) detekt
+
 ### Do not eagerly read rememberUpdatedState in remember
 
 `rememberUpdatedState` keeps a stable state object while updating its value across recompositions. If you read a delegated `rememberUpdatedState(...)` value directly inside a `remember { }`, `rememberSaveable { }`, or `retain { }` initializer, the remembered value captures only the value from the composition that created it. Later source changes update the `rememberUpdatedState`, but they do not re-run the initializer unless the `remember` call is keyed on that source value.

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
@@ -28,14 +28,14 @@ internal fun KtElement.isInsideComposableScope(): Boolean {
     return false
 }
 
-private fun KtNamedFunction.isComposable(): Boolean = hasComposableAnnotationText ||
+internal fun KtNamedFunction.isComposable(): Boolean = hasComposableAnnotationText ||
     runCatching {
         analyze(this) {
             this@isComposable.symbol.hasComposableAnnotation()
         }
     }.getOrDefault(false)
 
-private fun KtPropertyAccessor.isComposable(): Boolean = hasComposableAnnotationText ||
+internal fun KtPropertyAccessor.isComposable(): Boolean = hasComposableAnnotationText ||
     runCatching {
         analyze(this) {
             this@isComposable.symbol.hasComposableAnnotation()
@@ -49,8 +49,23 @@ private fun KtLambdaExpression.isComposable(): Boolean = runCatching {
     }
 }.getOrDefault(false)
 
-private fun KaAnnotatedSymbol.hasComposableAnnotation(): Boolean =
+internal fun KtNamedFunction.isReadOnlyComposable(): Boolean = runCatching {
+    analyze(this) {
+        this@isReadOnlyComposable.symbol.hasReadOnlyComposableAnnotation()
+    }
+}.getOrDefault(false)
+
+internal fun KtPropertyAccessor.isReadOnlyComposable(): Boolean = runCatching {
+    analyze(this) {
+        this@isReadOnlyComposable.symbol.hasReadOnlyComposableAnnotation()
+    }
+}.getOrDefault(false)
+
+internal fun KaAnnotatedSymbol.hasComposableAnnotation(): Boolean =
     annotations.any { it.classId == ClassId.topLevel(ComposeFqNames.Composable) }
 
-private fun KaAnnotated.hasComposableAnnotation(): Boolean =
+internal fun KaAnnotated.hasComposableAnnotation(): Boolean =
     annotations.any { it.classId == ClassId.topLevel(ComposeFqNames.Composable) }
+
+internal fun KaAnnotatedSymbol.hasReadOnlyComposableAnnotation(): Boolean =
+    annotations.any { it.classId == ClassId.topLevel(ComposeFqNames.ReadOnlyComposable) }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
@@ -11,6 +11,8 @@ internal object ComposeFqNames {
 
     val Composable: FqName
         get() = runtime.child("Composable")
+    val ReadOnlyComposable: FqName
+        get() = runtime.child("ReadOnlyComposable")
     val Remember: FqName
         get() = runtime.child("remember")
     val RememberUpdatedState: FqName

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -25,6 +25,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             RuleName("ContentSlotReused") to { config: Config -> ContentSlotReusedCheck(config) },
             RuleName("ContentTrailingLambda") to { config: Config -> ContentTrailingLambdaCheck(config) },
             RuleName("DefaultsVisibility") to { config: Config -> DefaultsVisibilityCheck(config) },
+            RuleName("InvalidReadOnlyComposable") to { config: Config -> InvalidReadOnlyComposableCheck(config) },
             RuleName("LambdaParameterEventTrailing") to { config: Config -> LambdaParameterEventTrailingCheck(config) },
             RuleName("LambdaParameterInRestartableEffect") to { config: Config ->
                 LambdaParameterInRestartableEffectCheck(

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheck.kt
@@ -1,0 +1,122 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import java.net.URI
+
+/**
+ * Reports `@ReadOnlyComposable` declarations that make composable calls which are not also
+ * `@ReadOnlyComposable`.
+ */
+class InvalidReadOnlyComposableCheck(config: Config) :
+    Rule(
+        config,
+        "Functions marked as @ReadOnlyComposable should only call other read-only composables.",
+        URI("https://mrmans0n.github.io/compose-rules/rules/#do-not-mark-composables-that-emit-content-as-read-only"),
+    ),
+    RequiresAnalysisApi {
+
+    override val ruleName: RuleName = RuleName("InvalidReadOnlyComposable")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        if (!function.isComposable() || !function.isReadOnlyComposable()) return
+
+        function.bodyExpression?.findFirstNonReadOnlyComposableCall()?.let { call ->
+            reportInvalidReadOnlyComposable(call)
+        }
+    }
+
+    override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+        super.visitPropertyAccessor(accessor)
+        if (!accessor.isGetter || !accessor.isComposable() || !accessor.isReadOnlyComposable()) return
+
+        accessor.bodyExpression?.findFirstNonReadOnlyComposableCall()?.let { call ->
+            reportInvalidReadOnlyComposable(call)
+        }
+    }
+
+    private fun reportInvalidReadOnlyComposable(call: KtCallExpression) {
+        report(
+            Finding(
+                Entity.from(call),
+                InvalidReadOnlyComposable,
+            ),
+        )
+    }
+
+    private fun reportInvalidReadOnlyComposable(expression: KtSimpleNameExpression) {
+        report(
+            Finding(
+                Entity.from(expression),
+                InvalidReadOnlyComposable,
+            ),
+        )
+    }
+
+    private fun KtElement.findFirstNonReadOnlyComposableCall(): KtCallExpression? {
+        var firstInvalidCall: KtCallExpression? = null
+        var firstInvalidPropertyRead: KtSimpleNameExpression? = null
+        accept(
+            object : KtTreeVisitorVoid() {
+                override fun visitCallExpression(expression: KtCallExpression) {
+                    if (firstInvalidCall != null || firstInvalidPropertyRead != null) return
+                    if (expression.isComposableCall() && !expression.isReadOnlyComposableCall()) {
+                        firstInvalidCall = expression
+                        return
+                    }
+                    super.visitCallExpression(expression)
+                }
+
+                override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
+                    if (firstInvalidCall != null || firstInvalidPropertyRead != null) return
+                    if (
+                        expression.isComposablePropertyRead() &&
+                        !expression.isReadOnlyComposablePropertyRead()
+                    ) {
+                        firstInvalidPropertyRead = expression
+                        return
+                    }
+                    super.visitSimpleNameExpression(expression)
+                }
+
+                override fun visitNamedFunction(function: KtNamedFunction) {
+                    // Nested function bodies are not evaluated by the read-only declaration.
+                }
+
+                override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+                    // Nested accessor bodies are not evaluated by the read-only declaration.
+                }
+
+                override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+                    if (lambdaExpression.isEagerScopeFunctionLambda()) {
+                        super.visitLambdaExpression(lambdaExpression)
+                    }
+                }
+            },
+        )
+        firstInvalidPropertyRead?.let { reportInvalidReadOnlyComposable(it) }
+        return firstInvalidCall
+    }
+
+    internal companion object {
+        val InvalidReadOnlyComposable = """
+            This @ReadOnlyComposable declaration calls a composable that is not read-only.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#do-not-mark-composables-that-emit-content-as-read-only for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
@@ -1,19 +1,36 @@
 // Copyright 2026 Nacho Lopez
 // SPDX-License-Identifier: Apache-2.0
+@file:OptIn(KaExperimentalApi::class)
+
 package io.nlopez.compose.rules.detekt
 
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.expressionType
 import org.jetbrains.kotlin.analysis.api.components.resolveCall
 import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 
-@OptIn(KaExperimentalApi::class)
 internal fun KtCallExpression.isResolvedCallToAnyOf(fqNames: Set<FqName>): Boolean = runCatching {
     analyze(this) {
         val call = this@isResolvedCallToAnyOf.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
         call.signature.symbol.callableId?.asSingleFqName() in fqNames
+    }
+}.getOrDefault(false)
+
+internal fun KtCallExpression.isComposableCall(): Boolean = runCatching {
+    analyze(this) {
+        val call = this@isComposableCall.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        call.signature.symbol.hasComposableAnnotation() ||
+            calleeExpression?.expressionType?.hasComposableAnnotation() == true
+    }
+}.getOrDefault(false)
+
+internal fun KtCallExpression.isReadOnlyComposableCall(): Boolean = runCatching {
+    analyze(this) {
+        val call = this@isReadOnlyComposableCall.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        call.signature.symbol.hasReadOnlyComposableAnnotation()
     }
 }.getOrDefault(false)
 
@@ -28,7 +45,6 @@ internal fun KtCallExpression.isMemoizingComposableCall(): Boolean = isResolvedC
     ),
 )
 
-@OptIn(KaExperimentalApi::class)
 internal fun KtCallExpression.isResolvedCallToAnyNamed(fqNames: Set<String>): Boolean = runCatching {
     analyze(this) {
         val call = this@isResolvedCallToAnyNamed.resolveCall() as? KaFunctionCall<*> ?: return@analyze false

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
@@ -1,0 +1,27 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+
+internal fun KtLambdaExpression.isEagerScopeFunctionLambda(): Boolean {
+    val callExpression = generateSequence(parent) { element -> element.parent }
+        .filterIsInstance<KtCallExpression>()
+        .firstOrNull()
+
+    return callExpression?.isResolvedCallToAnyNamed(EagerScopeFunctions) == true
+}
+
+private val EagerScopeFunctions = setOf(
+    "kotlin.run",
+    "kotlin.with",
+    "kotlin.let",
+    "kotlin.also",
+    "kotlin.apply",
+    "kotlin.takeIf",
+    "kotlin.takeUnless",
+    "kotlin.repeat",
+    "kotlin.collections.forEach",
+    "kotlin.sequences.forEach",
+)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
@@ -6,9 +6,11 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.resolveToCall
 import org.jetbrains.kotlin.analysis.api.components.resolveToSymbol
 import org.jetbrains.kotlin.analysis.api.resolution.KaVariableAccessCall
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.sourcePsiSafe
 import org.jetbrains.kotlin.analysis.api.symbols.symbol
 import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
@@ -36,3 +38,27 @@ internal fun KtSimpleNameExpression.resolvedLocalImmutableProperty(): KtProperty
             ?.takeIf { property -> property.isLocal && !property.isVar }
     }
 }.getOrNull()
+
+internal fun KtSimpleNameExpression.isComposablePropertyRead(): Boolean = resolvedPropertyRead(
+    symbolPredicate = { property -> property.getter?.hasComposableAnnotation() == true },
+    sourcePredicate = { property -> property.getter?.isComposable() == true },
+)
+
+internal fun KtSimpleNameExpression.isReadOnlyComposablePropertyRead(): Boolean = resolvedPropertyRead(
+    symbolPredicate = { property -> property.getter?.hasReadOnlyComposableAnnotation() == true },
+    sourcePredicate = { property -> property.getter?.isReadOnlyComposable() == true },
+)
+
+private fun KtSimpleNameExpression.resolvedPropertyRead(
+    symbolPredicate: (KaPropertySymbol) -> Boolean,
+    sourcePredicate: (KtProperty) -> Boolean,
+): Boolean = runCatching {
+    if ((parent as? KtDotQualifiedExpression)?.receiverExpression == this) return@runCatching false
+
+    analyze(this) {
+        val property = ((resolveToCall() as? KaVariableAccessCall)?.signature?.symbol as? KaPropertySymbol)
+            ?: mainReference.resolveToSymbol() as? KaPropertySymbol
+            ?: return@analyze false
+        symbolPredicate(property) || property.sourcePsiSafe<KtProperty>()?.let(sourcePredicate) == true
+    }
+}.getOrDefault(false)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/StaleRememberUpdatedStateInRememberCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/StaleRememberUpdatedStateInRememberCheck.kt
@@ -320,28 +320,12 @@ class StaleRememberUpdatedStateInRememberCheck(config: Config) :
     private fun KtDotQualifiedExpression.isStateValueReadOf(receiver: KtSimpleNameExpression): Boolean =
         receiverExpression == receiver && selectorExpression?.text == "value"
 
-    private fun KtLambdaExpression.isEagerScopeFunctionLambda(): Boolean {
-        val callExpression = generateSequence(parent) { element -> element.parent }
-            .filterIsInstance<KtCallExpression>()
-            .firstOrNull()
-
-        return callExpression?.isResolvedCallToAnyNamed(EagerScopeFunctions) == true
-    }
-
     internal companion object {
-        private val EagerScopeFunctions = setOf(
-            "kotlin.run",
-            "kotlin.with",
-            "kotlin.let",
-            "kotlin.also",
-            "kotlin.apply",
-            "kotlin.takeIf",
-            "kotlin.takeUnless",
-        )
-
         val StaleRememberUpdatedStateInRemember = """
             Reading a `rememberUpdatedState` value directly inside `remember { }`, `rememberSaveable { }`, or `retain { }` captures the initial value only.
             Key the call on the source value or defer the read in a lambda.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#stale-rememberupdatedstate-in-remember for more information.
         """.trimIndent()
     }
 }

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -19,6 +19,8 @@ Compose:
     active: true
   DefaultsVisibility:
     active: true
+  InvalidReadOnlyComposable:
+    active: true
   LambdaParameterEventTrailing:
     active: true
   LambdaParameterInRestartableEffect:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
@@ -57,6 +57,9 @@ private fun fakeComposeRuntime(): String = codeWithFakeCompose(
     )
     annotation class Composable
 
+    @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+    annotation class ReadOnlyComposable
+
     @Composable
     fun <T> remember(vararg keys: Any?, calculation: () -> T): T = calculation()
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheckTest.kt
@@ -1,0 +1,370 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.SourceLocation
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class InvalidReadOnlyComposableCheckTest {
+
+    private val rule = InvalidReadOnlyComposableCheck(Config.empty)
+
+    @Test
+    fun `reports read only composable function that calls non read only composable`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): Int {
+                EmitsContent()
+                return 42
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(11, 13))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports read only composable getter that calls non read only composable`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun currentValue(): Int = 42
+
+            val value: Int
+                @ReadOnlyComposable
+                @Composable
+                get() = currentValue()
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(10, 21))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports read only composable function that reads non read only composable property`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val emitsContent: Unit
+                @Composable
+                get() {
+                }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example() {
+                emitsContent
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(12, 13))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports read only composable function that reads qualified non read only composable property`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            object Content {
+                val emitsContent: Unit
+                    @Composable
+                    get() {
+                    }
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example() {
+                Content.emitsContent
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(14, 21))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `does not report read only composable function that reads read only composable property`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val currentValue: Int
+                @ReadOnlyComposable
+                @Composable
+                get() = 42
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): Int = currentValue
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports read only composable function that calls composable lambda parameter`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun Example(content: @Composable () -> Unit) {
+                content()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(7, 13))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `does not report read only composable function that only calls read only composables`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun localContext(): String = "context"
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): String = localContext()
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function without read only annotation`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @Composable
+            fun Example() {
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report read only composable function without composable calls`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            fun currentValue(): Int = 42
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): Int = currentValue()
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report non read only composable call inside deferred lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): () -> Unit = {
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports non read only composable call inside eager stdlib scope lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): Unit = run {
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(11, 13))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports non read only composable call inside repeat lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example() {
+                repeat(1) {
+                    EmitsContent()
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(12, 17))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports non read only composable call inside collection forEach lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(items: List<Int>) {
+                items.forEach {
+                    EmitsContent()
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(12, 17))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
+    fun `does not report non read only composable call inside custom deferred run lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            class DeferredRunner {
+                fun run(block: () -> Unit) = block
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(runner: DeferredRunner): () -> Unit = runner.run {
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report non read only composable call inside custom deferred forEach lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            class DeferredItems {
+                fun forEach(block: () -> Unit) = block
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(items: DeferredItems): () -> Unit = items.forEach {
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary
- add detekt-only Analysis API rule for invalid @ReadOnlyComposable declarations
- add read-only composable helpers and shared eager scope-function lambda detection
- register the rule in detekt config and document it

## Validation
- ./gradlew :rules:detekt:test --tests io.nlopez.compose.rules.detekt.InvalidReadOnlyComposableCheckTest --tests io.nlopez.compose.rules.detekt.StaleRememberUpdatedStateInRememberCheckTest --rerun-tasks
- ./gradlew :rules:detekt:test --rerun-tasks
- ./gradlew check
- scripts/test-detekt-sample.sh
- git diff --check