### PR TITLE
Add missing read-only composable detekt rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -94,6 +94,8 @@ Compose:
     active: false # Opt-in, disabled by default. Turn on if you want to disallow Material 2 usages.
     # -- You can optionally allow parts of it, if you are in the middle of a migration.
     # allowedFromM2: icons.Icons,TopAppBar
+  MissingReadOnlyComposable:
+    active: true
   ModifierClickableOrder:
     active: true
     # -- You can optionally add your own Modifier types

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -523,6 +523,27 @@ This rule is detekt-only and uses detekt's analysis API.
 
     :material-chevron-right-box: [InvalidReadOnlyComposable](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheck.kt) detekt
 
+### Mark read-only composables as read-only
+
+If a composable function or property getter only calls other read-only composables or reads composition locals, it can be marked with `@ReadOnlyComposable`. This communicates the narrower contract to callers and lets other read-only composables use it safely.
+
+```kotlin
+// ❌ This only reads composition data, but callers cannot know it is read-only.
+@Composable
+fun currentDensity(): Density = LocalDensity.current
+
+// ✅ Mark read-only composables with both annotations.
+@ReadOnlyComposable
+@Composable
+fun currentDensity(): Density = LocalDensity.current
+```
+
+This rule is detekt-only and uses detekt's analysis API.
+
+!!! info ""
+
+    :material-chevron-right-box: [MissingReadOnlyComposable](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MissingReadOnlyComposableCheck.kt) detekt
+
 ### Do not eagerly read rememberUpdatedState in remember
 
 `rememberUpdatedState` keeps a stable state object while updating its value across recompositions. If you read a delegated `rememberUpdatedState(...)` value directly inside a `remember { }`, `rememberSaveable { }`, or `retain { }` initializer, the remembered value captures only the value from the composition that created it. Later source changes update the `rememberUpdatedState`, but they do not re-run the initializer unless the `remember` call is keyed on that source value.

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
@@ -13,6 +13,8 @@ internal object ComposeFqNames {
         get() = runtime.child("Composable")
     val ReadOnlyComposable: FqName
         get() = runtime.child("ReadOnlyComposable")
+    val CompositionLocal: FqName
+        get() = runtime.child("CompositionLocal")
     val Remember: FqName
         get() = runtime.child("remember")
     val RememberUpdatedState: FqName

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -33,6 +33,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
                 )
             },
             RuleName("Material2") to { config: Config -> Material2Check(config) },
+            RuleName("MissingReadOnlyComposable") to { config: Config -> MissingReadOnlyComposableCheck(config) },
             RuleName("ModifierClickableOrder") to { config: Config -> ModifierClickableOrderCheck(config) },
             RuleName("ModifierComposed") to { config: Config -> ModifierComposedCheck(config) },
             RuleName("ModifierMissing") to { config: Config -> ModifierMissingCheck(config) },

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtDotQualifiedExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtDotQualifiedExpressions.analysis.kt
@@ -1,0 +1,22 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.expressionType
+import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+
+internal fun KtDotQualifiedExpression.isCompositionLocalCurrentRead(): Boolean = runCatching {
+    val selector = selectorExpression as? KtNameReferenceExpression ?: return@runCatching false
+    if (selector.getReferencedName() != "current") return@runCatching false
+
+    analyze(receiverExpression) {
+        val type = receiverExpression.expressionType ?: return@analyze false
+        type.symbol?.classId?.asSingleFqName() == ComposeFqNames.CompositionLocal ||
+            type.allSupertypes.any { supertype ->
+                supertype.symbol?.classId?.asSingleFqName() == ComposeFqNames.CompositionLocal
+            }
+    }
+}.getOrDefault(false)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
@@ -2,16 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules.detekt
 
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaArgument
 import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
 
-internal fun KtLambdaExpression.isEagerScopeFunctionLambda(): Boolean {
-    val callExpression = generateSequence(parent) { element -> element.parent }
-        .filterIsInstance<KtCallExpression>()
-        .firstOrNull()
+internal fun KtLambdaExpression.isEagerScopeFunctionLambda(): Boolean =
+    parent.immediateLambdaArgumentCall()?.isEagerScopeFunctionCall() == true
 
-    return callExpression?.isResolvedCallToAnyNamed(EagerScopeFunctions) == true
+private tailrec fun PsiElement?.immediateLambdaArgumentCall(): KtCallExpression? = when (this) {
+    is KtLambdaArgument -> parent as? KtCallExpression
+    is KtValueArgument -> parent?.parent as? KtCallExpression
+    is KtAnnotatedExpression -> parent.immediateLambdaArgumentCall()
+    is KtLabeledExpression -> parent.immediateLambdaArgumentCall()
+    is KtParenthesizedExpression -> parent.immediateLambdaArgumentCall()
+    else -> null
 }
+
+internal fun KtCallExpression.isEagerScopeFunctionCall(): Boolean = isResolvedCallToAnyNamed(EagerScopeFunctions)
 
 private val EagerScopeFunctions = setOf(
     "kotlin.run",

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
@@ -49,6 +49,11 @@ internal fun KtSimpleNameExpression.isReadOnlyComposablePropertyRead(): Boolean 
     sourcePredicate = { property -> property.getter?.isReadOnlyComposable() == true },
 )
 
+internal fun KtSimpleNameExpression.isPropertyReadWithExecutableAccess(): Boolean = resolvedPropertyRead(
+    symbolPredicate = { false },
+    sourcePredicate = { property -> property.getter?.bodyExpression != null || property.hasDelegate() },
+)
+
 private fun KtSimpleNameExpression.resolvedPropertyRead(
     symbolPredicate: (KaPropertySymbol) -> Boolean,
     sourcePredicate: (KtProperty) -> Boolean,

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MissingReadOnlyComposableCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MissingReadOnlyComposableCheck.kt
@@ -1,0 +1,175 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.psi.KtUnaryExpression
+import java.net.URI
+
+/**
+ * Reports composable declarations that call only read-only composables, and can therefore be marked
+ * `@ReadOnlyComposable`.
+ */
+class MissingReadOnlyComposableCheck(config: Config) :
+    Rule(
+        config,
+        "Composable declarations that only call read-only composables should be marked as @ReadOnlyComposable.",
+        URI("https://mrmans0n.github.io/compose-rules/rules/#mark-read-only-composables-as-read-only"),
+    ),
+    RequiresAnalysisApi {
+
+    override val ruleName: RuleName = RuleName("MissingReadOnlyComposable")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        if (!function.isComposable()) return
+        if (function.isReadOnlyComposable()) return
+        if (function.hasModifier(KtTokens.OVERRIDE_KEYWORD)) return
+        if (function.bodyExpression == null) return
+        if ((function.bodyExpression as? KtBlockExpression)?.statements?.isEmpty() == true) return
+
+        if (function.bodyExpression!!.readOnlyComposableUsage().canBeReadOnlyComposable) {
+            reportMissingReadOnlyComposable(function)
+        }
+    }
+
+    override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+        super.visitPropertyAccessor(accessor)
+        if (!accessor.isGetter) return
+        if (!accessor.isComposable()) return
+        if (accessor.isReadOnlyComposable()) return
+        if (accessor.property.hasModifier(KtTokens.OVERRIDE_KEYWORD)) return
+        if (accessor.bodyExpression == null) return
+
+        if (accessor.bodyExpression!!.readOnlyComposableUsage().canBeReadOnlyComposable) {
+            reportMissingReadOnlyComposable(accessor)
+        }
+    }
+
+    private fun reportMissingReadOnlyComposable(element: KtElement) {
+        report(
+            Finding(
+                Entity.from(element),
+                MissingReadOnlyComposable,
+            ),
+        )
+    }
+
+    private fun KtElement.readOnlyComposableUsage(): ReadOnlyComposableUsage {
+        var hasReadOnlyComposableUsage = false
+        var hasNonReadOnlyComposableUsage = false
+
+        accept(
+            object : KtTreeVisitorVoid() {
+                override fun visitCallExpression(expression: KtCallExpression) {
+                    if (expression.isComposableCall()) {
+                        if (expression.isReadOnlyComposableCall()) {
+                            hasReadOnlyComposableUsage = true
+                        } else {
+                            hasNonReadOnlyComposableUsage = true
+                            return
+                        }
+                    } else if (!expression.isEagerScopeFunctionCall()) {
+                        hasNonReadOnlyComposableUsage = true
+                        return
+                    }
+                    super.visitCallExpression(expression)
+                }
+
+                override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
+                    if (expression.isComposablePropertyRead()) {
+                        if (expression.isReadOnlyComposablePropertyRead()) {
+                            hasReadOnlyComposableUsage = true
+                        } else {
+                            hasNonReadOnlyComposableUsage = true
+                            return
+                        }
+                    } else if (expression.isPropertyReadWithExecutableAccess()) {
+                        hasNonReadOnlyComposableUsage = true
+                        return
+                    }
+                    super.visitSimpleNameExpression(expression)
+                }
+
+                override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                    if (expression.isCompositionLocalCurrentRead()) {
+                        hasReadOnlyComposableUsage = true
+                        expression.receiverExpression.accept(this)
+                        return
+                    }
+                    super.visitDotQualifiedExpression(expression)
+                }
+
+                override fun visitArrayAccessExpression(expression: KtArrayAccessExpression) {
+                    hasNonReadOnlyComposableUsage = true
+                }
+
+                override fun visitBinaryExpression(expression: KtBinaryExpression) {
+                    hasNonReadOnlyComposableUsage = true
+                }
+
+                override fun visitUnaryExpression(expression: KtUnaryExpression) {
+                    if (expression.operationToken in IncrementOrDecrementOperators) {
+                        hasNonReadOnlyComposableUsage = true
+                        return
+                    }
+                    super.visitUnaryExpression(expression)
+                }
+
+                override fun visitNamedFunction(function: KtNamedFunction) {
+                    // Nested function bodies are not evaluated by the composable declaration.
+                }
+
+                override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+                    // Nested accessor bodies are not evaluated by the composable declaration.
+                }
+
+                override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+                    if (lambdaExpression.isEagerScopeFunctionLambda()) {
+                        super.visitLambdaExpression(lambdaExpression)
+                    }
+                }
+            },
+        )
+
+        return ReadOnlyComposableUsage(
+            hasReadOnlyComposableUsage = hasReadOnlyComposableUsage,
+            hasNonReadOnlyComposableUsage = hasNonReadOnlyComposableUsage,
+        )
+    }
+
+    internal companion object {
+        val MissingReadOnlyComposable = """
+            This @Composable declaration only calls read-only composables and should be marked @ReadOnlyComposable.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#mark-read-only-composables-as-read-only for more information.
+        """.trimIndent()
+    }
+}
+
+private val IncrementOrDecrementOperators = setOf(KtTokens.PLUSPLUS, KtTokens.MINUSMINUS)
+
+private data class ReadOnlyComposableUsage(
+    val hasReadOnlyComposableUsage: Boolean,
+    val hasNonReadOnlyComposableUsage: Boolean,
+) {
+    val canBeReadOnlyComposable: Boolean
+        get() = hasReadOnlyComposableUsage && !hasNonReadOnlyComposableUsage
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -27,6 +27,8 @@ Compose:
     active: true
   Material2:
     active: false
+  MissingReadOnlyComposable:
+    active: true
   ModifierClickableOrder:
     active: true
   ModifierComposed:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
@@ -98,5 +98,12 @@ private fun fakeComposeRuntime(): String = codeWithFakeCompose(
 
     @Composable
     operator fun <T> State<T>.getValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>): T = value
+
+    open class CompositionLocal<T>(val current: T)
+
+    class ProvidableCompositionLocal<T>(current: T) : CompositionLocal<T>(current)
+
+    fun <T> compositionLocalOf(defaultFactory: () -> T): ProvidableCompositionLocal<T> =
+        ProvidableCompositionLocal(defaultFactory())
     """,
 )

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/InvalidReadOnlyComposableCheckTest.kt
@@ -263,6 +263,31 @@ class InvalidReadOnlyComposableCheckTest {
     }
 
     @Test
+    fun `reports non read only composable call inside labeled eager stdlib scope lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): Unit = run label@{
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(11, 13))
+            .hasMessage(InvalidReadOnlyComposableCheck.InvalidReadOnlyComposable)
+    }
+
+    @Test
     fun `reports non read only composable call inside repeat lambda`() {
         @Language("kotlin")
         val code = codeWithFakeCompose(

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MissingReadOnlyComposableCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MissingReadOnlyComposableCheckTest.kt
@@ -1,0 +1,469 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.SourceLocation
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class MissingReadOnlyComposableCheckTest {
+
+    private val rule = MissingReadOnlyComposableCheck(Config.empty)
+
+    @Test
+    fun `reports composable function that only calls read only composables`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun currentValue(): Int = 42
+
+            @Composable
+            fun Example(): Int = currentValue()
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 9))
+            .hasMessage(MissingReadOnlyComposableCheck.MissingReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports composable getter that only calls read only composables`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun currentValue(): Int = 42
+
+            val value: Int
+                @Composable
+                get() = currentValue()
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(9, 13))
+            .hasMessage(MissingReadOnlyComposableCheck.MissingReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports composable function that reads read only composable property`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val currentValue: Int
+                @ReadOnlyComposable
+                @Composable
+                get() = 42
+
+            @Composable
+            fun Example(): Int = currentValue
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(9, 9))
+            .hasMessage(MissingReadOnlyComposableCheck.MissingReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports composable function that only reads composition local current`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(): Int = LocalCount.current
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(6, 9))
+            .hasMessage(MissingReadOnlyComposableCheck.MissingReadOnlyComposable)
+    }
+
+    @Test
+    fun `does not report composition local current read with ordinary receiver call`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            fun localWithSideEffects(): CompositionLocal<Int> = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(): Int = localWithSideEffects().current
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composition local current read with ordinary operator receiver call`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            class Locals {
+                operator fun get(index: Int): CompositionLocal<Int> = compositionLocalOf { index }
+            }
+
+            @Composable
+            fun Example(locals: Locals): Int = locals[0].current
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function without read only usage`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(): Int = 42
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that calls non read only composable`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @Composable
+            fun Example() {
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that calls composable lambda parameter`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(content: @Composable () -> Unit) {
+                content()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function with read only usage and ordinary call`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            fun trackMetric() {
+            }
+
+            @Composable
+            fun Example(): Int {
+                trackMetric()
+                return LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function with read only usage and ordinary custom getter read`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            val sideEffectingValue: Int
+                get() = 1
+
+            @Composable
+            fun Example(): Int = LocalCount.current + sideEffectingValue
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function with read only usage and delegated property read`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            val token by lazy { 1 }
+
+            @Composable
+            fun Example(): Int = LocalCount.current + token
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function with read only usage and custom operator call`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCounter = compositionLocalOf { Counter(0) }
+
+            class Counter(val value: Int) {
+                operator fun plus(other: Counter): Counter = Counter(value + other.value)
+            }
+
+            @Composable
+            fun Example(other: Counter): Counter = LocalCounter.current + other
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function with read only usage and mutation`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            var count = 0
+
+            @Composable
+            fun Example(): Int {
+                count += 1
+                return LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report already read only composable function`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): Int = 42
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report override composable function`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            abstract class Base {
+                @Composable
+                abstract fun currentValue(): Int
+            }
+
+            class Child : Base() {
+                @Composable
+                override fun currentValue(): Int = 42
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report override composable getter`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            abstract class Base {
+                abstract val currentValue: Int
+                    @Composable get
+            }
+
+            class Child : Base() {
+                override val currentValue: Int
+                    @Composable get() = LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable getter that calls non read only composable`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            val value: Unit
+                @Composable
+                get() = EmitsContent()
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports read only usage inside eager stdlib lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun currentValue(): Int = 42
+
+            @Composable
+            fun Example(): Int = run {
+                currentValue()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 9))
+            .hasMessage(MissingReadOnlyComposableCheck.MissingReadOnlyComposable)
+    }
+
+    @Test
+    fun `reports read only usage inside labeled eager stdlib lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun currentValue(): Int = 42
+
+            @Composable
+            fun Example(): Int = run label@{
+                currentValue()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(8, 9))
+            .hasMessage(MissingReadOnlyComposableCheck.MissingReadOnlyComposable)
+    }
+
+    @Test
+    fun `does not report read only usage inside deferred lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun currentValue(): Int = 42
+
+            @Composable
+            fun Example(): () -> Int = {
+                currentValue()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report deferred lambda returned from eager stdlib lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun currentValue(): Int = 42
+
+            @Composable
+            fun Example(): () -> Int = run {
+                {
+                    currentValue()
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+}

--- a/samples/detekt-sample/detekt.yml
+++ b/samples/detekt-sample/detekt.yml
@@ -59,6 +59,8 @@ Compose:
     active: true
   Material2:
     active: false
+  MissingReadOnlyComposable:
+    active: true
   ModifierClickableOrder:
     active: true
   ModifierComposed:
@@ -103,4 +105,3 @@ Compose:
     active: true
   ViewModelInjection:
     active: true
-

--- a/samples/detekt-sample/src/main/kotlin/com/example/violations/MissingReadOnlyComposableViolation.kt
+++ b/samples/detekt-sample/src/main/kotlin/com/example/violations/MissingReadOnlyComposableViolation.kt
@@ -1,0 +1,14 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package com.example.violations
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+
+// Violation: can be marked @ReadOnlyComposable (MissingReadOnlyComposable)
+@Composable
+fun MissingReadOnlyComposableViolation(): Int = readOnlyValue()
+
+@ReadOnlyComposable
+@Composable
+private fun readOnlyValue(): Int = 42

--- a/scripts/test-detekt-sample.sh
+++ b/scripts/test-detekt-sample.sh
@@ -33,6 +33,7 @@ set -e
 EXPECTED_RULES=(
     "ComposableNaming"
     "ModifierMissing"
+    "MissingReadOnlyComposable"
     "MultipleEmitters"
     "MutableParams"
     "MutableStateAutoboxing"
@@ -91,4 +92,3 @@ fi
 echo ""
 echo "SUCCESS: All expected compose-rules violations were detected!"
 exit 0
-


### PR DESCRIPTION
Adds a detekt-only Analysis API rule that reports @Composable declarations that can be marked @ReadOnlyComposable.

Includes focused tests, provider/config registration, docs, sample coverage, and the detekt sample smoke-script assertion.

Verification run locally:
- ./gradlew :rules:detekt:test --tests io.nlopez.compose.rules.detekt.MissingReadOnlyComposableCheckTest --tests io.nlopez.compose.rules.detekt.ComposeRuleSetProviderTest --rerun-tasks
- ./gradlew :rules:detekt:test --rerun-tasks
- scripts/test-detekt-sample.sh
- ./gradlew check
- git diff --check