### PR TITLE
Add ConditionHoist detekt rule

### DIFF
--- a/docs/detekt.md
+++ b/docs/detekt.md
@@ -60,6 +60,12 @@ Compose:
     # allowedCompositionLocals: LocalSomething,LocalSomethingElse
   CompositionLocalNaming:
     active: true
+  ConditionHoist:
+    active: true
+    # -- You can optionally add your own composables here that count as layouts/content emitters
+    # contentEmitters: MyLayout,MyOtherLayout
+    # -- You can optionally configure argument names that make a layout call too specific to hoist.
+    # ignoreCallsWithArgumentNames: modifier,contentAlignment,horizontalArrangement,verticalAlignment
   ContentEmitterReturningValues:
     active: true
     # -- You can optionally add your own composables here

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -310,6 +310,40 @@ This effectively ties the function to be called from a Column, but is still not 
 
 > **Note**: To add your custom composables so they are used in this rule (things like your design system composables), you can add `composeEmitters` to this rule config in Detekt, or `compose_emitters` to your .editorconfig in ktlint.
 
+### Hoist single conditional layout content
+
+When a layout's only content is a conditional composable child, prefer hoisting the condition outside the layout. This keeps the conditional structure visible at the call site and avoids creating an otherwise empty layout when the condition is false.
+
+```kotlin
+// ❌ The Column exists only to wrap a conditional child.
+@Composable
+fun Content(showMessage: Boolean) {
+    Column {
+        if (showMessage) {
+            Text("Hello")
+        }
+    }
+}
+
+// ✅ Hoist the condition so the layout is only emitted when it has content.
+@Composable
+fun Content(showMessage: Boolean) {
+    if (showMessage) {
+        Column {
+            Text("Hello")
+        }
+    }
+}
+```
+
+Layouts with other composable siblings, composable `else` branches, slot lambdas with parameters, or explicitly configured layout arguments such as `modifier` are ignored. The rule only checks known content emitters; add custom layout composables through `contentEmitters` in Detekt.
+
+This rule is detekt-only and uses detekt's analysis API.
+
+!!! info ""
+
+    :material-chevron-right-box: [ConditionHoist](https://github.com/mrmans0n/compose-rules/blob/main/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ConditionHoistCheck.kt) detekt
+
 ### Slots for main content should be the trailing lambda
 
 Content slots (typically `content: @Composable () -> Unit` or nullable variants) should always be the last parameter so they can be written as a trailing lambda. This makes the UI flow more natural and easier to read.

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/Composables.analysis.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.analysis.api.components.functionType
 import org.jetbrains.kotlin.analysis.api.components.type
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KaAnnotatedSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.symbol
+import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtElement
@@ -54,6 +55,13 @@ internal fun KtLambdaExpression.isComposable(): Boolean =
                     this@isComposable.expectedType?.hasComposableAnnotation() == true
             }
         }.getOrDefault(false)
+
+internal fun KtLambdaExpression.hasFunctionTypeReceiver(): Boolean = runCatching {
+    analyze(this) {
+        (functionLiteral.functionType as? KaFunctionType)?.hasReceiver == true ||
+            (this@hasFunctionTypeReceiver.expectedType as? KaFunctionType)?.hasReceiver == true
+    }
+}.getOrDefault(false)
 
 internal fun KtNamedFunction.isReadOnlyComposable(): Boolean = runCatching {
     analyze(this) {

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ComposeRuleSetProvider.kt
@@ -20,6 +20,7 @@ class ComposeRuleSetProvider : RuleSetProvider {
             RuleName("ComposableParamOrder") to { config: Config -> ParameterOrderCheck(config) },
             RuleName("CompositionLocalAllowlist") to { config: Config -> CompositionLocalAllowlistCheck(config) },
             RuleName("CompositionLocalNaming") to { config: Config -> CompositionLocalNamingCheck(config) },
+            RuleName("ConditionHoist") to { config: Config -> ConditionHoistCheck(config) },
             RuleName("ContentEmitterReturningValues") to
                 { config: Config -> ContentEmitterReturningValuesCheck(config) },
             RuleName("ContentSlotReused") to { config: Config -> ContentSlotReusedCheck(config) },

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ConditionHoistCheck.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/ConditionHoistCheck.kt
@@ -1,0 +1,358 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import dev.detekt.api.config
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.expectedType
+import org.jetbrains.kotlin.analysis.api.components.functionType
+import org.jetbrains.kotlin.analysis.api.components.resolveToSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.sourcePsiSafe
+import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
+import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.psi.psiUtil.siblings
+import java.net.URI
+
+/**
+ * Reports Compose layouts whose only content is a conditional composable child.
+ */
+class ConditionHoistCheck(config: Config) :
+    Rule(
+        config,
+        "Compose layouts with a single conditional expression should hoist the condition.",
+        URI("https://mrmans0n.github.io/compose-rules/rules/#hoist-single-conditional-layout-content"),
+    ),
+    RequiresAnalysisApi {
+
+    override val ruleName: RuleName = RuleName("ConditionHoist")
+
+    private val ignoreCallsWithArgumentNames by config(
+        defaultValue = listOf(
+            "modifier",
+            "contentAlignment",
+            "horizontalArrangement",
+            "verticalAlignment",
+        ),
+    )
+
+    private val ignoreCallsWithArgumentNamesSet by lazy { ignoreCallsWithArgumentNames.toSet() }
+
+    private val contentEmitters by config(defaultValue = emptyList<String>())
+
+    private val contentEmittersSet by lazy { DefaultContentEmitters + contentEmitters }
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+        if (!function.isComposable()) return
+
+        checkBody(function.bodyExpression)
+    }
+
+    override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+        super.visitPropertyAccessor(accessor)
+        if (!accessor.isGetter) return
+        if (!accessor.isComposable()) return
+
+        checkBody(accessor.bodyExpression)
+    }
+
+    private fun checkBody(body: KtExpression?) {
+        body ?: return
+        val candidates = body.composableCallsInCurrentDeclaration()
+            .asSequence()
+            .filter { call -> call.isConfiguredContentEmitter() }
+            .filterNot { call -> call.hasExplicitArgumentMappedToAny(ignoreCallsWithArgumentNamesSet) }
+            .filterNot { call -> call.hasExplicitNonLambdaArguments() }
+            .mapNotNull { call -> call.singleComposableLambdaArgument() }
+            .filterNot { lambda -> lambda.hasValueParameters() }
+            .mapNotNull { lambda -> lambda.singleConditionalComposableChild() }
+            .distinct()
+
+        candidates.forEach(::reportConditionCouldBeHoisted)
+    }
+
+    private fun KtCallExpression.singleComposableLambdaArgument(): KtLambdaExpression? {
+        val composableLambdas = directLambdaArguments().filter { lambda -> lambda.isComposable() }
+        return composableLambdas.singleOrNull()
+    }
+
+    private fun KtCallExpression.directLambdaArguments(): List<KtLambdaExpression> = (
+        valueArguments.mapNotNull { argument -> argument.getArgumentExpression() as? KtLambdaExpression } +
+            lambdaArguments.mapNotNull { argument -> argument.getLambdaExpression() }
+        ).distinct()
+
+    private fun KtCallExpression.hasExplicitNonLambdaArguments(): Boolean =
+        valueArguments.any { argument -> argument.getArgumentExpression() !is KtLambdaExpression }
+
+    private fun KtCallExpression.isConfiguredContentEmitter(): Boolean = calleeExpression?.text in contentEmittersSet
+
+    private fun KtLambdaExpression.hasValueParameters(): Boolean = valueParameters.isNotEmpty() ||
+        runCatching {
+            analyze(this) {
+                (functionLiteral.functionType as? KaFunctionType)?.parameterTypes?.isNotEmpty() == true ||
+                    (expectedType as? KaFunctionType)?.parameterTypes?.isNotEmpty() == true
+            }
+        }.getOrDefault(false)
+
+    private fun KtLambdaExpression.singleConditionalComposableChild(): KtIfExpression? {
+        val body = bodyExpression ?: return null
+        val ifExpression = body.directIfExpressions().singleOrNull() ?: return null
+        if (ifExpression.then?.hasEmittedComposableCall() != true) return null
+        if (ifExpression.`else`?.hasEmittedComposableCall() == true) return null
+        if (ifExpression.hasContentSiblings()) return null
+        if (ifExpression.condition?.usesImplicitReceiverOf(this) == true) return null
+        return ifExpression
+    }
+
+    private fun KtExpression.usesImplicitReceiverOf(lambda: KtLambdaExpression): Boolean = runCatching {
+        if (!lambda.hasFunctionTypeReceiver()) return@runCatching false
+
+        analyze(this) {
+            val receiverTypes = listOfNotNull(
+                (lambda.functionLiteral.functionType as? KaFunctionType)?.receiverType,
+                (lambda.expectedType as? KaFunctionType)?.receiverType,
+            )
+            val receiverClasses = receiverTypes.mapNotNull { type -> type.symbol?.sourcePsiSafe<KtClassOrObject>() }
+            val receiverClassIds = receiverTypes.mapNotNull { type -> type.symbol?.classId }.toSet()
+            if (receiverClasses.isEmpty() && receiverClassIds.isEmpty()) return@analyze false
+
+            simpleNameExpressions().any { expression ->
+                val receiverMember = when (val symbol = expression.mainReference.resolveToSymbol()) {
+                    is KaPropertySymbol -> symbol.toReceiverMember(
+                        sourceClass = symbol.sourcePsiSafe<KtProperty>()
+                            ?.getStrictParentOfType<KtClassOrObject>(),
+                    )
+
+                    is KaFunctionSymbol -> symbol.toReceiverMember(
+                        sourceClass = symbol.sourcePsiSafe<KtNamedFunction>()
+                            ?.getStrictParentOfType<KtClassOrObject>(),
+                    )
+
+                    else -> ReceiverMember()
+                }
+
+                receiverMember.sourceClass in receiverClasses ||
+                    receiverMember.classId in receiverClassIds ||
+                    receiverMember.extensionReceiverSourceClass in receiverClasses ||
+                    receiverMember.extensionReceiverClassId in receiverClassIds
+            }
+        }
+    }.getOrDefault(false)
+
+    private fun KaCallableSymbol.toReceiverMember(sourceClass: KtClassOrObject?): ReceiverMember = ReceiverMember(
+        sourceClass = sourceClass,
+        classId = callableId?.classId,
+        extensionReceiverSourceClass = receiverParameter?.returnType?.symbol?.sourcePsiSafe<KtClassOrObject>(),
+        extensionReceiverClassId = receiverParameter?.returnType?.symbol?.classId,
+    )
+
+    private fun KtExpression.simpleNameExpressions(): List<KtSimpleNameExpression> =
+        listOfNotNull(this as? KtSimpleNameExpression) + collectDescendantsOfType()
+
+    private fun KtElement.directIfExpressions(): List<KtIfExpression> = when (this) {
+        is KtIfExpression -> listOf(this)
+        is KtBlockExpression -> statements.filterIsInstance<KtIfExpression>()
+        else -> emptyList()
+    }
+
+    private data class ReceiverMember(
+        val sourceClass: KtClassOrObject? = null,
+        val classId: ClassId? = null,
+        val extensionReceiverSourceClass: KtClassOrObject? = null,
+        val extensionReceiverClassId: ClassId? = null,
+    )
+
+    private fun KtIfExpression.hasContentSiblings(): Boolean {
+        val before = siblings(forward = false, withItself = false)
+        val after = siblings(forward = true, withItself = false)
+        return (before + after)
+            .filterIsInstance<KtElement>()
+            .any()
+    }
+
+    private fun KtElement.hasEmittedComposableCall(): Boolean {
+        if ((this as? KtCallExpression)?.isComposableCall() == true) return true
+
+        var hasEmittedComposableCall = false
+        accept(
+            object : KtTreeVisitorVoid() {
+                override fun visitCallExpression(expression: KtCallExpression) {
+                    if (expression.isComposableCall()) {
+                        hasEmittedComposableCall = true
+                        return
+                    }
+                    super.visitCallExpression(expression)
+                }
+
+                override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+                    // Deferred lambda bodies are not emitted by this branch.
+                }
+
+                override fun visitNamedFunction(function: KtNamedFunction) {
+                    // Nested function bodies are not emitted by this branch.
+                }
+
+                override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+                    // Nested accessor bodies are not emitted by this branch.
+                }
+
+                override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+                    // Member bodies are not emitted by this branch.
+                }
+            },
+        )
+        return hasEmittedComposableCall
+    }
+
+    private fun KtElement.composableCallsInCurrentDeclaration(): List<KtCallExpression> {
+        val calls = mutableListOf<KtCallExpression>()
+        accept(
+            object : KtTreeVisitorVoid() {
+                override fun visitCallExpression(expression: KtCallExpression) {
+                    if (expression.isComposableCall()) {
+                        calls += expression
+                    }
+                    super.visitCallExpression(expression)
+                }
+
+                override fun visitNamedFunction(function: KtNamedFunction) {
+                    // Nested function bodies are visited as their own declarations.
+                }
+
+                override fun visitPropertyAccessor(accessor: KtPropertyAccessor) {
+                    // Nested accessor bodies are visited as their own declarations.
+                }
+
+                override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+                    // Member bodies are not part of the current composable declaration.
+                }
+            },
+        )
+        return calls
+    }
+
+    private fun reportConditionCouldBeHoisted(ifExpression: KtIfExpression) {
+        report(
+            Finding(
+                Entity.from(ifExpression),
+                ConditionCouldBeHoisted,
+            ),
+        )
+    }
+
+    internal companion object {
+        private val DefaultContentEmitters = setOf(
+            "BasicTextField",
+            "Box",
+            "Canvas",
+            "ClickableText",
+            "Column",
+            "Icon",
+            "Image",
+            "Layout",
+            "LazyColumn",
+            "LazyRow",
+            "LazyVerticalGrid",
+            "Row",
+            "Spacer",
+            "Text",
+            "BottomDrawer",
+            "Button",
+            "Card",
+            "Checkbox",
+            "CircularProgressIndicator",
+            "Divider",
+            "DropdownMenu",
+            "DropdownMenuItem",
+            "ExposedDropdownMenuBox",
+            "ExtendedFloatingActionButton",
+            "FloatingActionButton",
+            "IconButton",
+            "IconToggleButton",
+            "LeadingIconTab",
+            "LinearProgressIndicator",
+            "ListItem",
+            "ModalBottomSheetLayout",
+            "ModalDrawer",
+            "NavigationRail",
+            "NavigationRailItem",
+            "OutlinedButton",
+            "OutlinedTextField",
+            "RadioButton",
+            "Scaffold",
+            "ScrollableTabRow",
+            "Slider",
+            "SnackbarHost",
+            "Surface",
+            "SwipeToDismiss",
+            "Switch",
+            "Tab",
+            "TabRow",
+            "TextButton",
+            "TopAppBar",
+            "AssistChip",
+            "DatePickerDialog",
+            "DockedSearchBar",
+            "ElevatedAssistChip",
+            "ElevatedFilterChip",
+            "ElevatedSuggestionChip",
+            "FilterChip",
+            "HorizontalDivider",
+            "InputChip",
+            "InputField",
+            "ModalBottomSheet",
+            "NavigationBar",
+            "NavigationBarItem",
+            "PlainTooltip",
+            "RichTooltip",
+            "SearchBar",
+            "SuggestionChip",
+            "VerticalDivider",
+            "BottomNavigation",
+            "BottomNavigationContent",
+            "BottomNavigationSurface",
+            "FlowColumn",
+            "FlowRow",
+            "HorizontalPager",
+            "HorizontalPagerIndicator",
+            "SwipeRefresh",
+            "SwipeRefreshIndicator",
+            "TopAppBarContent",
+            "TopAppBarSurface",
+            "VerticalPager",
+            "VerticalPagerIndicator",
+            "WebView",
+        )
+
+        val ConditionCouldBeHoisted = """
+            Conditional expression could be hoisted out of the layout.
+
+            See https://mrmans0n.github.io/compose-rules/rules/#hoist-single-conditional-layout-content for more information.
+        """.trimIndent()
+    }
+}

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
@@ -73,6 +73,15 @@ internal fun KtCallExpression.isResolvedInlineArgument(argumentExpression: KtExp
     }
 }.getOrDefault(false)
 
+internal fun KtCallExpression.hasExplicitArgumentMappedToAny(parameterNames: Set<String>): Boolean = runCatching {
+    analyze(this) {
+        val call = this@hasExplicitArgumentMappedToAny.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        call.argumentMapping.values.any { parameter ->
+            parameter.symbol.name.asString() in parameterNames
+        }
+    }
+}.getOrDefault(false)
+
 private tailrec fun KtExpression.unwrapArgumentExpression(): KtExpression = when (this) {
     is KtAnnotatedExpression -> baseExpression?.unwrapArgumentExpression() ?: this
     is KtLabeledExpression -> baseExpression?.unwrapArgumentExpression() ?: this

--- a/rules/detekt/src/main/resources/config/config.yml
+++ b/rules/detekt/src/main/resources/config/config.yml
@@ -11,6 +11,8 @@ Compose:
     active: true
   CompositionLocalNaming:
     active: true
+  ConditionHoist:
+    active: true
   ContentEmitterReturningValues:
     active: true
   ContentSlotReused:

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ConditionHoistCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ConditionHoistCheckTest.kt
@@ -1,0 +1,917 @@
+// Copyright 2026 Nacho Lopez
+// SPDX-License-Identifier: Apache-2.0
+package io.nlopez.compose.rules.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.test.TestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ConditionHoistCheckTest {
+
+    private val rule = ConditionHoistCheck(Config.empty)
+
+    @Test
+    fun `reports layout with a single conditional composable child`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(10, 9)
+    }
+
+    @Test
+    fun `reports layout with a single expression conditional composable child`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) Text("Hello")
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(10, 9)
+    }
+
+    @Test
+    fun `reports expression body layout with a single conditional composable child`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) = Column {
+                if (showText) {
+                    Text("Hello")
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(9, 5)
+    }
+
+    @Test
+    fun `reports property getter layout with a single conditional composable child`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            val Content
+                @Composable get() = Column {
+                    if (showText()) {
+                        Text("Hello")
+                    }
+                }
+
+            fun showText(): Boolean = true
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(9, 9)
+    }
+
+    @Test
+    fun `does not report conditional with composable else branch`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) {
+                        Text("Hello")
+                    } else {
+                        Text("Fallback")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional with single expression composable else branch`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) {
+                        Text("Hello")
+                    } else Text("Fallback")
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional with composable lambda parameter in else branch`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.BasicTextField
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                BasicTextField { innerTextField ->
+                    Column {
+                        if (showText) {
+                            Text("Hint")
+                        } else {
+                            innerTextField()
+                        }
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports conditional when else branch only declares deferred composable content`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) {
+                        Text("Hello")
+                    } else {
+                        val content: @Composable () -> Unit = {
+                            Text("Fallback")
+                        }
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(10, 9)
+    }
+
+    @Test
+    fun `does not report conditional that only declares deferred composable content`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) {
+                        val content: @Composable () -> Unit = {
+                            Text("Hello")
+                        }
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional in one slot when call has another composable slot`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Icon
+            import com.example.compose.fake.ListItem
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showIcon: Boolean) {
+                ListItem(
+                    headlineContent = {
+                        Text("Title")
+                    },
+                    trailingContent = {
+                        if (showIcon) {
+                            Icon()
+                        }
+                    },
+                )
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional in a single slot call with semantic arguments`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.AnimatedVisibility
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(expanded: Boolean, showHint: Boolean) {
+                AnimatedVisibility(visible = expanded) {
+                    if (showHint) {
+                        Text("Hint")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional inside a non layout wrapper`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.AppTheme
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                AppTheme {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports configured custom layout with a single conditional composable child`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("DesignColumn")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.DesignColumn
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                DesignColumn {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(10, 9)
+    }
+
+    @Test
+    fun `keeps default layouts when custom content emitters are configured`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("DesignColumn")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(10, 9)
+    }
+
+    @Test
+    fun `does not report conditional with composable siblings in the same layout`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    Text("Header")
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional with non composable siblings in the same layout`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Column {
+                    val label = "Hello"
+                    if (showText) {
+                        Text(label)
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional nested in non-layout content`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            data class Item(val name: String, val visible: Boolean)
+
+            @Composable
+            fun Content(items: List<Item>) {
+                Column {
+                    items.forEach { item ->
+                        if (item.visible) {
+                            Text(item.name)
+                        }
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional that depends on a composable receiver scope`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("BoxWithConstraints")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.BoxWithConstraints
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content() {
+                BoxWithConstraints {
+                    if (maxWidth > 600) {
+                        Text("Wide")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report simple conditional that depends on a composable receiver scope`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("BoxWithConstraints")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.BoxWithConstraints
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content() {
+                BoxWithConstraints {
+                    if (shouldShow) {
+                        Text("Visible")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional that calls a composable receiver scope function`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("BoxWithConstraints")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.BoxWithConstraints
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content() {
+                BoxWithConstraints {
+                    if (shouldShow()) {
+                        Text("Visible")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional that depends on receiver scope extension property`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("BoxWithConstraints")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.BoxWithConstraints
+            import com.example.compose.fake.BoxWithConstraintsScope
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Text
+
+            val BoxWithConstraintsScope.isExpanded: Boolean
+                get() = maxWidth > 600
+
+            @Composable
+            fun Content() {
+                BoxWithConstraints {
+                    if (isExpanded) {
+                        Text("Visible")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional that calls a receiver scope extension function`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("BoxWithConstraints")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.BoxWithConstraints
+            import com.example.compose.fake.BoxWithConstraintsScope
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Text
+
+            fun BoxWithConstraintsScope.isExpanded(): Boolean = maxWidth > 600
+
+            @Composable
+            fun Content() {
+                BoxWithConstraints {
+                    if (isExpanded()) {
+                        Text("Visible")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports scoped layout conditional that does not depend on receiver scope`() {
+        val customRule = ConditionHoistCheck(TestConfig("contentEmitters" to listOf("ScopedColumn")))
+        val findings = customRule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.ScopedColumn
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                ScopedColumn {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(10, 9)
+    }
+
+    @Test
+    fun `does not report conditional in a slot lambda with parameters`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Items
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Items(listOf("Hello")) { item ->
+                    if (showText) {
+                        Text(item)
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditional in a slot lambda with inferred parameters`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Scaffold
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                Scaffold {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report layout with explicit ignored arguments`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Modifier
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean, modifier: Modifier) {
+                Column(modifier = modifier) {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report layout with positional explicit ignored arguments`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Modifier
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean, modifier: Modifier) {
+                Column(modifier) {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report conditionals outside composable functions`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            fun Content(showText: Boolean) {
+                Column {
+                    if (showText) {
+                        Text("Hello")
+                    }
+                }
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+            allowCompilationErrors = true,
+        )
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports local composable function conditionals only once`() {
+        val findings = rule.lintWithAnalysisApi(
+            """
+            package com.example
+
+            import com.example.compose.fake.Composable
+            import com.example.compose.fake.Column
+            import com.example.compose.fake.Text
+
+            @Composable
+            fun Content(showText: Boolean) {
+                @Composable
+                fun LocalContent() {
+                    Column {
+                        if (showText) {
+                            Text("Hello")
+                        }
+                    }
+                }
+
+                LocalContent()
+            }
+            """.trimIndent(),
+            fakeLayoutRuntime(),
+        )
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0])
+            .hasMessage(ConditionHoistCheck.ConditionCouldBeHoisted)
+            .hasStartSourceLocation(12, 13)
+    }
+
+    private fun fakeLayoutRuntime(): String = codeWithFakeCompose(
+        """
+        object Modifier
+
+        @Composable
+        fun Column(
+            modifier: Modifier = Modifier,
+            content: @Composable () -> Unit,
+        ) {
+            content()
+        }
+
+        interface ColumnScope
+
+        @Composable
+        fun ScopedColumn(
+            modifier: Modifier = Modifier,
+            content: @Composable ColumnScope.() -> Unit,
+        ) {
+            val scope = object : ColumnScope {
+            }
+            scope.content()
+        }
+
+        @Composable
+        fun DesignColumn(
+            content: @Composable () -> Unit,
+        ) {
+            content()
+        }
+
+        @Composable
+        fun AppTheme(
+            content: @Composable () -> Unit,
+        ) {
+            content()
+        }
+
+        @Composable
+        fun Text(value: String) {
+        }
+
+        @Composable
+        fun Icon() {
+        }
+
+        @Composable
+        fun ListItem(
+            headlineContent: @Composable () -> Unit,
+            trailingContent: @Composable () -> Unit,
+        ) {
+            headlineContent()
+            trailingContent()
+        }
+
+        @Composable
+        fun AnimatedVisibility(
+            visible: Boolean,
+            content: @Composable () -> Unit,
+        ) {
+            if (visible) {
+                content()
+            }
+        }
+
+        @Composable
+        fun <T> Items(
+            items: List<T>,
+            itemContent: @Composable (T) -> Unit,
+        ) {
+            items.forEach { itemContent(it) }
+        }
+
+        @Composable
+        fun BasicTextField(
+            decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit,
+        ) {
+            decorationBox {}
+        }
+
+        interface PaddingValues
+
+        @Composable
+        fun Scaffold(
+            content: @Composable (PaddingValues) -> Unit,
+        ) {
+            content(object : PaddingValues {
+            })
+        }
+
+        interface BoxWithConstraintsScope {
+            val maxWidth: Int
+            val shouldShow: Boolean
+            fun shouldShow(): Boolean
+        }
+
+        @Composable
+        fun BoxWithConstraints(
+            content: @Composable BoxWithConstraintsScope.() -> Unit,
+        ) {
+            val scope = object : BoxWithConstraintsScope {
+                override val maxWidth: Int = 0
+                override val shouldShow: Boolean = false
+                override fun shouldShow(): Boolean = false
+            }
+            scope.content()
+        }
+        """.trimIndent(),
+    )
+}


### PR DESCRIPTION
## What changed

Adds the detekt-only `ConditionHoist` rule backed by Kotlin Analysis API. The rule reports composable layout calls whose only content is an `if` branch with composable content and no composable `else`, encouraging the condition to be hoisted outside the layout.

## Details

- Adds `ConditionHoistCheck` and focused Analysis API tests.
- Resolves explicit argument parameter names so configured arguments such as `modifier` are ignored for named and positional calls.
- Registers the rule and enables it in the default detekt config.
- Documents the rule in `docs/detekt.md` and `docs/rules.md`.

## Validation

- `./gradlew :rules:detekt:test --tests io.nlopez.compose.rules.detekt.ConditionHoistCheckTest --rerun-tasks`
- `./gradlew :rules:detekt:spotlessKotlinApply check`
- `scripts/test-detekt-sample.sh`
- `git diff --cached --check`