### PR TITLE
Detect shadow-with-shape in ModifierClickableOrder rule

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -62,6 +62,8 @@ class ModifierClickableOrder : ComposeKtVisitor {
 
                     currentSelector.isBackgroundWithShape -> shapeAlteringCandidate = true
 
+                    currentSelector.isShadowWithShape -> shapeAlteringCandidate = true
+
                     currentSelector.isThen -> {
                         val param = currentSelector.valueArguments.firstOrNull()
                         if (param != null) {
@@ -72,7 +74,10 @@ class ModifierClickableOrder : ComposeKtVisitor {
                                 val suspicious = sequenceOf(argumentExpression.then, argumentExpression.`else`)
                                     .filterNotNull()
                                     .filterIsInstance<KtCallExpression>()
-                                    .any { it.isClipWithShape || it.isBackgroundWithShape || it.isBorderWithShape }
+                                    .any {
+                                        it.isClipWithShape || it.isBackgroundWithShape ||
+                                            it.isBorderWithShape || it.isShadowWithShape
+                                    }
 
                                 if (suspicious) {
                                     shapeAlteringCandidate = true
@@ -114,6 +119,15 @@ class ModifierClickableOrder : ComposeKtVisitor {
 
     private val KtCallExpression.isBorderWithShape: Boolean
         get() = calleeExpression?.text == "border" && valueArguments.any { it.isNamedShape || it.referencesShape }
+
+    private val KtCallExpression.isShadowWithShape: Boolean
+        // `shadow` clips its content to the shape, unless clipping is explicitly disabled with `clip = false`.
+        get() = calleeExpression?.text == "shadow" &&
+            valueArguments.any { it.isNamedShape || it.referencesShape } &&
+            !valueArguments.any { it.isClipDisabled }
+
+    private val KtValueArgument.isClipDisabled: Boolean
+        get() = getArgumentName()?.asName?.asString() == "clip" && getArgumentExpression()?.text == "false"
 
     private val KtValueArgument.isNamedShape: Boolean
         get() = isNamed() && name == "shape"

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -126,8 +126,14 @@ class ModifierClickableOrder : ComposeKtVisitor {
     private val KtCallExpression.isShadowWithShape: Boolean
         // `shadow` clips its content to the shape, unless clipping is explicitly disabled via `clip = false`.
         get() = calleeExpression?.text == "shadow" &&
-            valueArguments.any { it.isNamedShape || it.referencesShape } &&
+            hasShadowShape &&
             !isShadowClipDisabled
+
+    private val KtCallExpression.hasShadowShape: Boolean
+        // In `shadow(elevation, shape, ...)` the shape can be named, a recognizable `*Shape` reference, or
+        // simply the second positional argument (e.g. a lower-case `shape` parameter passed through).
+        get() = valueArguments.any { it.isNamedShape || it.referencesShape } ||
+            valueArguments.getOrNull(1)?.isNamed() == false
 
     private val KtCallExpression.isShadowClipDisabled: Boolean
         get() {

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -75,8 +75,8 @@ class ModifierClickableOrder : ComposeKtVisitor {
                                     .filterNotNull()
                                     // A branch can be a bare call (`clip(X)`), a qualified call
                                     // (`Modifier.clip(X)`), or a chain (`Modifier.clip(X).padding(Y)`),
-                                    // so we scan every call expression it contains.
-                                    .flatMap { it.findAllChildrenByClass<KtCallExpression>() }
+                                    // so we walk the modifier chain it returns.
+                                    .flatMap { it.modifierChainCalls() }
                                     .any {
                                         it.isClipWithShape || it.isBackgroundWithShape ||
                                             it.isBorderWithShape || it.isShadowWithShape
@@ -148,6 +148,19 @@ class ModifierClickableOrder : ComposeKtVisitor {
                 ?: valueArguments.firstOrNull()?.takeUnless { it.isNamed() }
             return elevation?.getArgumentExpression()?.text == "0.dp"
         }
+
+    // Collects the call expressions that make up a modifier chain (e.g. `Modifier.clip(X).padding(Y)`),
+    // without descending into their arguments or nested blocks, so shape calls that aren't part of the
+    // returned modifier (e.g. inside a `run { ... }`) are ignored.
+    private fun KtExpression.modifierChainCalls(): Sequence<KtCallExpression> = when (this) {
+        is KtCallExpression -> sequenceOf(this)
+
+        is KtDotQualifiedExpression ->
+            receiverExpression.modifierChainCalls() +
+                ((selectorExpression as? KtCallExpression)?.let { sequenceOf(it) } ?: emptySequence())
+
+        else -> emptySequence()
+    }
 
     private val KtValueArgument.isNamedShape: Boolean
         get() = isNamed() && name == "shape"

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -73,9 +73,10 @@ class ModifierClickableOrder : ComposeKtVisitor {
                                 // we flag them as well.
                                 val suspicious = sequenceOf(argumentExpression.then, argumentExpression.`else`)
                                     .filterNotNull()
-                                    // Branches can be a bare call (`clip(X)`) or a qualified call
-                                    // (`Modifier.clip(X)`), the latter being the more common form.
-                                    .mapNotNull { it.asShapeModifierCall() }
+                                    // A branch can be a bare call (`clip(X)`), a qualified call
+                                    // (`Modifier.clip(X)`), or a chain (`Modifier.clip(X).padding(Y)`),
+                                    // so we scan every call expression it contains.
+                                    .flatMap { it.findAllChildrenByClass<KtCallExpression>() }
                                     .any {
                                         it.isClipWithShape || it.isBackgroundWithShape ||
                                             it.isBorderWithShape || it.isShadowWithShape
@@ -135,14 +136,18 @@ class ModifierClickableOrder : ComposeKtVisitor {
             val namedClip = valueArguments.firstOrNull { it.getArgumentName()?.asName?.asString() == "clip" }
             if (namedClip != null) return namedClip.getArgumentExpression()?.text == "false"
             val positionalClip = valueArguments.getOrNull(2)?.takeUnless { it.isNamed() }
-            return positionalClip?.getArgumentExpression()?.text == "false"
+            if (positionalClip != null) return positionalClip.getArgumentExpression()?.text == "false"
+            // When `clip` is omitted it defaults to `elevation > 0.dp`, so a literal zero elevation
+            // is a no-op shadow that never clips and shouldn't be flagged.
+            return isZeroElevation
         }
 
-    private fun KtExpression.asShapeModifierCall(): KtCallExpression? = when (this) {
-        is KtCallExpression -> this
-        is KtDotQualifiedExpression -> selectorExpression as? KtCallExpression
-        else -> null
-    }
+    private val KtCallExpression.isZeroElevation: Boolean
+        get() {
+            val elevation = valueArguments.firstOrNull { it.getArgumentName()?.asName?.asString() == "elevation" }
+                ?: valueArguments.firstOrNull()?.takeUnless { it.isNamed() }
+            return elevation?.getArgumentExpression()?.text == "0.dp"
+        }
 
     private val KtValueArgument.isNamedShape: Boolean
         get() = isNamed() && name == "shape"

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierClickableOrder.kt
@@ -73,7 +73,9 @@ class ModifierClickableOrder : ComposeKtVisitor {
                                 // we flag them as well.
                                 val suspicious = sequenceOf(argumentExpression.then, argumentExpression.`else`)
                                     .filterNotNull()
-                                    .filterIsInstance<KtCallExpression>()
+                                    // Branches can be a bare call (`clip(X)`) or a qualified call
+                                    // (`Modifier.clip(X)`), the latter being the more common form.
+                                    .mapNotNull { it.asShapeModifierCall() }
                                     .any {
                                         it.isClipWithShape || it.isBackgroundWithShape ||
                                             it.isBorderWithShape || it.isShadowWithShape
@@ -121,13 +123,26 @@ class ModifierClickableOrder : ComposeKtVisitor {
         get() = calleeExpression?.text == "border" && valueArguments.any { it.isNamedShape || it.referencesShape }
 
     private val KtCallExpression.isShadowWithShape: Boolean
-        // `shadow` clips its content to the shape, unless clipping is explicitly disabled with `clip = false`.
+        // `shadow` clips its content to the shape, unless clipping is explicitly disabled via `clip = false`.
         get() = calleeExpression?.text == "shadow" &&
             valueArguments.any { it.isNamedShape || it.referencesShape } &&
-            !valueArguments.any { it.isClipDisabled }
+            !isShadowClipDisabled
 
-    private val KtValueArgument.isClipDisabled: Boolean
-        get() = getArgumentName()?.asName?.asString() == "clip" && getArgumentExpression()?.text == "false"
+    private val KtCallExpression.isShadowClipDisabled: Boolean
+        get() {
+            // `clip` can be passed by name (`shadow(..., clip = false)`) or positionally as the
+            // third argument (`shadow(elevation, shape, false)`).
+            val namedClip = valueArguments.firstOrNull { it.getArgumentName()?.asName?.asString() == "clip" }
+            if (namedClip != null) return namedClip.getArgumentExpression()?.text == "false"
+            val positionalClip = valueArguments.getOrNull(2)?.takeUnless { it.isNamed() }
+            return positionalClip?.getArgumentExpression()?.text == "false"
+        }
+
+    private fun KtExpression.asShapeModifierCall(): KtCallExpression? = when (this) {
+        is KtCallExpression -> this
+        is KtDotQualifiedExpression -> selectorExpression as? KtCallExpression
+        else -> null
+    }
 
     private val KtValueArgument.isNamedShape: Boolean
         get() = isNamed() && name == "shape"

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
@@ -65,6 +65,56 @@ class ModifierClickableOrderCheckTest {
     }
 
     @Test
+    fun `errors when a clickable is before a shadow with shape`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(modifier: Modifier = Modifier) {
+                    Something2(
+                        modifier = Modifier.clickable { }.shadow(8.dp, RoundedCornerShape(8.dp))
+                    )
+                    Something3(
+                        modifier = modifier.clickable { }.shadow(elevation = 4.dp, shape = CircleShape)
+                    )
+                    Something4(
+                        modifier.clickable { }.then(if (x) shadow(8.dp, MyShape) else Modifier)
+                    )
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 29),
+                SourceLocation(7, 29),
+                SourceLocation(10, 18),
+            )
+
+        assertThat(errors[0]).hasMessage(ModifierClickableOrder.ModifierChainWithSuspiciousOrder)
+    }
+
+    @Test
+    fun `passes when shadow comes before clickable or shadow does not clip`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1() {
+                    Something2(
+                        modifier = Modifier.shadow(8.dp, RoundedCornerShape(8.dp)).clickable { }
+                    )
+                    Something3(
+                        modifier = Modifier.clickable { }.shadow(8.dp, MyShape, clip = false)
+                    )
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
     fun `passes with the correct order of modifiers`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
@@ -83,6 +83,9 @@ class ModifierClickableOrderCheckTest {
                     Something5(
                         modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape) else Modifier)
                     )
+                    Something6(
+                        modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape).padding(4.dp) else Modifier)
+                    )
                 }
             """.trimIndent()
 
@@ -93,6 +96,7 @@ class ModifierClickableOrderCheckTest {
                 SourceLocation(7, 29),
                 SourceLocation(10, 18),
                 SourceLocation(13, 18),
+                SourceLocation(16, 18),
             )
 
         assertThat(errors[0]).hasMessage(ModifierClickableOrder.ModifierChainWithSuspiciousOrder)
@@ -113,6 +117,12 @@ class ModifierClickableOrderCheckTest {
                     )
                     Something4(
                         modifier = Modifier.clickable { }.shadow(8.dp, MyShape, false)
+                    )
+                    Something5(
+                        modifier = Modifier.clickable { }.shadow(0.dp, MyShape)
+                    )
+                    Something6(
+                        modifier = Modifier.clickable { }.shadow(elevation = 0.dp, shape = MyShape)
                     )
                 }
             """.trimIndent()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
@@ -80,6 +80,9 @@ class ModifierClickableOrderCheckTest {
                     Something4(
                         modifier.clickable { }.then(if (x) shadow(8.dp, MyShape) else Modifier)
                     )
+                    Something5(
+                        modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape) else Modifier)
+                    )
                 }
             """.trimIndent()
 
@@ -89,6 +92,7 @@ class ModifierClickableOrderCheckTest {
                 SourceLocation(4, 29),
                 SourceLocation(7, 29),
                 SourceLocation(10, 18),
+                SourceLocation(13, 18),
             )
 
         assertThat(errors[0]).hasMessage(ModifierClickableOrder.ModifierChainWithSuspiciousOrder)
@@ -106,6 +110,9 @@ class ModifierClickableOrderCheckTest {
                     )
                     Something3(
                         modifier = Modifier.clickable { }.shadow(8.dp, MyShape, clip = false)
+                    )
+                    Something4(
+                        modifier = Modifier.clickable { }.shadow(8.dp, MyShape, false)
                     )
                 }
             """.trimIndent()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
@@ -86,6 +86,9 @@ class ModifierClickableOrderCheckTest {
                     Something6(
                         modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape).padding(4.dp) else Modifier)
                     )
+                    Something7(
+                        modifier = modifier.clickable { }.shadow(8.dp, shape)
+                    )
                 }
             """.trimIndent()
 
@@ -97,6 +100,7 @@ class ModifierClickableOrderCheckTest {
                 SourceLocation(10, 18),
                 SourceLocation(13, 18),
                 SourceLocation(16, 18),
+                SourceLocation(19, 29),
             )
 
         assertThat(errors[0]).hasMessage(ModifierClickableOrder.ModifierChainWithSuspiciousOrder)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierClickableOrderCheckTest.kt
@@ -124,6 +124,10 @@ class ModifierClickableOrderCheckTest {
                     Something6(
                         modifier = Modifier.clickable { }.shadow(elevation = 0.dp, shape = MyShape)
                     )
+                    Something7(
+                        modifier = Modifier.clickable { }
+                            .then(if (x) run { something(Modifier.clip(CircleShape)); Modifier } else Modifier)
+                    )
                 }
             """.trimIndent()
 

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
@@ -108,6 +108,9 @@ class ModifierClickableOrderCheckTest {
                     Something5(
                         modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape) else Modifier)
                     )
+                    Something6(
+                        modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape).padding(4.dp) else Modifier)
+                    )
                 }
             """.trimIndent()
         modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
@@ -131,6 +134,11 @@ class ModifierClickableOrderCheckTest {
                 col = 18,
                 detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
             ),
+            LintViolation(
+                line = 16,
+                col = 18,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
         )
     }
 
@@ -149,6 +157,12 @@ class ModifierClickableOrderCheckTest {
                     )
                     Something4(
                         modifier = Modifier.clickable { }.shadow(8.dp, MyShape, false)
+                    )
+                    Something5(
+                        modifier = Modifier.clickable { }.shadow(0.dp, MyShape)
+                    )
+                    Something6(
+                        modifier = Modifier.clickable { }.shadow(elevation = 0.dp, shape = MyShape)
                     )
                 }
             """.trimIndent()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
@@ -90,6 +90,62 @@ class ModifierClickableOrderCheckTest {
     }
 
     @Test
+    fun `errors when a clickable is before a shadow with shape`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1(modifier: Modifier = Modifier) {
+                    Something2(
+                        modifier = Modifier.clickable { }.shadow(8.dp, RoundedCornerShape(8.dp))
+                    )
+                    Something3(
+                        modifier = modifier.clickable { }.shadow(elevation = 4.dp, shape = CircleShape)
+                    )
+                    Something4(
+                        modifier.clickable { }.then(if (x) shadow(8.dp, MyShape) else Modifier)
+                    )
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 4,
+                col = 29,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 7,
+                col = 29,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 10,
+                col = 18,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+        )
+    }
+
+    @Test
+    fun `passes when shadow comes before clickable or shadow does not clip`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something1() {
+                    Something2(
+                        modifier = Modifier.shadow(8.dp, RoundedCornerShape(8.dp)).clickable { }
+                    )
+                    Something3(
+                        modifier = Modifier.clickable { }.shadow(8.dp, MyShape, clip = false)
+                    )
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `passes with the correct order of modifiers`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
@@ -105,6 +105,9 @@ class ModifierClickableOrderCheckTest {
                     Something4(
                         modifier.clickable { }.then(if (x) shadow(8.dp, MyShape) else Modifier)
                     )
+                    Something5(
+                        modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape) else Modifier)
+                    )
                 }
             """.trimIndent()
         modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
@@ -123,6 +126,11 @@ class ModifierClickableOrderCheckTest {
                 col = 18,
                 detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
             ),
+            LintViolation(
+                line = 13,
+                col = 18,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
         )
     }
 
@@ -138,6 +146,9 @@ class ModifierClickableOrderCheckTest {
                     )
                     Something3(
                         modifier = Modifier.clickable { }.shadow(8.dp, MyShape, clip = false)
+                    )
+                    Something4(
+                        modifier = Modifier.clickable { }.shadow(8.dp, MyShape, false)
                     )
                 }
             """.trimIndent()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
@@ -111,6 +111,9 @@ class ModifierClickableOrderCheckTest {
                     Something6(
                         modifier.clickable { }.then(if (x) Modifier.shadow(8.dp, MyShape).padding(4.dp) else Modifier)
                     )
+                    Something7(
+                        modifier = modifier.clickable { }.shadow(8.dp, shape)
+                    )
                 }
             """.trimIndent()
         modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
@@ -137,6 +140,11 @@ class ModifierClickableOrderCheckTest {
             LintViolation(
                 line = 16,
                 col = 18,
+                detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
+            ),
+            LintViolation(
+                line = 19,
+                col = 29,
                 detail = ModifierClickableOrder.ModifierChainWithSuspiciousOrder,
             ),
         )

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierClickableOrderCheckTest.kt
@@ -164,6 +164,10 @@ class ModifierClickableOrderCheckTest {
                     Something6(
                         modifier = Modifier.clickable { }.shadow(elevation = 0.dp, shape = MyShape)
                     )
+                    Something7(
+                        modifier = Modifier.clickable { }
+                            .then(if (x) run { something(Modifier.clip(CircleShape)); Modifier } else Modifier)
+                    )
                 }
             """.trimIndent()
 


### PR DESCRIPTION
## Summary
- Extend `ModifierClickableOrder` to flag chains where `clickable` precedes `shadow(..., shape = ...)`, since the shadow clips its content to the shape and ripples would be cut off.
- Exempt `shadow(..., clip = false)` since clipping is explicitly disabled in that case.
- Detect the same pattern inside `Modifier.then(if (...) shadow(...) else ...)` branches, matching existing handling for `clip`/`background`/`border`.

## Testing
- Added ktlint and detekt test cases covering the violation (direct chain, named-arg form, conditional `then` branch), correct ordering, and the `clip = false` exemption; full ktlint + detekt test suites pass.