### PR TITLE
Bump to detekt 2.0.0-alpha.4 and Kotlin 2.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 // Copyright 2024 Nacho Lopez
 // SPDX-License-Identifier: Apache-2.0
 import com.diffplug.gradle.spotless.SpotlessExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -49,10 +50,8 @@ allprojects {
             // Treat all Kotlin warnings as errors
             allWarningsAsErrors = true
             jvmTarget.set(JvmTarget.JVM_11)
-            freeCompilerArgs.addAll(
-                // Enable default methods in interfaces
-                "-Xjvm-default=all",
-            )
+            // Enable default methods in interfaces
+            jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-kotlin = "2.2.21" # Used for the code of the rules
+kotlin = "2.4.0" # Used for the code of the rules
 ktlint = "1.8.0"
 kotlin-ktlint = "2.2.21" # Update only when ktlint version updates
-detekt = "2.0.0-alpha.3"
-kotlin-detekt = "2.3.21" # Update only when detekt version updates
+detekt = "2.0.0-alpha.4"
+kotlin-detekt = "2.4.0" # Update only when detekt version updates
 junit = "5.14.4"
 junit-platform = "1.14.4"
 

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/DetektRule.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/DetektRule.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.nlopez.compose.rules
 
+import com.intellij.psi.PsiElement
 import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
@@ -28,14 +29,10 @@ abstract class DetektRule(
     private val composeConfig: DetektComposeKtConfig by lazy { DetektComposeKtConfig(config) }
 
     private val emitter: Emitter = Emitter { element, message, canBeAutoCorrected ->
-        // Create entity and finding using the detekt 2.0 API
-        @Suppress("UNCHECKED_CAST")
-        val psiElement = element as com.intellij.psi.PsiElement
-
         // Use Entity.atName() for named declarations to report at the name identifier location
-        val entity = when (psiElement) {
-            is KtNamedDeclaration -> Entity.atName(psiElement)
-            else -> Entity.from(psiElement)
+        val entity = when (element) {
+            is KtNamedDeclaration -> Entity.atName(element)
+            is PsiElement -> Entity.from(element)
         }
 
         val finding = Finding(

--- a/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
+++ b/rules/detekt/src/main/kotlin/io/nlopez/compose/rules/detekt/KtCallExpressions.analysis.kt
@@ -8,7 +8,6 @@ import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.expressionType
 import org.jetbrains.kotlin.analysis.api.components.resolveCall
-import org.jetbrains.kotlin.analysis.api.resolution.KaFunctionCall
 import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
@@ -19,14 +18,14 @@ import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 
 internal fun KtCallExpression.isResolvedCallToAnyOf(fqNames: Set<FqName>): Boolean = runCatching {
     analyze(this) {
-        val call = this@isResolvedCallToAnyOf.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        val call = this@isResolvedCallToAnyOf.resolveCall() ?: return@analyze false
         call.signature.symbol.callableId?.asSingleFqName() in fqNames
     }
 }.getOrDefault(false)
 
 internal fun KtCallExpression.isComposableCall(): Boolean = runCatching {
     analyze(this) {
-        val call = this@isComposableCall.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        val call = this@isComposableCall.resolveCall() ?: return@analyze false
         call.signature.symbol.hasComposableAnnotation() ||
             calleeExpression?.expressionType?.hasComposableAnnotation() == true
     }
@@ -34,7 +33,7 @@ internal fun KtCallExpression.isComposableCall(): Boolean = runCatching {
 
 internal fun KtCallExpression.isReadOnlyComposableCall(): Boolean = runCatching {
     analyze(this) {
-        val call = this@isReadOnlyComposableCall.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        val call = this@isReadOnlyComposableCall.resolveCall() ?: return@analyze false
         call.signature.symbol.hasReadOnlyComposableAnnotation()
     }
 }.getOrDefault(false)
@@ -52,18 +51,18 @@ internal fun KtCallExpression.isMemoizingComposableCall(): Boolean = isResolvedC
 
 internal fun KtCallExpression.isResolvedCallToAnyNamed(fqNames: Set<String>): Boolean = runCatching {
     analyze(this) {
-        val call = this@isResolvedCallToAnyNamed.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
+        val call = this@isResolvedCallToAnyNamed.resolveCall() ?: return@analyze false
         call.signature.symbol.callableId?.asSingleFqName()?.asString() in fqNames
     }
 }.getOrDefault(false)
 
 internal fun KtCallExpression.isResolvedInlineArgument(argumentExpression: KtExpression): Boolean = runCatching {
     analyze(this) {
-        val call = this@isResolvedInlineArgument.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
-        val function = call.signature.symbol as? KaNamedFunctionSymbol ?: return@analyze false
-        if (!function.isInline) return@analyze false
+        val call = this@isResolvedInlineArgument.resolveCall() ?: return@analyze false
+        val function = call.signature.symbol
+        if (function !is KaNamedFunctionSymbol || !function.isInline) return@analyze false
 
-        val parameter = call.argumentMapping.entries
+        val parameter = call.valueArgumentMapping.entries
             .firstOrNull { (argument, _) -> argument.unwrapArgumentExpression() == argumentExpression }
             ?.value
             ?.symbol
@@ -75,8 +74,8 @@ internal fun KtCallExpression.isResolvedInlineArgument(argumentExpression: KtExp
 
 internal fun KtCallExpression.hasExplicitArgumentMappedToAny(parameterNames: Set<String>): Boolean = runCatching {
     analyze(this) {
-        val call = this@hasExplicitArgumentMappedToAny.resolveCall() as? KaFunctionCall<*> ?: return@analyze false
-        call.argumentMapping.values.any { parameter ->
+        val call = this@hasExplicitArgumentMappedToAny.resolveCall() ?: return@analyze false
+        call.valueArgumentMapping.values.any { parameter ->
             parameter.symbol.name.asString() in parameterNames
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,20 @@ plugins {
 
 dependencyResolutionManagement {
     repositories {
+        exclusiveContent {
+            forRepository {
+                mavenCentral {
+                    metadataSources {
+                        mavenPom()
+                        artifact()
+                        ignoreGradleMetadataRedirection()
+                    }
+                }
+            }
+            filter {
+                includeGroup("dev.detekt")
+            }
+        }
         mavenCentral()
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade detekt to `2.0.0-alpha.4` and Kotlin to `2.4.0` (with matching `kotlin-detekt` bump to `2.4.0`).
- Replace deprecated `-Xjvm-default=all` compiler arg with the new `jvmDefault = NO_COMPATIBILITY` DSL.
- Adapt to detekt 2.0 API changes: drop the unchecked `KaFunctionCall<*>` casts (now returned directly by `resolveCall()`), rename `argumentMapping` to `valueArgumentMapping`, and use a typed `PsiElement` branch in `DetektRule`'s emitter.
- Add an exclusive `mavenCentral` repository filter for the `dev.detekt` group to resolve the alpha artifacts.

## Testing
- Not run (not provided).