### PR TITLE
Add UnnecessaryComposable detekt rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -164,6 +164,8 @@ Compose:
     active: true
   StateParam:
     active: true
+  UnnecessaryComposable:
+    active: true
   UnstableCollections:
     active: false # Opt-in, disabled by default. Turn on if you want to enforce this (e.g. you have strong skipping disabled)
   ViewModelForwarding:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -544,6 +544,27 @@ This rule is detekt-only and uses detekt's analysis API.
 
     :material-chevron-right-box: [MissingReadOnlyComposable](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/MissingReadOnlyComposableCheck.kt) detekt
 
+### Do not mark functions as composable when they don't need it
+
+`@Composable` changes where a function can be called from. If a function or property getter does not call composables, read composition locals, read Compose state, or otherwise use composition, it should be a regular Kotlin declaration instead.
+
+```kotlin
+// ❌ This does not use composition, so callers should not need a composable scope.
+@Composable
+fun formatLabel(name: String): String = name.trim()
+
+// ✅ Keep pure helpers as regular Kotlin functions.
+fun formatLabel(name: String): String = name.trim()
+```
+
+Functions that own a composable slot parameter are ignored, because they define a composable API even when the current body does not invoke the slot.
+
+This rule is detekt-only and uses detekt's analysis API.
+
+!!! info ""
+
+    :material-chevron-right-box: [UnnecessaryComposable](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/UnnecessaryComposableCheck.kt) detekt
+
 ### Do not eagerly read rememberUpdatedState in remember
 
 `rememberUpdatedState` keeps a stable state object while updating its value across recompositions. If you read a delegated `rememberUpdatedState(...)` value directly inside a `remember { }`, `rememberSaveable { }`, or `retain { }` initializer, the remembered value captures only the value from the composition that created it. Later source changes update the `rememberUpdatedState`, but they do not re-run the initializer unless the `remember` call is keyed on that source value.

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
@@ -6,13 +6,16 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotated
 import org.jetbrains.kotlin.analysis.api.components.expectedType
 import org.jetbrains.kotlin.analysis.api.components.functionType
+import org.jetbrains.kotlin.analysis.api.components.type
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KaAnnotatedSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.symbol
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtTypeReference
 import io.nlopez.compose.core.util.isComposable as hasComposableAnnotationText
 
 internal fun KtElement.isInsideComposableScope(): Boolean {
@@ -60,6 +63,15 @@ internal fun KtPropertyAccessor.isReadOnlyComposable(): Boolean = runCatching {
         this@isReadOnlyComposable.symbol.hasReadOnlyComposableAnnotation()
     }
 }.getOrDefault(false)
+
+internal fun KtParameter.hasComposableType(): Boolean = typeReference?.hasComposableType() == true
+
+internal fun KtTypeReference.hasComposableType(): Boolean = text.contains("@Composable") ||
+    runCatching {
+        analyze(this) {
+            type.hasComposableAnnotation()
+        }
+    }.getOrDefault(false)
 
 internal fun KaAnnotatedSymbol.hasComposableAnnotation(): Boolean =
     annotations.any { it.classId == ClassId.topLevel(ComposeFqNames.Composable) }

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeFqNames.kt
@@ -15,6 +15,26 @@ internal object ComposeFqNames {
         get() = runtime.child("ReadOnlyComposable")
     val CompositionLocal: FqName
         get() = runtime.child("CompositionLocal")
+    val State: FqName
+        get() = runtime.child("State")
+    val MutableState: FqName
+        get() = runtime.child("MutableState")
+    val IntState: FqName
+        get() = runtime.child("IntState")
+    val MutableIntState: FqName
+        get() = runtime.child("MutableIntState")
+    val LongState: FqName
+        get() = runtime.child("LongState")
+    val MutableLongState: FqName
+        get() = runtime.child("MutableLongState")
+    val FloatState: FqName
+        get() = runtime.child("FloatState")
+    val MutableFloatState: FqName
+        get() = runtime.child("MutableFloatState")
+    val DoubleState: FqName
+        get() = runtime.child("DoubleState")
+    val MutableDoubleState: FqName
+        get() = runtime.child("MutableDoubleState")
     val Remember: FqName
         get() = runtime.child("remember")
     val RememberUpdatedState: FqName

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -55,6 +55,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
                 StaleRememberUpdatedStateInRememberCheck(config)
             },
             RuleName("StateParam") to { config: Config -> StateParameterCheck(config) },
+            RuleName("UnnecessaryComposable") to { config: Config -> UnnecessaryComposableCheck(config) },
             RuleName("UnstableCollections") to { config: Config -> UnstableCollectionsCheck(config) },
             RuleName("ViewModelForwarding") to { config: Config -> ViewModelForwardingCheck(config) },
             RuleName("ViewModelInjection") to { config: Config -> ViewModelInjectionCheck(config) },

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
@@ -9,8 +9,13 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.expressionType
 import org.jetbrains.kotlin.analysis.api.components.resolveCall
 import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 
 internal fun KtCallExpression.isResolvedCallToAnyOf(fqNames: Set<FqName>): Boolean = runCatching {
     analyze(this) {
@@ -51,3 +56,26 @@ internal fun KtCallExpression.isResolvedCallToAnyNamed(fqNames: Set<String>): Bo
         call.signature.symbol.callableId?.asSingleFqName()?.asString() in fqNames
     }
 }.getOrDefault(false)
+
+internal fun KtCallExpression.isResolvedInlineArgument(argumentExpression: KtExpression): Boolean = runCatching {
+    analyze(this) {
+        val call = this@isResolvedInlineArgument.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        val function = call.signature.symbol as? KaNamedFunctionSymbol ?: return@analyze false
+        if (!function.isInline) return@analyze false
+
+        val parameter = call.argumentMapping.entries
+            .firstOrNull { (argument, _) -> argument.unwrapArgumentExpression() == argumentExpression }
+            ?.value
+            ?.symbol
+            ?: return@analyze false
+
+        !parameter.isNoinline && !parameter.isCrossinline
+    }
+}.getOrDefault(false)
+
+private tailrec fun KtExpression.unwrapArgumentExpression(): KtExpression = when (this) {
+    is KtAnnotatedExpression -> baseExpression?.unwrapArgumentExpression() ?: this
+    is KtLabeledExpression -> baseExpression?.unwrapArgumentExpression() ?: this
+    is KtParenthesizedExpression -> expression?.unwrapArgumentExpression() ?: this
+    else -> this
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtDotQualifiedExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtDotQualifiedExpressions.analysis.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.analysis.api.components.expressionType
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
 
 internal fun KtDotQualifiedExpression.isCompositionLocalCurrentRead(): Boolean = runCatching {
     val selector = selectorExpression as? KtNameReferenceExpression ?: return@runCatching false
@@ -20,3 +21,24 @@ internal fun KtDotQualifiedExpression.isCompositionLocalCurrentRead(): Boolean =
             }
     }
 }.getOrDefault(false)
+
+internal fun KtQualifiedExpression.isComposeStateValueRead(): Boolean = runCatching {
+    val selector = selectorExpression as? KtNameReferenceExpression ?: return@runCatching false
+    val stateFqNames = ComposeStateValueFqNames[selector.getReferencedName()] ?: return@runCatching false
+
+    analyze(receiverExpression) {
+        val type = receiverExpression.expressionType ?: return@analyze false
+        type.symbol?.classId?.asSingleFqName() in stateFqNames ||
+            type.allSupertypes.any { supertype ->
+                supertype.symbol?.classId?.asSingleFqName() in stateFqNames
+            }
+    }
+}.getOrDefault(false)
+
+private val ComposeStateValueFqNames = mapOf(
+    "value" to setOf(ComposeFqNames.State, ComposeFqNames.MutableState),
+    "intValue" to setOf(ComposeFqNames.IntState, ComposeFqNames.MutableIntState),
+    "longValue" to setOf(ComposeFqNames.LongState, ComposeFqNames.MutableLongState),
+    "floatValue" to setOf(ComposeFqNames.FloatState, ComposeFqNames.MutableFloatState),
+    "doubleValue" to setOf(ComposeFqNames.DoubleState, ComposeFqNames.MutableDoubleState),
+)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 
 internal fun KtLambdaExpression.isEagerScopeFunctionLambda(): Boolean =
-    parent.immediateLambdaArgumentCall()?.isEagerScopeFunctionCall() == true
+    parent.immediateLambdaArgumentCall()?.isEagerScopeFunctionCall(this) == true
 
 private tailrec fun PsiElement?.immediateLambdaArgumentCall(): KtCallExpression? = when (this) {
     is KtLambdaArgument -> parent as? KtCallExpression
@@ -22,6 +22,9 @@ private tailrec fun PsiElement?.immediateLambdaArgumentCall(): KtCallExpression?
     is KtParenthesizedExpression -> parent.immediateLambdaArgumentCall()
     else -> null
 }
+
+internal fun KtCallExpression.isEagerScopeFunctionCall(lambdaExpression: KtLambdaExpression): Boolean =
+    isResolvedCallToAnyNamed(EagerScopeFunctions) || isResolvedInlineArgument(lambdaExpression)
 
 internal fun KtCallExpression.isEagerScopeFunctionCall(): Boolean = isResolvedCallToAnyNamed(EagerScopeFunctions)
 
@@ -35,5 +38,30 @@ private val EagerScopeFunctions = setOf(
     "kotlin.takeUnless",
     "kotlin.repeat",
     "kotlin.collections.forEach",
+    "kotlin.collections.forEachIndexed",
+    "kotlin.collections.map",
+    "kotlin.collections.mapIndexed",
+    "kotlin.collections.mapNotNull",
+    "kotlin.collections.filter",
+    "kotlin.collections.filterNot",
+    "kotlin.collections.filterNotNull",
+    "kotlin.collections.flatMap",
+    "kotlin.collections.fold",
+    "kotlin.collections.foldIndexed",
+    "kotlin.collections.reduce",
+    "kotlin.collections.reduceIndexed",
+    "kotlin.collections.reduceOrNull",
+    "kotlin.collections.reduceIndexedOrNull",
+    "kotlin.collections.runningFold",
+    "kotlin.collections.runningFoldIndexed",
+    "kotlin.collections.runningReduce",
+    "kotlin.collections.runningReduceIndexed",
+    "kotlin.collections.onEach",
+    "kotlin.collections.onEachIndexed",
+    "kotlin.collections.any",
+    "kotlin.collections.all",
+    "kotlin.collections.none",
+    "kotlin.collections.count",
+    "kotlin.collections.sumOf",
     "kotlin.sequences.forEach",
 )

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtSimpleNameExpressions.analysis.kt
@@ -3,13 +3,17 @@
 package io.nlopez.compose.rules.detekt
 
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.expressionType
 import org.jetbrains.kotlin.analysis.api.components.resolveToCall
 import org.jetbrains.kotlin.analysis.api.components.resolveToSymbol
 import org.jetbrains.kotlin.analysis.api.resolution.KaVariableAccessCall
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.sourcePsiSafe
 import org.jetbrains.kotlin.analysis.api.symbols.symbol
+import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtProperty
@@ -54,6 +58,23 @@ internal fun KtSimpleNameExpression.isPropertyReadWithExecutableAccess(): Boolea
     sourcePredicate = { property -> property.getter?.bodyExpression != null || property.hasDelegate() },
 )
 
+internal fun KtSimpleNameExpression.isDelegatedComposeStateRead(): Boolean = runCatching {
+    if (isPlainAssignmentLeftHandSide()) return@runCatching false
+
+    analyze(this) {
+        val property = ((resolveToCall() as? KaVariableAccessCall)?.signature?.symbol as? KaPropertySymbol)
+            ?.sourcePsiSafe<KtProperty>()
+            ?: mainReference.resolveToSymbol()?.sourcePsiSafe<KtProperty>()
+            ?: return@analyze false
+        val delegateExpression = property.delegateExpression ?: return@analyze false
+        val delegateType = delegateExpression.expressionType ?: return@analyze false
+        delegateType.symbol?.classId?.asSingleFqName() in ComposeStateFqNames ||
+            delegateType.allSupertypes.any { supertype ->
+                supertype.symbol?.classId?.asSingleFqName() in ComposeStateFqNames
+            }
+    }
+}.getOrDefault(false)
+
 private fun KtSimpleNameExpression.resolvedPropertyRead(
     symbolPredicate: (KaPropertySymbol) -> Boolean,
     sourcePredicate: (KtProperty) -> Boolean,
@@ -67,3 +88,14 @@ private fun KtSimpleNameExpression.resolvedPropertyRead(
         symbolPredicate(property) || property.sourcePsiSafe<KtProperty>()?.let(sourcePredicate) == true
     }
 }.getOrDefault(false)
+
+private val ComposeStateFqNames = setOf(ComposeFqNames.State, ComposeFqNames.MutableState)
+
+private fun KtSimpleNameExpression.isPlainAssignmentLeftHandSide(): Boolean {
+    val assignedExpression = (parent as? KtDotQualifiedExpression)
+        ?.takeIf { expression -> expression.selectorExpression == this }
+        ?: this
+    return (assignedExpression.parent as? KtBinaryExpression)?.let { expression ->
+        expression.operationToken == KtTokens.EQ && expression.left == assignedExpression
+    } == true
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/UnnecessaryComposableCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/UnnecessaryComposableCheck.kt
@@ -1,0 +1,180 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import java.net.URI
+
+/**
+ * Reports `@Composable` declarations that do not use composition and can remove the annotation.
+ */
+class UnnecessaryComposableCheck(config: Config) :
+    Rule(
+        config,
+        "Composable declarations that do not use composition should not be marked as @Composable.",
+        URI(
+            "https://mrmans0n.github.io/compose-rules/rules/#do-not-mark-functions-as-composable-when-they-dont-need-it",
+        ),
+    ),
+    RequiresAnalysisApi {
+
+    override val ruleName: RuleName = RuleName("UnnecessaryComposable")
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        if (!function.isComposable()) return
+        if (function.isReadOnlyComposable()) return
+        if (function.isContractDeclaration()) return
+        if (function.hasComposableSlotParameter()) return
+        val body = function.bodyExpression ?: return
+        if ((body as? KtBlockExpression)?.statements?.isEmpty() == true) return
+        if (body.usesComposition()) return
+        if (function.valueParameters.any { parameter -> parameter.defaultValue?.usesComposition() == true }) return
+
+        reportUnnecessaryComposable(function)
+    }
+
+    override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+        super.visitPropertyAccessor(accessor)
+        if (!accessor.isGetter) return
+        if (!accessor.isComposable()) return
+        if (accessor.isReadOnlyComposable()) return
+        if (accessor.isContractDeclaration()) return
+        val body = accessor.bodyExpression ?: return
+        if ((body as? KtBlockExpression)?.statements?.isEmpty() == true) return
+        if (body.usesComposition()) return
+
+        reportUnnecessaryComposable(accessor)
+    }
+
+    private fun reportUnnecessaryComposable(element: KtElement) {
+        report(
+            Finding(
+                Entity.from(element),
+                UnnecessaryComposable,
+            ),
+        )
+    }
+
+    private fun KtElement.usesComposition(): Boolean {
+        var usesComposition = false
+        accept(
+            object : KtTreeVisitorVoid() {
+                override fun visitCallExpression(expression: KtCallExpression) {
+                    if (usesComposition) return
+                    if (expression.isComposableCall()) {
+                        usesComposition = true
+                        return
+                    }
+                    super.visitCallExpression(expression)
+                }
+
+                override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
+                    if (usesComposition) return
+                    if (expression.isComposablePropertyRead() || expression.isDelegatedComposeStateRead()) {
+                        usesComposition = true
+                        return
+                    }
+                    super.visitSimpleNameExpression(expression)
+                }
+
+                override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                    if (usesComposition) return
+                    if (expression.isCompositionLocalCurrentRead() || expression.isComposeStateValueReadExpression()) {
+                        usesComposition = true
+                        return
+                    }
+                    super.visitDotQualifiedExpression(expression)
+                }
+
+                override fun visitSafeQualifiedExpression(expression: KtSafeQualifiedExpression) {
+                    if (usesComposition) return
+                    if (expression.isComposeStateValueReadExpression()) {
+                        usesComposition = true
+                        return
+                    }
+                    super.visitSafeQualifiedExpression(expression)
+                }
+
+                override fun visitNamedFunction(function: KtNamedFunction) {
+                    // Nested function bodies are not evaluated by the composable declaration.
+                }
+
+                override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+                    // Nested accessor bodies are not evaluated by the composable declaration.
+                }
+
+                override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+                    if (lambdaExpression.isEagerScopeFunctionLambda()) {
+                        super.visitLambdaExpression(lambdaExpression)
+                    }
+                }
+            },
+        )
+        return usesComposition
+    }
+
+    private fun KtNamedFunction.isContractDeclaration(): Boolean {
+        if (hasAnyContractModifier()) return true
+        return getStrictParentOfType<KtClass>()?.isInterface() == true
+    }
+
+    private fun KtPropertyAccessor.isContractDeclaration(): Boolean {
+        if (property.hasAnyContractModifier()) return true
+        return getStrictParentOfType<KtClass>()?.isInterface() == true
+    }
+
+    private fun KtNamedFunction.hasComposableSlotParameter(): Boolean =
+        valueParameters.any(KtParameter::hasComposableType) ||
+            receiverTypeReference?.hasComposableType() == true
+
+    internal companion object {
+        val UnnecessaryComposable = """
+            This @Composable declaration does not use composition and should not be marked @Composable.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#do-not-mark-functions-as-composable-when-they-dont-need-it for more information.
+        """.trimIndent()
+    }
+}
+
+private val ContractModifiers = setOf(
+    KtTokens.OVERRIDE_KEYWORD,
+    KtTokens.OPEN_KEYWORD,
+    KtTokens.ABSTRACT_KEYWORD,
+    KtTokens.EXPECT_KEYWORD,
+    KtTokens.ACTUAL_KEYWORD,
+    KtTokens.EXTERNAL_KEYWORD,
+)
+
+private fun KtNamedFunction.hasAnyContractModifier(): Boolean = ContractModifiers.any(::hasModifier)
+
+private fun KtProperty.hasAnyContractModifier(): Boolean = ContractModifiers.any(::hasModifier)
+
+private fun KtQualifiedExpression.isComposeStateValueReadExpression(): Boolean =
+    isComposeStateValueRead() && !isAssignmentLeftHandSide()
+
+private fun KtElement.isAssignmentLeftHandSide(): Boolean = (parent as? KtBinaryExpression)?.let { expression ->
+    expression.operationToken == KtTokens.EQ && expression.left == this
+} == true

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -67,6 +67,8 @@ Compose:
     active: true
   StateParam:
     active: true
+  UnnecessaryComposable:
+    active: true
   UnstableCollections:
     active: false
   ViewModelForwarding:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/AnalysisApiTestExtensions.kt
@@ -91,6 +91,66 @@ private fun fakeComposeRuntime(): String = codeWithFakeCompose(
         val value: T
     }
 
+    interface MutableState<T> : State<T> {
+        override var value: T
+    }
+
+    interface IntState : State<Int> {
+        val intValue: Int
+        override val value: Int get() = intValue
+    }
+
+    interface MutableIntState : IntState, MutableState<Int> {
+        override var intValue: Int
+        override var value: Int
+            get() = intValue
+            set(value) {
+                intValue = value
+            }
+    }
+
+    interface LongState : State<Long> {
+        val longValue: Long
+        override val value: Long get() = longValue
+    }
+
+    interface MutableLongState : LongState, MutableState<Long> {
+        override var longValue: Long
+        override var value: Long
+            get() = longValue
+            set(value) {
+                longValue = value
+            }
+    }
+
+    interface FloatState : State<Float> {
+        val floatValue: Float
+        override val value: Float get() = floatValue
+    }
+
+    interface MutableFloatState : FloatState, MutableState<Float> {
+        override var floatValue: Float
+        override var value: Float
+            get() = floatValue
+            set(value) {
+                floatValue = value
+            }
+    }
+
+    interface DoubleState : State<Double> {
+        val doubleValue: Double
+        override val value: Double get() = doubleValue
+    }
+
+    interface MutableDoubleState : DoubleState, MutableState<Double> {
+        override var doubleValue: Double
+        override var value: Double
+            get() = doubleValue
+            set(value) {
+                doubleValue = value
+            }
+    }
+
     @Composable
     fun <T> rememberUpdatedState(newValue: T): State<T> = object : State<T> {
         override val value: T get() = newValue
@@ -98,6 +158,10 @@ private fun fakeComposeRuntime(): String = codeWithFakeCompose(
 
     @Composable
     operator fun <T> State<T>.getValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>): T = value
+
+    operator fun <T> MutableState<T>.setValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>, value: T) {
+        this.value = value
+    }
 
     open class CompositionLocal<T>(val current: T)
 

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/UnnecessaryComposableCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/UnnecessaryComposableCheckTest.kt
@@ -1,0 +1,628 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.SourceLocation
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class UnnecessaryComposableCheckTest {
+
+    private val rule = UnnecessaryComposableCheck(Config.empty)
+
+    @Test
+    fun `reports composable function that does not use composition`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(): Int = 42
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(4, 9))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `reports composable getter that does not use composition`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val value: Int
+                @Composable
+                get() = 42
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(5, 13))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `does not report composable function that calls composable function`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun EmitsContent() {
+            }
+
+            @Composable
+            fun Example() {
+                EmitsContent()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that reads composable property`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            val currentValue: Int
+                @Composable
+                get() = LocalCount.current
+
+            @Composable
+            fun Example(): Int = currentValue
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that reads composition local current`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(): Int = LocalCount.current
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that reads compose state value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: State<Int>): Int = state.value
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that reads delegated compose state`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: State<Int>): Int {
+                val count by state
+                return count
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports composable function that only writes compose mutable state value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: MutableState<Int>) {
+                state.value = 5
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(4, 9))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `does not report composable function that compound assigns compose mutable state value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: MutableState<Int>) {
+                state.value += 1
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports composable function that only writes delegated compose mutable state`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: MutableState<Int>) {
+                var count by state
+                count = 5
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(4, 9))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `reports composable function that only writes qualified delegated compose mutable state`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            class Holder(state: MutableState<Int>) {
+                var count by state
+
+                @Composable
+                fun Example() {
+                    this.count = 5
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(7, 13))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `does not report composable function that reads nullable compose state value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: State<Int>?): Int? = state?.value
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that reads primitive compose state values`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun IntExample(state: IntState): Int = state.intValue
+
+            @Composable
+            fun LongExample(state: LongState): Long = state.longValue
+
+            @Composable
+            fun FloatExample(state: FloatState): Float = state.floatValue
+
+            @Composable
+            fun DoubleExample(state: DoubleState): Double = state.doubleValue
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports composable function that only writes primitive compose mutable state value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: MutableIntState) {
+                state.intValue = 5
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(4, 9))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `does not report composable function that compound assigns primitive compose mutable state value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: MutableIntState) {
+                state.intValue += 1
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function that uses composition in default parameter value`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(value: Int = LocalCount.current): Int = value
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function with composable slot parameter`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Wrapper(content: @Composable () -> Unit) {
+                println(content)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable function with typealiased composable slot parameter`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            typealias Slot = @Composable () -> Unit
+
+            @Composable
+            fun Wrapper(content: Slot) {
+                println(content)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composable extension function with composable receiver slot`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun (@Composable () -> Unit).Wrapper() {
+                println(this)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report contract declarations`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            interface Screen {
+                @Composable
+                fun Content()
+            }
+
+            abstract class Base {
+                @Composable
+                open fun Render() = Unit
+
+                @Composable
+                abstract fun AbstractRender()
+            }
+
+            class Child : Base() {
+                @Composable
+                override fun Render() = Unit
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report read only composable declarations`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @ReadOnlyComposable
+            @Composable
+            fun Example(): Int = 42
+
+            val value: Int
+                @ReadOnlyComposable
+                @Composable
+                get() = 42
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composition use inside eager stdlib lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(): Int = run {
+                LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composition use inside eager collection transform`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(items: List<Int>): List<Int> = items.map {
+                it + LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composition use inside indexed eager collection iteration`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(items: List<Int>) = items.forEachIndexed { index, item ->
+                println(index + item + LocalCount.current)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composition use inside custom inline lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            inline fun <T> immediate(block: () -> T): T = block()
+
+            @Composable
+            fun Example(): Int = immediate {
+                LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report composition use inside wrapped custom inline lambdas`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Target(AnnotationTarget.EXPRESSION)
+            annotation class Marker
+
+            val LocalCount = compositionLocalOf { 0 }
+
+            inline fun <T> immediate(block: () -> T): T = block()
+
+            @Composable
+            fun LabeledExample(): Int = immediate(label@ {
+                LocalCount.current
+            })
+
+            @Composable
+            fun ParenthesizedExample(): Int = immediate(({
+                LocalCount.current
+            }))
+
+            @Composable
+            fun AnnotatedExample(): Int = immediate(@Marker {
+                LocalCount.current
+            })
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports when inline noinline lambda only defers composition use`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            inline fun later(noinline block: () -> Int): () -> Int = block
+
+            @Composable
+            fun Example(state: State<Int>): () -> Int = later {
+                state.value
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(6, 9))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `reports when inline crossinline lambda only defers composition use`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            inline fun later(crossinline block: () -> Int): () -> Int = { block() }
+
+            @Composable
+            fun Example(state: State<Int>): () -> Int = later {
+                state.value
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(6, 9))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+
+    @Test
+    fun `does not report composition use inside eager collection reducers`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun FoldExample(items: List<Int>): Int = items.fold(0) { acc, item ->
+                acc + item + LocalCount.current
+            }
+
+            @Composable
+            fun ReduceExample(items: List<Int>): Int = items.reduce { acc, item ->
+                acc + item + LocalCount.current
+            }
+
+            @Composable
+            fun OnEachExample(items: List<Int>): List<Int> = items.onEach {
+                LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports composable function when composition use is only inside deferred lambda`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val LocalCount = compositionLocalOf { 0 }
+
+            @Composable
+            fun Example(): () -> Int = {
+                LocalCount.current
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(6, 9))
+            .hasMessage(UnnecessaryComposableCheck.UnnecessaryComposable)
+    }
+}


### PR DESCRIPTION
Adds the detekt-only Analysis API-backed UnnecessaryComposable rule.\n\nIncludes:\n- rule implementation and focused analysis API tests\n- State.value / MutableState.value analysis helper\n- provider registration and default config\n- detekt sample violation and smoke-script expectation\n- docs in docs/detekt.md and docs/rules.md\n\nLocal verification:\n- ./gradlew :rules:detekt:test --tests io.nlopez.compose.rules.detekt.UnnecessaryComposableCheckTest --rerun-tasks\n- ./gradlew :rules:detekt:test --rerun-tasks\n- scripts/test-detekt-sample.sh\n- ./gradlew check\n- git diff --check