### PR TITLE
Add VarsWithoutStateBacking detekt rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -168,6 +168,8 @@ Compose:
     active: true
   UnstableCollections:
     active: false # Opt-in, disabled by default. Turn on if you want to enforce this (e.g. you have strong skipping disabled)
+  VarsWithoutStateBacking:
+    active: true
   ViewModelForwarding:
     active: true
     # -- You can optionally use this rule on things other than types ending in "ViewModel" or "Presenter" (which are the defaults). You can add your own via a regex here:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -39,6 +39,36 @@ Be careful when using `mutableStateOf` (or any of the other `State<T>` builders)
 
     :material-chevron-right-box: [compose:remember-missing-check](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberStateMissing.kt) ktlint :material-chevron-right-box: [RememberMissing](https://github.com/mrmans0n/compose-rules/blob/main/rules/common/src/main/kotlin/io/nlopez/compose/rules/RememberStateMissing.kt) detekt
 
+### Back composable vars with State
+
+Local `var` properties in composable scopes are not observable by Compose unless they are backed by snapshot state. If a `var` changes without going through `State`, Compose cannot automatically recompose the UI that depends on it.
+
+```kotlin
+// ❌ This value can change without invalidating composition.
+@Composable
+fun Counter() {
+    var count = 0
+    Button(onClick = { count++ }) {
+        Text("$count")
+    }
+}
+
+// ✅ Back mutable local UI state with snapshot state.
+@Composable
+fun Counter() {
+    var count by remember { mutableStateOf(0) }
+    Button(onClick = { count++ }) {
+        Text("$count")
+    }
+}
+```
+
+This rule is detekt-only and uses detekt's analysis API.
+
+!!! info ""
+
+    :material-chevron-right-box: [VarsWithoutStateBacking](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/VarsWithoutStateBackingCheck.kt) detekt
+
 ### Use mutableStateOf type-specific variants when possible
 
 Compose provides type-specific state variants that avoid autoboxing on JVM platforms, making them more memory efficient. Use these instead of `mutableStateOf` when working with primitives or primitive collections.

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.analysis.api.components.type
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KaAnnotatedSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.symbol
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -45,12 +46,14 @@ internal fun KtPropertyAccessor.isComposable(): Boolean = hasComposableAnnotatio
         }
     }.getOrDefault(false)
 
-private fun KtLambdaExpression.isComposable(): Boolean = runCatching {
-    analyze(this) {
-        functionLiteral.functionType.hasComposableAnnotation() ||
-            this@isComposable.expectedType?.hasComposableAnnotation() == true
-    }
-}.getOrDefault(false)
+internal fun KtLambdaExpression.isComposable(): Boolean =
+    (parent as? KtAnnotatedExpression)?.hasComposableAnnotationText == true ||
+        runCatching {
+            analyze(this) {
+                functionLiteral.functionType.hasComposableAnnotation() ||
+                    this@isComposable.expectedType?.hasComposableAnnotation() == true
+            }
+        }.getOrDefault(false)
 
 internal fun KtNamedFunction.isReadOnlyComposable(): Boolean = runCatching {
     analyze(this) {

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -57,6 +57,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             RuleName("StateParam") to { config: Config -> StateParameterCheck(config) },
             RuleName("UnnecessaryComposable") to { config: Config -> UnnecessaryComposableCheck(config) },
             RuleName("UnstableCollections") to { config: Config -> UnstableCollectionsCheck(config) },
+            RuleName("VarsWithoutStateBacking") to { config: Config -> VarsWithoutStateBackingCheck(config) },
             RuleName("ViewModelForwarding") to { config: Config -> ViewModelForwardingCheck(config) },
             RuleName("ViewModelInjection") to { config: Config -> ViewModelInjectionCheck(config) },
         ),

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtLambdaExpressions.analysis.kt
@@ -14,6 +14,9 @@ import org.jetbrains.kotlin.psi.KtValueArgument
 internal fun KtLambdaExpression.isEagerScopeFunctionLambda(): Boolean =
     parent.immediateLambdaArgumentCall()?.isEagerScopeFunctionCall(this) == true
 
+internal fun KtLambdaExpression.isEagerStdlibScopeFunctionLambda(): Boolean =
+    parent.immediateLambdaArgumentCall()?.isEagerScopeFunctionCall() == true
+
 private tailrec fun PsiElement?.immediateLambdaArgumentCall(): KtCallExpression? = when (this) {
     is KtLambdaArgument -> parent as? KtCallExpression
     is KtValueArgument -> parent?.parent as? KtCallExpression

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtProperties.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtProperties.analysis.kt
@@ -1,0 +1,34 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.expressionType
+import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtProperty
+
+internal fun KtProperty.hasComposeStateDelegate(): Boolean = runCatching {
+    val delegate = delegateExpression ?: return@runCatching false
+
+    analyze(delegate) {
+        val delegateType = delegate.expressionType ?: return@analyze false
+        delegateType.symbol?.classId?.asSingleFqName() in ComposeStateFqNames ||
+            delegateType.allSupertypes.any { supertype ->
+                supertype.symbol?.classId?.asSingleFqName() in ComposeStateFqNames
+            }
+    }
+}.getOrDefault(false)
+
+private val ComposeStateFqNames: Set<FqName> = setOf(
+    ComposeFqNames.State,
+    ComposeFqNames.MutableState,
+    ComposeFqNames.IntState,
+    ComposeFqNames.MutableIntState,
+    ComposeFqNames.LongState,
+    ComposeFqNames.MutableLongState,
+    ComposeFqNames.FloatState,
+    ComposeFqNames.MutableFloatState,
+    ComposeFqNames.DoubleState,
+    ComposeFqNames.MutableDoubleState,
+)

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/VarsWithoutStateBackingCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/VarsWithoutStateBackingCheck.kt
@@ -1,0 +1,115 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import java.net.URI
+
+/**
+ * Reports local `var` properties in composable scopes when they are not backed by observable state.
+ */
+class VarsWithoutStateBackingCheck(config: Config) :
+    Rule(
+        config,
+        "Local var properties in composable scopes should be backed by observable state.",
+        URI("https://mrmans0n.github.io/compose-rules/rules/#back-composable-vars-with-state"),
+    ),
+    RequiresAnalysisApi {
+
+    override val ruleName: RuleName = RuleName("VarsWithoutStateBacking")
+
+    private var composableScopeDepth = 0
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        if (!function.isComposable()) {
+            if (composableScopeDepth == 0) {
+                super.visitNamedFunction(function)
+            }
+            return
+        }
+
+        composableScopeDepth++
+        try {
+            super.visitNamedFunction(function)
+        } finally {
+            composableScopeDepth--
+        }
+    }
+
+    override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+        if (!accessor.isGetter || !accessor.isComposable()) {
+            if (composableScopeDepth == 0) {
+                super.visitPropertyAccessor(accessor)
+            }
+            return
+        }
+
+        composableScopeDepth++
+        try {
+            super.visitPropertyAccessor(accessor)
+        } finally {
+            composableScopeDepth--
+        }
+    }
+
+    override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+        if (lambdaExpression.isComposable()) {
+            composableScopeDepth++
+            try {
+                super.visitLambdaExpression(lambdaExpression)
+            } finally {
+                composableScopeDepth--
+            }
+        } else if (composableScopeDepth == 0 || lambdaExpression.isEagerStdlibScopeFunctionLambda()) {
+            super.visitLambdaExpression(lambdaExpression)
+        } else {
+            val previousComposableScopeDepth = composableScopeDepth
+            composableScopeDepth = 0
+            try {
+                super.visitLambdaExpression(lambdaExpression)
+            } finally {
+                composableScopeDepth = previousComposableScopeDepth
+            }
+        }
+    }
+
+    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+        if (composableScopeDepth == 0) {
+            super.visitClassOrObject(classOrObject)
+        }
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        if (composableScopeDepth > 0 && property.isVar && !property.hasComposeStateDelegate()) {
+            reportVarsWithoutStateBacking(property)
+        }
+        super.visitProperty(property)
+    }
+
+    private fun reportVarsWithoutStateBacking(property: KtProperty) {
+        report(
+            Finding(
+                entity = Entity.from(property),
+                message = VarsWithoutStateBacking,
+            ),
+        )
+    }
+
+    internal companion object {
+        val VarsWithoutStateBacking = """
+            Local var properties in composable scopes should be backed by observable State.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#back-composable-vars-with-state for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -71,6 +71,8 @@ Compose:
     active: true
   UnstableCollections:
     active: false
+  VarsWithoutStateBacking:
+    active: true
   ViewModelForwarding:
     active: true
   ViewModelInjection:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/VarsWithoutStateBackingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/VarsWithoutStateBackingCheckTest.kt
@@ -1,0 +1,323 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.SourceLocation
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+class VarsWithoutStateBackingCheckTest {
+
+    private val rule = VarsWithoutStateBackingCheck(Config.empty)
+
+    @Test
+    fun `reports bare local vars in composable functions`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example() {
+                var count = 0
+                if (count == 0) {
+                    var label = "empty"
+                    println(label)
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(2)
+        assertThat(findings[0])
+            .hasStartSourceLocation(SourceLocation(6, 13))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+        assertThat(findings[1])
+            .hasStartSourceLocation(SourceLocation(8, 17))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+    }
+
+    @Test
+    fun `reports bare local vars in composable lambdas`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Row(content: @Composable () -> Unit) {
+                content()
+            }
+
+            @Composable
+            fun Example() {
+                Row {
+                    var count = 0
+                    println(count)
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(12, 17))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+    }
+
+    @Test
+    fun `reports bare local vars in top-level composable lambda properties`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val Content: @Composable () -> Unit = {
+                var count = 0
+                println(count)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(5, 13))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+    }
+
+    @Test
+    fun `reports bare local vars in eager lambdas inside composable functions`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example() {
+                run {
+                    var count = 0
+                    println(count)
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(7, 17))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+    }
+
+    @Test
+    fun `reports bare local vars in composable getters`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            val value: Int
+                @Composable
+                get() {
+                    var count = 0
+                    return count
+                }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(7, 17))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+    }
+
+    @Test
+    fun `does not report local vars in non-composable lambdas`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Button(onClick: () -> Unit, content: @Composable () -> Unit) {
+                content()
+            }
+
+            @Composable
+            fun Example() {
+                Button(
+                    onClick = {
+                        var count = 0
+                        println(count)
+                    },
+                ) {
+                    println("content")
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report local vars in non-composable getters`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example() {
+                val value: Int
+                    get() {
+                        var count = 0
+                        return count
+                    }
+                println(value)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report member vars in anonymous objects`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example() {
+                val holder = object {
+                    var count = 0
+                }
+                println(holder.count)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report local vars in non-composable inline composable lambdas`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            inline fun <T> inlineRemember(calculation: () -> T): T = calculation()
+
+            @Composable
+            fun Example() {
+                val values = inlineRemember {
+                    var index = 0
+                    List(3) { index++ }
+                }
+                println(values)
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports local vars in composable lambdas nested in skipped lambdas`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            inline fun <T> inlineRemember(calculation: () -> T): T = calculation()
+
+            @Composable
+            fun Example() {
+                val content = inlineRemember {
+                    @Composable {
+                        var count = 0
+                        println(count)
+                    }
+                }
+                content()
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(11, 21))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+    }
+
+    @Test
+    fun `reports non-compose delegated local vars`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            import kotlin.reflect.KProperty
+
+            class NonComposeDelegate {
+                operator fun getValue(thisRef: Any?, property: KProperty<*>): Int = 0
+                operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Int) = Unit
+            }
+
+            @Composable
+            fun Example() {
+                var count by NonComposeDelegate()
+                count = 1
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single())
+            .hasStartSourceLocation(SourceLocation(13, 13))
+            .hasMessage(VarsWithoutStateBackingCheck.VarsWithoutStateBacking)
+    }
+
+    @Test
+    fun `does not report compose state delegated local vars`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            @Composable
+            fun Example(state: MutableState<Int>) {
+                var count by state
+                count = 1
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report local vars outside composable functions`() {
+        @Language("kotlin")
+        val code = codeWithFakeCompose(
+            """
+            fun Example() {
+                var count = 0
+                if (count == 0) {
+                    var label = "empty"
+                    println(label)
+                }
+            }
+            """,
+        )
+
+        val findings = rule.lintWithAnalysisApi(code)
+
+        assertThat(findings).isEmpty()
+    }
+}


### PR DESCRIPTION
Adds a detekt-only Analysis API rule that reports local `var` properties in composable scopes when they are not backed by delegated state.

Included:
- `VarsWithoutStateBackingCheck` with focused Analysis API tests
- provider registration and default detekt config
- docs in `docs/detekt.md` and `docs/rules.md`
- no additional detekt sample violations; existing sample smoke coverage remains unchanged

Local verification:
- `./gradlew :rules:detekt:test --tests io.nlopez.compose.rules.detekt.VarsWithoutStateBackingCheckTest --rerun-tasks`
- `./gradlew :rules:detekt:spotlessKotlinApply check`
- `scripts/test-detekt-sample.sh`
- `git diff --check`