### PR TITLE
Detect modifier reuse in Modifier.then(modifier) argument patterns

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -28,10 +28,10 @@ fun KtCallExpression.parametersBeingUsedFrom(parameterNames: Set<String>): Set<S
 private fun KtDotQualifiedExpression.parameterNamesUsedIn(parameterNames: Set<String>): Set<String> = buildSet {
     val rootText = rootExpression.text
     if (rootText in parameterNames) add(rootText)
-    // Scan .then() arguments when the chain root is a modifier parameter/alias or looks like a
-    // type literal (uppercase first letter). Lowercase roots that aren't known modifier parameters
-    // are unrelated chains (e.g. somePipeline.then(modifier)) — skip them to avoid false positives.
-    val shouldScanThenArgs = rootText in parameterNames || rootText.firstOrNull()?.isUpperCase() == true
+    // Scan .then() arguments when the chain root is a modifier parameter/alias or a known
+    // Modifier type literal. Unrelated chains (SomePipeline.then(modifier)) are filtered out
+    // earlier by argumentsUsingModifiers, but the guard here provides defense-in-depth.
+    val shouldScanThenArgs = rootText in parameterNames || rootText in setOf("Modifier", "GlanceModifier")
     if (shouldScanThenArgs) {
         var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
         while (current != null) {

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -26,26 +26,36 @@ fun KtCallExpression.parametersBeingUsedFrom(parameterNames: Set<String>): Set<S
     }.toSet()
 
 private fun KtDotQualifiedExpression.parameterNamesUsedIn(parameterNames: Set<String>): Set<String> = buildSet {
-    if (rootExpression.text in parameterNames) add(rootExpression.text)
-    var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
-    while (current != null) {
-        val selector = current.selectorExpression as? KtCallExpression
-        if (selector != null) {
-            for (arg in selector.valueArguments) {
-                when (val expr = arg.getArgumentExpression()) {
-                    is KtReferenceExpression -> if (expr.text in parameterNames) add(expr.text)
+    val rootText = rootExpression.text
+    if (rootText in parameterNames) {
+        // Receiver is a modifier parameter — use only the root for shadowing checks. Don't also
+        // scan chain arguments, which may be a different (shadowed) modifier: e.g. in
+        // rootModifier.then(modifier) inside a lambda that shadows `modifier`, returning both
+        // names would cause isAnyShadowed to drop the call and hide the rootModifier reuse.
+        add(rootText)
+    } else {
+        // Root is not a parameter (e.g. the Modifier type itself); scan .then() arguments for
+        // patterns like Modifier.then(modifier).
+        var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
+        while (current != null) {
+            val selector = current.selectorExpression as? KtCallExpression
+            if (selector?.calleeExpression?.text == "then") {
+                for (arg in selector.valueArguments) {
+                    when (val expr = arg.getArgumentExpression()) {
+                        is KtReferenceExpression -> if (expr.text in parameterNames) add(expr.text)
 
-                    is KtDotQualifiedExpression -> if (expr.rootExpression.text in
-                        parameterNames
-                    ) {
-                        add(expr.rootExpression.text)
+                        is KtDotQualifiedExpression -> if (expr.rootExpression.text in
+                            parameterNames
+                        ) {
+                            add(expr.rootExpression.text)
+                        }
+
+                        else -> {}
                     }
-
-                    else -> {}
                 }
             }
+            current = current.receiverExpression as? KtDotQualifiedExpression
         }
-        current = current.receiverExpression as? KtDotQualifiedExpression
     }
 }
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -35,10 +35,12 @@ private fun KtDotQualifiedExpression.parameterNamesUsedIn(
 ): Set<String> = buildSet {
     val rootText = rootExpression.text
     if (rootText in parameterNames) add(rootText)
-    // Scan .then() arguments when the chain root is a modifier parameter/alias or a known
-    // Modifier type literal (including custom types). Unrelated chains are filtered out earlier
-    // by argumentsUsingModifiers, but the guard here provides defense-in-depth.
-    val shouldScanThenArgs = rootText in parameterNames || rootText in modifierTypeNames
+    // Scan .then() arguments when the chain root is a modifier parameter/alias, a known
+    // Modifier type literal (including custom types), or a lowercase local variable (which may
+    // itself be a Modifier value). This mirrors the expanded check in argumentsUsingModifiers.
+    val shouldScanThenArgs = rootText in parameterNames ||
+        rootText in modifierTypeNames ||
+        rootText.first().isLowerCase()
     if (shouldScanThenArgs) {
         var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
         while (current != null) {

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -35,12 +35,12 @@ private fun KtDotQualifiedExpression.parameterNamesUsedIn(
 ): Set<String> = buildSet {
     val rootText = rootExpression.text
     if (rootText in parameterNames) add(rootText)
-    // Scan .then() arguments when the chain root is a modifier parameter/alias, a known
-    // Modifier type literal (including custom types), or a lowercase local variable (which may
-    // itself be a Modifier value). This mirrors the expanded check in argumentsUsingModifiers.
+    // Scan .then() arguments when the chain root is a modifier parameter/alias or a known
+    // Modifier type literal (including custom types). Arbitrary lowercase roots are excluded:
+    // without type resolution we cannot tell a local Modifier variable from any other local,
+    // and the heuristic produces false positives for non-Modifier chains like pipeline.then(modifier).
     val shouldScanThenArgs = rootText in parameterNames ||
-        rootText in modifierTypeNames ||
-        rootText.first().isLowerCase()
+        rootText in modifierTypeNames
     if (shouldScanThenArgs) {
         var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
         while (current != null) {

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -11,27 +11,34 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
-fun KtCallExpression.parametersBeingUsedFrom(parameterNames: Set<String>): Set<String> =
-    valueArguments.flatMap { argument ->
-        when (val expression = argument.getArgumentExpression()) {
-            // if it's MyComposable(modifier) or similar
-            is KtReferenceExpression -> listOfNotNull(expression.text.takeIf { it in parameterNames })
+private val DefaultModifierTypeNames = setOf("Modifier", "GlanceModifier")
 
-            // if it's MyComposable(modifier.fillMaxWidth()) or similar,
-            // also handles MyComposable(Modifier.then(modifier)) and chained variants
-            is KtDotQualifiedExpression -> expression.parameterNamesUsedIn(parameterNames)
+fun KtCallExpression.parametersBeingUsedFrom(
+    parameterNames: Set<String>,
+    modifierTypeNames: Set<String> = DefaultModifierTypeNames,
+): Set<String> = valueArguments.flatMap { argument ->
+    when (val expression = argument.getArgumentExpression()) {
+        // if it's MyComposable(modifier) or similar
+        is KtReferenceExpression -> listOfNotNull(expression.text.takeIf { it in parameterNames })
 
-            else -> emptyList()
-        }
-    }.toSet()
+        // if it's MyComposable(modifier.fillMaxWidth()) or similar,
+        // also handles MyComposable(Modifier.then(modifier)) and chained variants
+        is KtDotQualifiedExpression -> expression.parameterNamesUsedIn(parameterNames, modifierTypeNames)
 
-private fun KtDotQualifiedExpression.parameterNamesUsedIn(parameterNames: Set<String>): Set<String> = buildSet {
+        else -> emptyList()
+    }
+}.toSet()
+
+private fun KtDotQualifiedExpression.parameterNamesUsedIn(
+    parameterNames: Set<String>,
+    modifierTypeNames: Set<String>,
+): Set<String> = buildSet {
     val rootText = rootExpression.text
     if (rootText in parameterNames) add(rootText)
     // Scan .then() arguments when the chain root is a modifier parameter/alias or a known
-    // Modifier type literal. Unrelated chains (SomePipeline.then(modifier)) are filtered out
-    // earlier by argumentsUsingModifiers, but the guard here provides defense-in-depth.
-    val shouldScanThenArgs = rootText in parameterNames || rootText in setOf("Modifier", "GlanceModifier")
+    // Modifier type literal (including custom types). Unrelated chains are filtered out earlier
+    // by argumentsUsingModifiers, but the guard here provides defense-in-depth.
+    val shouldScanThenArgs = rootText in parameterNames || rootText in modifierTypeNames
     if (shouldScanThenArgs) {
         var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
         while (current != null) {
@@ -89,8 +96,12 @@ fun KtCallExpression.findShadowingRedeclarations(
     .filter { (name, _) -> name == parameterName }
     .mapSecond()
 
-fun KtCallExpression.isFullyShadowed(parameterNames: Set<String>, origin: PsiElement): Boolean {
-    val currentNames = parametersBeingUsedFrom(parameterNames)
+fun KtCallExpression.isFullyShadowed(
+    parameterNames: Set<String>,
+    origin: PsiElement,
+    modifierTypeNames: Set<String> = DefaultModifierTypeNames,
+): Boolean {
+    val currentNames = parametersBeingUsedFrom(parameterNames, modifierTypeNames)
     if (currentNames.isEmpty()) return false
 
     // Only skip this call if every modifier it uses comes from a shadow scope.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -28,28 +28,29 @@ fun KtCallExpression.parametersBeingUsedFrom(parameterNames: Set<String>): Set<S
 private fun KtDotQualifiedExpression.parameterNamesUsedIn(parameterNames: Set<String>): Set<String> = buildSet {
     val rootText = rootExpression.text
     if (rootText in parameterNames) add(rootText)
-    // Always scan .then() arguments — covers both Modifier.then(modifier) and
-    // modifier.then(rootModifier) patterns where either end may be a modifier parameter.
-    // isFullyShadowed's all{} semantics handle the case where only some names are shadowed.
-    var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
-    while (current != null) {
-        val selector = current.selectorExpression as? KtCallExpression
-        if (selector?.calleeExpression?.text == "then") {
-            for (arg in selector.valueArguments) {
-                when (val expr = arg.getArgumentExpression()) {
-                    is KtReferenceExpression -> if (expr.text in parameterNames) add(expr.text)
+    // Scan .then() arguments when the chain root is a modifier parameter/alias or looks like a
+    // type literal (uppercase first letter). Lowercase roots that aren't known modifier parameters
+    // are unrelated chains (e.g. somePipeline.then(modifier)) — skip them to avoid false positives.
+    val shouldScanThenArgs = rootText in parameterNames || rootText.firstOrNull()?.isUpperCase() == true
+    if (shouldScanThenArgs) {
+        var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
+        while (current != null) {
+            val selector = current.selectorExpression as? KtCallExpression
+            if (selector?.calleeExpression?.text == "then") {
+                for (arg in selector.valueArguments) {
+                    when (val expr = arg.getArgumentExpression()) {
+                        is KtReferenceExpression -> if (expr.text in parameterNames) add(expr.text)
 
-                    is KtDotQualifiedExpression -> if (expr.rootExpression.text in
-                        parameterNames
-                    ) {
-                        add(expr.rootExpression.text)
+                        is KtDotQualifiedExpression -> if (expr.rootExpression.text in parameterNames) {
+                            add(expr.rootExpression.text)
+                        }
+
+                        else -> {}
                     }
-
-                    else -> {}
                 }
             }
+            current = current.receiverExpression as? KtDotQualifiedExpression
         }
-        current = current.receiverExpression as? KtDotQualifiedExpression
     }
 }
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -94,10 +94,13 @@ fun KtCallExpression.findShadowingRedeclarations(
     .filter { (name, _) -> name == parameterName }
     .mapSecond()
 
-fun KtCallExpression.isAnyShadowed(parameterNames: Set<String>, origin: PsiElement): Boolean {
+fun KtCallExpression.isFullyShadowed(parameterNames: Set<String>, origin: PsiElement): Boolean {
     val currentNames = parametersBeingUsedFrom(parameterNames)
+    if (currentNames.isEmpty()) return false
 
-    // For those modifiers, we look at the parents and see if any of them is a function that has a param with
-    //  the same name.
-    return ancestorsParameterNamesSequence(stopAt = origin).any { it in currentNames }
+    // Only skip this call if every modifier it uses comes from a shadow scope.
+    // Using any { } here would incorrectly drop calls where one argument is a shadowed lambda-local
+    // modifier but another argument is a genuine outer-modifier alias.
+    val ancestorNames = ancestorsParameterNamesSequence(stopAt = origin).toSet()
+    return currentNames.all { it in ancestorNames }
 }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -12,19 +12,42 @@ import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
 fun KtCallExpression.parametersBeingUsedFrom(parameterNames: Set<String>): Set<String> =
-    valueArguments.mapNotNull { argument ->
+    valueArguments.flatMap { argument ->
         when (val expression = argument.getArgumentExpression()) {
             // if it's MyComposable(modifier) or similar
-            is KtReferenceExpression -> expression.text
+            is KtReferenceExpression -> listOfNotNull(expression.text.takeIf { it in parameterNames })
 
-            // if it's MyComposable(modifier.fillMaxWidth()) or similar
-            is KtDotQualifiedExpression -> expression.rootExpression.text
+            // if it's MyComposable(modifier.fillMaxWidth()) or similar,
+            // also handles MyComposable(Modifier.then(modifier)) and chained variants
+            is KtDotQualifiedExpression -> expression.parameterNamesUsedIn(parameterNames)
 
-            else -> null
+            else -> emptyList()
         }
+    }.toSet()
+
+private fun KtDotQualifiedExpression.parameterNamesUsedIn(parameterNames: Set<String>): Set<String> = buildSet {
+    if (rootExpression.text in parameterNames) add(rootExpression.text)
+    var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
+    while (current != null) {
+        val selector = current.selectorExpression as? KtCallExpression
+        if (selector != null) {
+            for (arg in selector.valueArguments) {
+                when (val expr = arg.getArgumentExpression()) {
+                    is KtReferenceExpression -> if (expr.text in parameterNames) add(expr.text)
+
+                    is KtDotQualifiedExpression -> if (expr.rootExpression.text in
+                        parameterNames
+                    ) {
+                        add(expr.rootExpression.text)
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+        current = current.receiverExpression as? KtDotQualifiedExpression
     }
-        .filter { it in parameterNames }
-        .toSet()
+}
 
 private fun KtCallExpression.ancestorsParameterNamesSequence(stopAt: PsiElement) = parents.takeWhile { it != stopAt }
     .filterIsInstance<KtCallableDeclaration>()

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtCallExpressions.kt
@@ -27,35 +27,29 @@ fun KtCallExpression.parametersBeingUsedFrom(parameterNames: Set<String>): Set<S
 
 private fun KtDotQualifiedExpression.parameterNamesUsedIn(parameterNames: Set<String>): Set<String> = buildSet {
     val rootText = rootExpression.text
-    if (rootText in parameterNames) {
-        // Receiver is a modifier parameter — use only the root for shadowing checks. Don't also
-        // scan chain arguments, which may be a different (shadowed) modifier: e.g. in
-        // rootModifier.then(modifier) inside a lambda that shadows `modifier`, returning both
-        // names would cause isAnyShadowed to drop the call and hide the rootModifier reuse.
-        add(rootText)
-    } else {
-        // Root is not a parameter (e.g. the Modifier type itself); scan .then() arguments for
-        // patterns like Modifier.then(modifier).
-        var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
-        while (current != null) {
-            val selector = current.selectorExpression as? KtCallExpression
-            if (selector?.calleeExpression?.text == "then") {
-                for (arg in selector.valueArguments) {
-                    when (val expr = arg.getArgumentExpression()) {
-                        is KtReferenceExpression -> if (expr.text in parameterNames) add(expr.text)
+    if (rootText in parameterNames) add(rootText)
+    // Always scan .then() arguments — covers both Modifier.then(modifier) and
+    // modifier.then(rootModifier) patterns where either end may be a modifier parameter.
+    // isFullyShadowed's all{} semantics handle the case where only some names are shadowed.
+    var current: KtDotQualifiedExpression? = this@parameterNamesUsedIn
+    while (current != null) {
+        val selector = current.selectorExpression as? KtCallExpression
+        if (selector?.calleeExpression?.text == "then") {
+            for (arg in selector.valueArguments) {
+                when (val expr = arg.getArgumentExpression()) {
+                    is KtReferenceExpression -> if (expr.text in parameterNames) add(expr.text)
 
-                        is KtDotQualifiedExpression -> if (expr.rootExpression.text in
-                            parameterNames
-                        ) {
-                            add(expr.rootExpression.text)
-                        }
-
-                        else -> {}
+                    is KtDotQualifiedExpression -> if (expr.rootExpression.text in
+                        parameterNames
+                    ) {
+                        add(expr.rootExpression.text)
                     }
+
+                    else -> {}
                 }
             }
-            current = current.receiverExpression as? KtDotQualifiedExpression
         }
+        current = current.receiverExpression as? KtDotQualifiedExpression
     }
 }
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -49,37 +49,38 @@ private fun KtBlockExpression.findModifierManipulations(contains: (String) -> Bo
     }
     .mapNotNull { it.nameIdentifier?.text }
 
-fun KtCallExpression.isUsingModifiers(modifierNames: Set<String>): Boolean =
-    argumentsUsingModifiers(modifierNames).isNotEmpty()
+fun KtCallExpression.isUsingModifiers(
+    modifierNames: Set<String>,
+    modifierTypeNames: Set<String> = ModifierNames,
+): Boolean = argumentsUsingModifiers(modifierNames, modifierTypeNames).isNotEmpty()
 
-fun KtCallExpression.argumentsUsingModifiers(modifierNames: Set<String>): List<KtValueArgument> =
-    valueArguments.filter { argument ->
-        when (val expression = argument.getArgumentExpression()) {
-            // if it's MyComposable(modifier) or similar
-            is KtReferenceExpression -> {
-                expression.text in modifierNames
-            }
-
-            // if it's MyComposable(modifier.fillMaxWidth()) or similar,
-            // also handles MyComposable(Modifier.then(modifier)) and chained variants
-            is KtDotQualifiedExpression -> {
-                // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
-                // we need to iterate until we find the start of the chain
-                val rootText = expression.rootExpression.text
-                rootText in modifierNames ||
-                    // Only scan .then() args when the chain root is a modifier parameter/alias
-                    // (already handled above) or looks like a type literal (uppercase first letter —
-                    // Modifier, BananaModifier, etc.). Lowercase roots that aren't known modifier
-                    // parameters are unrelated chains like somePipeline.then(modifier).
-                    (
-                        rootText.firstOrNull()?.isUpperCase() == true &&
-                            expression.hasModifierAsChainArgument(modifierNames)
-                        )
-            }
-
-            else -> false
+fun KtCallExpression.argumentsUsingModifiers(
+    modifierNames: Set<String>,
+    modifierTypeNames: Set<String> = ModifierNames,
+): List<KtValueArgument> = valueArguments.filter { argument ->
+    when (val expression = argument.getArgumentExpression()) {
+        // if it's MyComposable(modifier) or similar
+        is KtReferenceExpression -> {
+            expression.text in modifierNames
         }
+
+        // if it's MyComposable(modifier.fillMaxWidth()) or similar,
+        // also handles MyComposable(Modifier.then(modifier)) and chained variants
+        is KtDotQualifiedExpression -> {
+            // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
+            // we need to iterate until we find the start of the chain
+            val rootText = expression.rootExpression.text
+            rootText in modifierNames ||
+                // Only scan .then() args when the chain root is a known Modifier type literal
+                // (Modifier, GlanceModifier, or a configured custom modifier type). Guarding
+                // against exact type names prevents false positives from unrelated chains like
+                // SomePipeline.then(modifier) where the receiver is not a Modifier at all.
+                (rootText in modifierTypeNames && expression.hasModifierAsChainArgument(modifierNames))
+        }
+
+        else -> false
     }
+}
 
 // Checks if a modifier name appears as a direct argument to a .then() call anywhere in a
 // dot-qualified chain. Restricting to .then() avoids false positives from unrelated chains like
@@ -109,11 +110,14 @@ private val ModifierNames by lazy {
     )
 }
 
+fun modifierTypeNames(config: ComposeKtConfig): Set<String> =
+    ModifierNames + config.getSet("customModifiers", emptySet())
+
 fun KtCallableDeclaration.isModifier(config: ComposeKtConfig): Boolean =
-    typeReference?.text in ModifierNames + config.getSet("customModifiers", emptySet())
+    typeReference?.text in modifierTypeNames(config)
 
 fun KtCallableDeclaration.isModifierReceiver(config: ComposeKtConfig): Boolean =
-    receiverTypeReference?.text in ModifierNames + config.getSet("customModifiers", emptySet())
+    receiverTypeReference?.text in modifierTypeNames(config)
 
 fun KtFunction.modifierParameter(config: ComposeKtConfig): KtParameter? {
     val modifiers = valueParameters.filter { it.isModifier(config) }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -8,11 +8,13 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentName
+import org.jetbrains.kotlin.psi.psiUtil.parents
 
 /**
  *  Try to get all possible names by iterating on possible name reassignments until it's stable
@@ -24,12 +26,19 @@ fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> 
         lastSize = tempModifierNames.size
         // Find usages in the current block (the original composable)
         tempModifierNames += findModifierManipulations { tempModifierNames.contains(it) }
-        // Find usages in child composable blocks
+        // Find usages in child blocks, but skip any block inside a lambda that shadows a
+        // modifier name — aliases created there belong to the lambda's local modifier, not the
+        // outer composable's, so including them would cause false positives.
         tempModifierNames += findAllChildrenByClass<KtBlockExpression>()
+            .filter { block -> !block.isInsideShadowingLambda(tempModifierNames) }
             .flatMap { block -> block.findModifierManipulations { tempModifierNames.contains(it) } }
     }
     return tempModifierNames.toList()
 }
+
+private fun KtBlockExpression.isInsideShadowingLambda(modifierNames: Set<String>): Boolean =
+    parents.filterIsInstance<KtFunctionLiteral>()
+        .any { literal -> literal.valueParameters.any { param -> param.name in modifierNames } }
 
 /**
  * Find references to modifier as a property in case they try to modify or reuse the modifier that way

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -60,16 +60,38 @@ fun KtCallExpression.argumentsUsingModifiers(modifierNames: Set<String>): List<K
                 expression.text in modifierNames
             }
 
-            // if it's MyComposable(modifier.fillMaxWidth()) or similar
+            // if it's MyComposable(modifier.fillMaxWidth()) or similar,
+            // also handles MyComposable(Modifier.then(modifier)) and chained variants
             is KtDotQualifiedExpression -> {
                 // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
                 // we need to iterate until we find the start of the chain
-                expression.rootExpression.text in modifierNames
+                expression.rootExpression.text in modifierNames ||
+                    expression.hasModifierAsChainArgument(modifierNames)
             }
 
             else -> false
         }
     }
+
+// Checks if a modifier name appears as a direct argument anywhere in a dot-qualified chain.
+// Handles patterns like Modifier.then(modifier) and Modifier.fillMaxWidth().then(modifier).
+private fun KtDotQualifiedExpression.hasModifierAsChainArgument(modifierNames: Set<String>): Boolean {
+    var current: KtDotQualifiedExpression? = this
+    while (current != null) {
+        val selector = current.selectorExpression as? KtCallExpression
+        if (selector != null) {
+            for (arg in selector.valueArguments) {
+                when (val expr = arg.getArgumentExpression()) {
+                    is KtReferenceExpression -> if (expr.text in modifierNames) return true
+                    is KtDotQualifiedExpression -> if (expr.rootExpression.text in modifierNames) return true
+                    else -> {}
+                }
+            }
+        }
+        current = current.receiverExpression as? KtDotQualifiedExpression
+    }
+    return false
+}
 
 private val ModifierNames by lazy {
     setOf(

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -45,7 +45,18 @@ fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> 
 private fun KtBlockExpression.shadowedModifierNames(modifierNames: Set<String>): Set<String> =
     parents.filterIsInstance<KtFunctionLiteral>()
         .flatMap { literal ->
-            literal.valueParameters.mapNotNull { param -> param.name?.takeIf { it in modifierNames } }
+            literal.valueParameters.flatMap { param ->
+                when {
+                    param.name != null -> listOfNotNull(param.name.takeIf { it in modifierNames })
+
+                    // Destructured parameters like (modifier, _) store names in the declaration.
+                    param.destructuringDeclaration != null ->
+                        param.destructuringDeclaration!!.entries
+                            .mapNotNull { it.name?.takeIf { it in modifierNames } }
+
+                    else -> emptyList()
+                }
+            }
         }
         .toSet()
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -100,11 +100,16 @@ fun KtCallExpression.argumentsUsingModifiers(
             // we need to iterate until we find the start of the chain
             val rootText = expression.rootExpression.text
             rootText in modifierNames ||
-                // Only scan .then() args when the chain root is a known Modifier type literal
-                // (Modifier, GlanceModifier, or a configured custom modifier type). Guarding
-                // against exact type names prevents false positives from unrelated chains like
-                // SomePipeline.then(modifier) where the receiver is not a Modifier at all.
-                (rootText in modifierTypeNames && expression.hasModifierAsChainArgument(modifierNames))
+                // Scan .then() args when the chain root is a known Modifier type name
+                // (Modifier, GlanceModifier, or a configured custom modifier type) OR when
+                // the root starts with a lowercase letter (a local variable that may itself
+                // be a Modifier value, e.g. `val base = Modifier.padding(...); base.then(modifier)`).
+                // Uppercase-only roots that are not known type names (e.g. SomePipeline) are
+                // excluded to avoid false positives from non-Modifier chains.
+                (
+                    (rootText in modifierTypeNames || rootText.first().isLowerCase()) &&
+                        expression.hasModifierAsChainArgument(modifierNames)
+                    )
         }
 
         else -> false

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -109,15 +109,12 @@ fun KtCallExpression.argumentsUsingModifiers(
             val rootText = expression.rootExpression.text
             rootText in modifierNames ||
                 // Scan .then() args when the chain root is a known Modifier type name
-                // (Modifier, GlanceModifier, or a configured custom modifier type) OR when
-                // the root starts with a lowercase letter (a local variable that may itself
-                // be a Modifier value, e.g. `val base = Modifier.padding(...); base.then(modifier)`).
-                // Uppercase-only roots that are not known type names (e.g. SomePipeline) are
-                // excluded to avoid false positives from non-Modifier chains.
-                (
-                    (rootText in modifierTypeNames || rootText.first().isLowerCase()) &&
-                        expression.hasModifierAsChainArgument(modifierNames)
-                    )
+                // (Modifier, GlanceModifier, or a configured custom modifier type).
+                // Lowercase-rooted chains are excluded: without type resolution there is no
+                // reliable way to know whether an arbitrary local variable is a Modifier,
+                // so checking a lowercase root would produce false positives for non-Modifier
+                // factory patterns like `pipeline.then(modifier)`.
+                (rootText in modifierTypeNames && expression.hasModifierAsChainArgument(modifierNames))
         }
 
         else -> false

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -65,8 +65,11 @@ fun KtCallExpression.argumentsUsingModifiers(modifierNames: Set<String>): List<K
             is KtDotQualifiedExpression -> {
                 // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
                 // we need to iterate until we find the start of the chain
-                expression.rootExpression.text in modifierNames ||
-                    expression.hasModifierAsChainArgument(modifierNames)
+                val rootText = expression.rootExpression.text
+                rootText in modifierNames ||
+                    // Only scan chain arguments when the root is a known modifier type, to avoid
+                    // false positives from unrelated dot chains like PainterFactory.create(modifier)
+                    (rootText in ModifierNames && expression.hasModifierAsChainArgument(modifierNames))
             }
 
             else -> false

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -65,24 +65,22 @@ fun KtCallExpression.argumentsUsingModifiers(modifierNames: Set<String>): List<K
             is KtDotQualifiedExpression -> {
                 // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
                 // we need to iterate until we find the start of the chain
-                val rootText = expression.rootExpression.text
-                rootText in modifierNames ||
-                    // Only scan chain arguments when the root is a known modifier type, to avoid
-                    // false positives from unrelated dot chains like PainterFactory.create(modifier)
-                    (rootText in ModifierNames && expression.hasModifierAsChainArgument(modifierNames))
+                expression.rootExpression.text in modifierNames ||
+                    expression.hasModifierAsChainArgument(modifierNames)
             }
 
             else -> false
         }
     }
 
-// Checks if a modifier name appears as a direct argument anywhere in a dot-qualified chain.
-// Handles patterns like Modifier.then(modifier) and Modifier.fillMaxWidth().then(modifier).
+// Checks if a modifier name appears as a direct argument to a .then() call anywhere in a
+// dot-qualified chain. Restricting to .then() avoids false positives from unrelated chains like
+// PainterFactory.create(modifier) and automatically covers custom modifier types.
 private fun KtDotQualifiedExpression.hasModifierAsChainArgument(modifierNames: Set<String>): Boolean {
     var current: KtDotQualifiedExpression? = this
     while (current != null) {
         val selector = current.selectorExpression as? KtCallExpression
-        if (selector != null) {
+        if (selector?.calleeExpression?.text == "then") {
             for (arg in selector.valueArguments) {
                 when (val expr = arg.getArgumentExpression()) {
                     is KtReferenceExpression -> if (expr.text in modifierNames) return true

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -26,19 +26,28 @@ fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> 
         lastSize = tempModifierNames.size
         // Find usages in the current block (the original composable)
         tempModifierNames += findModifierManipulations { tempModifierNames.contains(it) }
-        // Find usages in child blocks, but skip any block inside a lambda that shadows a
-        // modifier name — aliases created there belong to the lambda's local modifier, not the
-        // outer composable's, so including them would cause false positives.
+        // Find usages in child blocks. For each child block, only search for aliases derived
+        // from outer modifier names that are not shadowed at that scope — shadowed names belong
+        // to the lambda's local modifier so aliases from them would cause false positives.
         tempModifierNames += findAllChildrenByClass<KtBlockExpression>()
-            .filter { block -> !block.isInsideShadowingLambda(tempModifierNames) }
-            .flatMap { block -> block.findModifierManipulations { tempModifierNames.contains(it) } }
+            .flatMap { block ->
+                val accessible = tempModifierNames - block.shadowedModifierNames(tempModifierNames)
+                if (accessible.isEmpty()) {
+                    emptyList()
+                } else {
+                    block.findModifierManipulations { it in accessible }
+                }
+            }
     }
     return tempModifierNames.toList()
 }
 
-private fun KtBlockExpression.isInsideShadowingLambda(modifierNames: Set<String>): Boolean =
+private fun KtBlockExpression.shadowedModifierNames(modifierNames: Set<String>): Set<String> =
     parents.filterIsInstance<KtFunctionLiteral>()
-        .any { literal -> literal.valueParameters.any { param -> param.name in modifierNames } }
+        .flatMap { literal ->
+            literal.valueParameters.mapNotNull { param -> param.name?.takeIf { it in modifierNames } }
+        }
+        .toSet()
 
 /**
  * Find references to modifier as a property in case they try to modify or reuse the modifier that way

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -65,8 +65,16 @@ fun KtCallExpression.argumentsUsingModifiers(modifierNames: Set<String>): List<K
             is KtDotQualifiedExpression -> {
                 // On cases of multiple nested KtDotQualifiedExpressions (e.g. multiple chained methods)
                 // we need to iterate until we find the start of the chain
-                expression.rootExpression.text in modifierNames ||
-                    expression.hasModifierAsChainArgument(modifierNames)
+                val rootText = expression.rootExpression.text
+                rootText in modifierNames ||
+                    // Only scan .then() args when the chain root is a modifier parameter/alias
+                    // (already handled above) or looks like a type literal (uppercase first letter —
+                    // Modifier, BananaModifier, etc.). Lowercase roots that aren't known modifier
+                    // parameters are unrelated chains like somePipeline.then(modifier).
+                    (
+                        rootText.firstOrNull()?.isUpperCase() == true &&
+                            expression.hasModifierAsChainArgument(modifierNames)
+                        )
             }
 
             else -> false

--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/Modifiers.kt
@@ -8,7 +8,6 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
@@ -20,6 +19,7 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  *  Try to get all possible names by iterating on possible name reassignments until it's stable
  */
 fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> {
+    val rootBlock = this
     var lastSize = 0
     val tempModifierNames = mutableSetOf(initialName)
     while (lastSize < tempModifierNames.size) {
@@ -28,10 +28,11 @@ fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> 
         tempModifierNames += findModifierManipulations { tempModifierNames.contains(it) }
         // Find usages in child blocks. For each child block, only search for aliases derived
         // from outer modifier names that are not shadowed at that scope — shadowed names belong
-        // to the lambda's local modifier so aliases from them would cause false positives.
+        // to the lambda's or nested function's local modifier so aliases from them would cause
+        // false positives.
         tempModifierNames += findAllChildrenByClass<KtBlockExpression>()
             .flatMap { block ->
-                val accessible = tempModifierNames - block.shadowedModifierNames(tempModifierNames)
+                val accessible = tempModifierNames - block.shadowedModifierNames(tempModifierNames, rootBlock)
                 if (accessible.isEmpty()) {
                     emptyList()
                 } else {
@@ -42,23 +43,30 @@ fun KtBlockExpression.obtainAllModifierNames(initialName: String): List<String> 
     return tempModifierNames.toList()
 }
 
-private fun KtBlockExpression.shadowedModifierNames(modifierNames: Set<String>): Set<String> =
-    parents.filterIsInstance<KtFunctionLiteral>()
-        .flatMap { literal ->
-            literal.valueParameters.flatMap { param ->
-                when {
-                    param.name != null -> listOfNotNull(param.name.takeIf { it in modifierNames })
+// Returns the set of modifier names that are shadowed at this block's scope, stopping at
+// stopAt (the outer composable's body block) to avoid including the composable's own parameters.
+// Checks both lambda literals (KtFunctionLiteral) and named nested functions (KtNamedFunction)
+// via their common supertype KtFunction.
+private fun KtBlockExpression.shadowedModifierNames(
+    modifierNames: Set<String>,
+    stopAt: KtBlockExpression,
+): Set<String> = parents.takeWhile { it != stopAt }
+    .filterIsInstance<KtFunction>()
+    .flatMap { func ->
+        func.valueParameters.flatMap { param ->
+            when {
+                param.name != null -> listOfNotNull(param.name.takeIf { it in modifierNames })
 
-                    // Destructured parameters like (modifier, _) store names in the declaration.
-                    param.destructuringDeclaration != null ->
-                        param.destructuringDeclaration!!.entries
-                            .mapNotNull { it.name?.takeIf { it in modifierNames } }
+                // Destructured parameters like (modifier, _) store names in the declaration.
+                param.destructuringDeclaration != null ->
+                    param.destructuringDeclaration!!.entries
+                        .mapNotNull { it.name?.takeIf { it in modifierNames } }
 
-                    else -> emptyList()
-                }
+                else -> emptyList()
             }
         }
-        .toSet()
+    }
+    .toSet()
 
 /**
  * Find references to modifier as a property in case they try to modify or reuse the modifier that way

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -15,8 +15,12 @@ import io.nlopez.compose.core.util.mapSecond
 import io.nlopez.compose.core.util.modifierParameter
 import io.nlopez.compose.core.util.modifierTypeNames
 import io.nlopez.compose.core.util.obtainAllModifierNames
+import io.nlopez.compose.core.util.rootExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtFunctionLiteral
+import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
 class ModifierNotUsedAtRoot : ComposeKtVisitor {
@@ -34,8 +38,20 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
         val errors = code.findAllChildrenByClass<KtCallExpression>()
             .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
             .mapNotNull { callExpression ->
-                callExpression.argumentsUsingModifiers(modifiers, typeNames).firstOrNull()
-                    ?.let { usage -> callExpression to usage }
+                // When a call has multiple modifier-using arguments and the first belongs to a
+                // shadowed lambda parameter, firstOrNull() would report at the wrong location.
+                // Prefer the first argument whose modifier is not from a shadow scope.
+                val args = callExpression.argumentsUsingModifiers(modifiers, typeNames)
+                if (args.isEmpty()) return@mapNotNull null
+                val shadowedNames = callExpression.shadowedModifierNamesUpTo(function, modifiers)
+                val usage = args.firstOrNull { arg ->
+                    when (val expr = arg.getArgumentExpression()) {
+                        is KtReferenceExpression -> expr.text !in shadowedNames
+                        is KtDotQualifiedExpression -> expr.rootExpression.text !in shadowedNames
+                        else -> true
+                    }
+                } ?: args.first()
+                callExpression to usage
             }
             .filterNot { (callExpression, _) -> callExpression.isFullyShadowed(modifiers, function, typeNames) }
             .filter { (callExpression, _) ->
@@ -53,6 +69,24 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
             emitter.report(valueArgument, ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
         }
     }
+
+    private fun KtCallExpression.shadowedModifierNamesUpTo(stopAt: KtFunction, modifiers: Set<String>): Set<String> =
+        parents.takeWhile { it != stopAt }
+            .filterIsInstance<KtFunctionLiteral>()
+            .flatMap { literal ->
+                literal.valueParameters.flatMap { param ->
+                    when {
+                        param.name != null -> listOfNotNull(param.name.takeIf { it in modifiers })
+
+                        param.destructuringDeclaration != null ->
+                            param.destructuringDeclaration!!.entries
+                                .mapNotNull { it.name?.takeIf { it in modifiers } }
+
+                        else -> emptyList()
+                    }
+                }
+            }
+            .toSet()
 
     companion object {
         val ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace = """

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -9,6 +9,7 @@ import io.nlopez.compose.core.report
 import io.nlopez.compose.core.util.argumentsUsingModifiers
 import io.nlopez.compose.core.util.emitsContent
 import io.nlopez.compose.core.util.findAllChildrenByClass
+import io.nlopez.compose.core.util.isAnyShadowed
 import io.nlopez.compose.core.util.isInContentEmittersDenylist
 import io.nlopez.compose.core.util.mapSecond
 import io.nlopez.compose.core.util.modifierParameter
@@ -34,6 +35,7 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
                 callExpression.argumentsUsingModifiers(modifiers).firstOrNull()
                     ?.let { usage -> callExpression to usage }
             }
+            .filterNot { (callExpression, _) -> callExpression.isAnyShadowed(modifiers, function) }
             .filter { (callExpression, _) ->
                 // we'll need to traverse upwards to the composable root and check if there is any parent that
                 // emits content: if this is the case, the main modifier should be used there instead.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -9,7 +9,7 @@ import io.nlopez.compose.core.report
 import io.nlopez.compose.core.util.argumentsUsingModifiers
 import io.nlopez.compose.core.util.emitsContent
 import io.nlopez.compose.core.util.findAllChildrenByClass
-import io.nlopez.compose.core.util.isAnyShadowed
+import io.nlopez.compose.core.util.isFullyShadowed
 import io.nlopez.compose.core.util.isInContentEmittersDenylist
 import io.nlopez.compose.core.util.mapSecond
 import io.nlopez.compose.core.util.modifierParameter
@@ -35,7 +35,7 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
                 callExpression.argumentsUsingModifiers(modifiers).firstOrNull()
                     ?.let { usage -> callExpression to usage }
             }
-            .filterNot { (callExpression, _) -> callExpression.isAnyShadowed(modifiers, function) }
+            .filterNot { (callExpression, _) -> callExpression.isFullyShadowed(modifiers, function) }
             .filter { (callExpression, _) ->
                 // we'll need to traverse upwards to the composable root and check if there is any parent that
                 // emits content: if this is the case, the main modifier should be used there instead.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -19,7 +19,6 @@ import io.nlopez.compose.core.util.rootExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFunction
-import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
@@ -72,9 +71,9 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
 
     private fun KtCallExpression.shadowedModifierNamesUpTo(stopAt: KtFunction, modifiers: Set<String>): Set<String> =
         parents.takeWhile { it != stopAt }
-            .filterIsInstance<KtFunctionLiteral>()
-            .flatMap { literal ->
-                literal.valueParameters.flatMap { param ->
+            .filterIsInstance<KtFunction>()
+            .flatMap { func ->
+                func.valueParameters.flatMap { param ->
                     when {
                         param.name != null -> listOfNotNull(param.name.takeIf { it in modifiers })
 

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -37,7 +37,7 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
                 callExpression.argumentsUsingModifiers(modifiers, typeNames).firstOrNull()
                     ?.let { usage -> callExpression to usage }
             }
-            .filterNot { (callExpression, _) -> callExpression.isFullyShadowed(modifiers, function) }
+            .filterNot { (callExpression, _) -> callExpression.isFullyShadowed(modifiers, function, typeNames) }
             .filter { (callExpression, _) ->
                 // we'll need to traverse upwards to the composable root and check if there is any parent that
                 // emits content: if this is the case, the main modifier should be used there instead.

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierNotUsedAtRoot.kt
@@ -13,6 +13,7 @@ import io.nlopez.compose.core.util.isFullyShadowed
 import io.nlopez.compose.core.util.isInContentEmittersDenylist
 import io.nlopez.compose.core.util.mapSecond
 import io.nlopez.compose.core.util.modifierParameter
+import io.nlopez.compose.core.util.modifierTypeNames
 import io.nlopez.compose.core.util.obtainAllModifierNames
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFunction
@@ -28,11 +29,12 @@ class ModifierNotUsedAtRoot : ComposeKtVisitor {
         val code = function.bodyBlockExpression ?: return
 
         val modifiers = code.obtainAllModifierNames("modifier").toSet()
+        val typeNames = modifierTypeNames(config)
 
         val errors = code.findAllChildrenByClass<KtCallExpression>()
             .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
             .mapNotNull { callExpression ->
-                callExpression.argumentsUsingModifiers(modifiers).firstOrNull()
+                callExpression.argumentsUsingModifiers(modifiers, typeNames).firstOrNull()
                     ?.let { usage -> callExpression to usage }
             }
             .filterNot { (callExpression, _) -> callExpression.isFullyShadowed(modifiers, function) }

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -11,6 +11,7 @@ import io.nlopez.compose.core.util.findAllChildrenByClass
 import io.nlopez.compose.core.util.isFullyShadowed
 import io.nlopez.compose.core.util.isUsingModifiers
 import io.nlopez.compose.core.util.modifierParameters
+import io.nlopez.compose.core.util.modifierTypeNames
 import io.nlopez.compose.core.util.obtainAllModifierNames
 import io.nlopez.compose.core.util.walkBackwards
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -26,6 +27,7 @@ class ModifierReused : ComposeKtVisitor {
         val composableBlockExpression = function.bodyBlockExpression ?: return
         val initialModifierNames = function.modifierParameters(config).mapNotNull { it.name }.toSet()
         if (initialModifierNames.isEmpty()) return
+        val typeNames = modifierTypeNames(config)
 
         initialModifierNames
             .map {
@@ -36,14 +38,14 @@ class ModifierReused : ComposeKtVisitor {
                 // Find all composable-looking CALL_EXPRESSIONs that are using any of these modifier names
                 composableBlockExpression.findAllChildrenByClass<KtCallExpression>()
                     .filter { it.calleeExpression?.text?.first()?.isUpperCase() == true }
-                    .filter { it.isUsingModifiers(modifierNames) }
+                    .filter { it.isUsingModifiers(modifierNames, typeNames) }
                     // For those modifiers, we look at the parents and see if any of them is a function that has a param with
                     //  the same name.
                     .filterNot { it.isFullyShadowed(modifierNames, function) }
                     .map { callExpression ->
                         fun Sequence<PsiElement>.modifierUsagesSet(): Set<KtCallExpression> =
                             filterIsInstance<KtCallExpression>()
-                                .filter { it.isUsingModifiers(modifierNames) }
+                                .filter { it.isUsingModifiers(modifierNames, typeNames) }
                                 .toSet()
 
                         // To get an accurate count (and respecting if/when/whatever different branches)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -46,6 +46,7 @@ class ModifierReused : ComposeKtVisitor {
                         fun Sequence<PsiElement>.modifierUsagesSet(): Set<KtCallExpression> =
                             filterIsInstance<KtCallExpression>()
                                 .filter { it.isUsingModifiers(modifierNames, typeNames) }
+                                .filterNot { it.isFullyShadowed(modifierNames, function, typeNames) }
                                 .toSet()
 
                         // To get an accurate count (and respecting if/when/whatever different branches)

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -41,7 +41,7 @@ class ModifierReused : ComposeKtVisitor {
                     .filter { it.isUsingModifiers(modifierNames, typeNames) }
                     // For those modifiers, we look at the parents and see if any of them is a function that has a param with
                     //  the same name.
-                    .filterNot { it.isFullyShadowed(modifierNames, function) }
+                    .filterNot { it.isFullyShadowed(modifierNames, function, typeNames) }
                     .map { callExpression ->
                         fun Sequence<PsiElement>.modifierUsagesSet(): Set<KtCallExpression> =
                             filterIsInstance<KtCallExpression>()

--- a/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/rules/ModifierReused.kt
@@ -8,7 +8,7 @@ import io.nlopez.compose.core.ComposeKtVisitor
 import io.nlopez.compose.core.Emitter
 import io.nlopez.compose.core.util.emitsContent
 import io.nlopez.compose.core.util.findAllChildrenByClass
-import io.nlopez.compose.core.util.isAnyShadowed
+import io.nlopez.compose.core.util.isFullyShadowed
 import io.nlopez.compose.core.util.isUsingModifiers
 import io.nlopez.compose.core.util.modifierParameters
 import io.nlopez.compose.core.util.obtainAllModifierNames
@@ -39,7 +39,7 @@ class ModifierReused : ComposeKtVisitor {
                     .filter { it.isUsingModifiers(modifierNames) }
                     // For those modifiers, we look at the parents and see if any of them is a function that has a param with
                     //  the same name.
-                    .filterNot { it.isAnyShadowed(modifierNames, function) }
+                    .filterNot { it.isFullyShadowed(modifierNames, function) }
                     .map { callExpression ->
                         fun Sequence<PsiElement>.modifierUsagesSet(): Set<KtCallExpression> =
                             filterIsInstance<KtCallExpression>()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
@@ -188,6 +188,27 @@ class ModifierNotUsedAtRootCheckTest {
     }
 
     @Test
+    fun `errors when modifier is passed via a local-var-rooted then chain at a non-root level`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Column {
+                        val base = Modifier.padding(8.dp)
+                        Row(modifier = base.then(modifier)) {}
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(SourceLocation(5, 13))
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
+        }
+    }
+
+    @Test
     fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
@@ -177,4 +177,27 @@ class ModifierNotUsedAtRootCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val rootModifier = modifier
+                    Column {
+                        Slot { modifier: Modifier ->
+                            Child(modifier = rootModifier, extra = modifier)
+                        }
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(SourceLocation(6, 19))
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
+        }
+    }
 }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
@@ -179,6 +179,29 @@ class ModifierNotUsedAtRootCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val rootModifier = modifier
+                    Column {
+                        Slot { modifier: Modifier ->
+                            Child(modifier = modifier.then(rootModifier))
+                        }
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(SourceLocation(6, 19))
+        for (error in errors) {
+            assertThat(error).hasMessage(ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
+        }
+    }
+
+    @Test
     fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
@@ -188,27 +188,6 @@ class ModifierNotUsedAtRootCheckTest {
     }
 
     @Test
-    fun `errors when modifier is passed via a local-var-rooted then chain at a non-root level`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something(modifier: Modifier = Modifier) {
-                    Column {
-                        val base = Modifier.padding(8.dp)
-                        Row(modifier = base.then(modifier)) {}
-                    }
-                }
-            """.trimIndent()
-        val errors = rule.lint(code)
-        assertThat(errors)
-            .hasStartSourceLocations(SourceLocation(5, 13))
-        for (error in errors) {
-            assertThat(error).hasMessage(ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace)
-        }
-    }
-
-    @Test
     fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
@@ -159,4 +159,22 @@ class ModifierNotUsedAtRootCheckTest {
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }
+
+    @Test
+    fun `passes when modifier is used via Modifier dot then inside a shadowing lambda`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Column(modifier = modifier) {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = Modifier.then(modifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
 }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierNotUsedAtRootCheckTest.kt
@@ -173,6 +173,15 @@ class ModifierNotUsedAtRootCheckTest {
                         }
                     }
                 }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Column(modifier = modifier) {
+                        Slot { (modifier, _) ->
+                            val local = modifier.padding(8.dp)
+                            Row(modifier = Modifier.then(local)) {}
+                        }
+                    }
+                }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -262,6 +262,33 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = modifier.then(rootModifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 5),
+                SourceLocation(6, 13),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierReused.ModifierShouldBeUsedOnceOnly)
+        }
+    }
+
+    @Test
     fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -360,20 +360,42 @@ class ModifierReusedCheckTest {
     }
 
     @Test
-    fun `passes when modifier is an argument to an unrelated dot then call`() {
+    fun `passes when modifier is an argument to an uppercase-rooted unrelated dot then call`() {
         @Language("kotlin")
         val code =
             """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
-                        Child(model = somePipeline.then(modifier))
                         Child(model = SomePipeline.then(modifier))
                     }
                 }
             """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `errors when modifier is passed as an argument to a local-var-rooted then chain`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val base = Modifier.padding(8.dp)
+                    Row(modifier = base.then(modifier)) {}
+                    Column(modifier = modifier) {}
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 5),
+                SourceLocation(5, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierReused.ModifierShouldBeUsedOnceOnly)
+        }
     }
 
     @Test

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -340,6 +340,7 @@ class ModifierReusedCheckTest {
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
                         Child(model = somePipeline.then(modifier))
+                        Child(model = SomePipeline.then(modifier))
                     }
                 }
             """.trimIndent()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -235,6 +235,22 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when modifier is used as an argument to a non-modifier factory function`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Icon(painter = PainterFactory.create(modifier))
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
     fun `passes when modifiers are reused for mutually exclusive branches`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -582,6 +582,26 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when a shadowed then-chain in the same lambda block does not inflate the reuse count`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val rootModifier = modifier
+                    Column {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = Modifier.then(modifier)) {}
+                            Box(modifier = rootModifier) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
     fun `passes when the modifier is followed by an early return`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -507,6 +507,15 @@ class ModifierReusedCheckTest {
                         }
                     }
                 }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        Slot { (modifier, _) ->
+                            val local = modifier.padding(8.dp)
+                            Row(modifier = Modifier.then(local)) {}
+                        }
+                    }
+                }
             """.trimIndent()
 
         val errors = rule.lint(code)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -293,6 +293,37 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when modifier is passed as an argument to Modifier dot then`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier = Modifier.then(modifier)) {
+                        Column(modifier = modifier) {}
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier = Modifier.fillMaxWidth().then(modifier)) {}
+                    Column(modifier = modifier) {}
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(3, 5),
+                SourceLocation(4, 9),
+                SourceLocation(9, 5),
+                SourceLocation(10, 5),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierReused.ModifierShouldBeUsedOnceOnly)
+        }
+    }
+
+    @Test
     fun `passes when the modifier parameter of a Composable is shadowed`() {
         @Language("kotlin")
         val code =
@@ -317,6 +348,12 @@ class ModifierReusedCheckTest {
                 fun Something(modifier: Modifier) {
                     Column(modifier) {
                         Bleh { modifier -> Potato(modifier) }
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Bleh { modifier: Modifier -> Row(modifier = Modifier.then(modifier)) }
                     }
                 }
             """.trimIndent()

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -332,6 +332,22 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when modifier is an argument to an unrelated dot then call`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Child(model = somePipeline.then(modifier))
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
     fun `passes when modifiers are reused for mutually exclusive branches`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -376,29 +376,6 @@ class ModifierReusedCheckTest {
     }
 
     @Test
-    fun `errors when modifier is passed as an argument to a local-var-rooted then chain`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something(modifier: Modifier) {
-                    val base = Modifier.padding(8.dp)
-                    Row(modifier = base.then(modifier)) {}
-                    Column(modifier = modifier) {}
-                }
-            """.trimIndent()
-        val errors = rule.lint(code)
-        assertThat(errors)
-            .hasStartSourceLocations(
-                SourceLocation(4, 5),
-                SourceLocation(5, 5),
-            )
-        for (error in errors) {
-            assertThat(error).hasMessage(ModifierReused.ModifierShouldBeUsedOnceOnly)
-        }
-    }
-
-    @Test
     fun `passes when modifiers are reused for mutually exclusive branches`() {
         @Language("kotlin")
         val code =
@@ -540,25 +517,6 @@ class ModifierReusedCheckTest {
                 }
             """.trimIndent()
 
-        val errors = rule.lint(code)
-        assertThat(errors).isEmpty()
-    }
-
-    @Test
-    fun `passes when modifier appears in a local-var-rooted then chain inside a shadowing lambda`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something(modifier: Modifier) {
-                    Column(modifier = modifier) {
-                        Slot { modifier: Modifier ->
-                            val base = Modifier
-                            Row(modifier = base.then(modifier)) {}
-                        }
-                    }
-                }
-            """.trimIndent()
         val errors = rule.lint(code)
         assertThat(errors).isEmpty()
     }

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -235,6 +235,34 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias derived inside a shadow lambda is also reused`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            val childModifier = rootModifier.padding(8.dp)
+                            Row(modifier = childModifier) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 5),
+                SourceLocation(7, 13),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierReused.ModifierShouldBeUsedOnceOnly)
+        }
+    }
+
+    @Test
     fun `errors when modifier alias is reused even when combined with a shadowed modifier in then`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -545,6 +545,43 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when modifier appears in a local-var-rooted then chain inside a shadowing lambda`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Slot { modifier: Modifier ->
+                            val base = Modifier
+                            Row(modifier = base.then(modifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `passes when modifier is used only in a nested local function with its own modifier parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    @Composable fun Local(modifier: Modifier) {
+                        val local = modifier.padding(8.dp)
+                        Row(modifier = Modifier.then(local)) {}
+                    }
+                    Column(modifier = modifier) {}
+                }
+            """.trimIndent()
+        val errors = rule.lint(code)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
     fun `passes when the modifier is followed by an early return`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -262,6 +262,33 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            Child(modifier = rootModifier, extra = modifier)
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 5),
+                SourceLocation(6, 13),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierReused.ModifierShouldBeUsedOnceOnly)
+        }
+    }
+
+    @Test
     fun `passes when modifier is used as an argument to a non-modifier factory function`() {
         @Language("kotlin")
         val code =

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -470,6 +470,15 @@ class ModifierReusedCheckTest {
                         Bleh { modifier: Modifier -> Row(modifier = Modifier.then(modifier)) }
                     }
                 }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        Slot { modifier: Modifier ->
+                            val local = modifier.padding(8.dp)
+                            Row(modifier = Modifier.then(local)) {}
+                        }
+                    }
+                }
             """.trimIndent()
 
         val errors = rule.lint(code)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/ModifierReusedCheckTest.kt
@@ -235,6 +235,33 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when modifier alias is reused even when combined with a shadowed modifier in then`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = rootModifier.then(modifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        val errors = rule.lint(code)
+        assertThat(errors)
+            .hasStartSourceLocations(
+                SourceLocation(4, 5),
+                SourceLocation(6, 13),
+            )
+        for (error in errors) {
+            assertThat(error).hasMessage(ModifierReused.ModifierShouldBeUsedOnceOnly)
+        }
+    }
+
+    @Test
     fun `passes when modifier is used as an argument to a non-modifier factory function`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
@@ -204,6 +204,32 @@ class ModifierNotUsedAtRootCheckTest {
     }
 
     @Test
+    fun `errors when modifier is passed via a local-var-rooted then chain at a non-root level`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Column {
+                        val base = Modifier.padding(8.dp)
+                        Row(modifier = base.then(modifier)) {}
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .withEditorConfigOverride(
+                contentEmittersProperty to "Potato,Banana",
+            )
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 5,
+                    col = 13,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+            )
+    }
+
+    @Test
     fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
@@ -176,4 +176,21 @@ class ModifierNotUsedAtRootCheckTest {
             )
             .hasNoLintViolations()
     }
+
+    @Test
+    fun `passes when modifier is used via Modifier dot then inside a shadowing lambda`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Column(modifier = modifier) {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = Modifier.then(modifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
@@ -195,6 +195,31 @@ class ModifierNotUsedAtRootCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val rootModifier = modifier
+                    Column {
+                        Slot { modifier: Modifier ->
+                            Child(modifier = modifier.then(rootModifier))
+                        }
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 6,
+                    col = 19,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+            )
+    }
+
+    @Test
     fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
@@ -204,32 +204,6 @@ class ModifierNotUsedAtRootCheckTest {
     }
 
     @Test
-    fun `errors when modifier is passed via a local-var-rooted then chain at a non-root level`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something(modifier: Modifier = Modifier) {
-                    Column {
-                        val base = Modifier.padding(8.dp)
-                        Row(modifier = base.then(modifier)) {}
-                    }
-                }
-            """.trimIndent()
-        modifierRuleAssertThat(code)
-            .withEditorConfigOverride(
-                contentEmittersProperty to "Potato,Banana",
-            )
-            .hasLintViolationsWithoutAutoCorrect(
-                LintViolation(
-                    line = 5,
-                    col = 13,
-                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
-                ),
-            )
-    }
-
-    @Test
     fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
@@ -193,4 +193,29 @@ class ModifierNotUsedAtRootCheckTest {
             """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
     }
+
+    @Test
+    fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val rootModifier = modifier
+                    Column {
+                        Slot { modifier: Modifier ->
+                            Child(modifier = rootModifier, extra = modifier)
+                        }
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code)
+            .hasLintViolationsWithoutAutoCorrect(
+                LintViolation(
+                    line = 6,
+                    col = 19,
+                    detail = ComposableModifierShouldBeUsedAtTheTopMostPossiblePlace,
+                ),
+            )
+    }
 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierNotUsedAtRootCheckTest.kt
@@ -190,6 +190,15 @@ class ModifierNotUsedAtRootCheckTest {
                         }
                     }
                 }
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    Column(modifier = modifier) {
+                        Slot { (modifier, _) ->
+                            val local = modifier.padding(8.dp)
+                            Row(modifier = Modifier.then(local)) {}
+                        }
+                    }
+                }
             """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
     }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -588,6 +588,15 @@ class ModifierReusedCheckTest {
                         Bleh { modifier: Modifier -> Row(modifier = Modifier.then(modifier)) }
                     }
                 }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        Slot { modifier: Modifier ->
+                            val local = modifier.padding(8.dp)
+                            Row(modifier = Modifier.then(local)) {}
+                        }
+                    }
+                }
             """.trimIndent()
 
         modifierRuleAssertThat(code).hasNoLintViolations()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -337,6 +337,29 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias derived inside a shadow lambda is also reused`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            val childModifier = rootModifier.padding(8.dp)
+                            Row(modifier = childModifier) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(4, 5, ModifierReused.ModifierShouldBeUsedOnceOnly),
+            LintViolation(7, 13, ModifierReused.ModifierShouldBeUsedOnceOnly),
+        )
+    }
+
+    @Test
     fun `errors when modifier alias is reused even when combined with a shadowed modifier in then`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -660,6 +660,41 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when modifier appears in a local-var-rooted then chain inside a shadowing lambda`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Slot { modifier: Modifier ->
+                            val base = Modifier
+                            Row(modifier = base.then(modifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `passes when modifier is used only in a nested local function with its own modifier parameter`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    @Composable fun Local(modifier: Modifier) {
+                        val local = modifier.padding(8.dp)
+                        Row(modifier = Modifier.then(local)) {}
+                    }
+                    Column(modifier = modifier) {}
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `passes when the modifier is followed by an early return`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -337,6 +337,21 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when modifier is used as an argument to a non-modifier factory function`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Icon(painter = PainterFactory.create(modifier))
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `passes when modifiers are reused for mutually exclusive branches`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -450,6 +450,7 @@ class ModifierReusedCheckTest {
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
                         Child(model = somePipeline.then(modifier))
+                        Child(model = SomePipeline.then(modifier))
                     }
                 }
             """.trimIndent()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -480,32 +480,6 @@ class ModifierReusedCheckTest {
     }
 
     @Test
-    fun `errors when modifier is passed as an argument to a local-var-rooted then chain`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something(modifier: Modifier) {
-                    val base = Modifier.padding(8.dp)
-                    Row(modifier = base.then(modifier)) {}
-                    Column(modifier = modifier) {}
-                }
-            """.trimIndent()
-        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
-            LintViolation(
-                line = 4,
-                col = 5,
-                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
-            ),
-            LintViolation(
-                line = 5,
-                col = 5,
-                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
-            ),
-        )
-    }
-
-    @Test
     fun `passes when modifiers are reused for mutually exclusive branches`() {
         @Language("kotlin")
         val code =
@@ -656,24 +630,6 @@ class ModifierReusedCheckTest {
                 }
             """.trimIndent()
 
-        modifierRuleAssertThat(code).hasNoLintViolations()
-    }
-
-    @Test
-    fun `passes when modifier appears in a local-var-rooted then chain inside a shadowing lambda`() {
-        @Language("kotlin")
-        val code =
-            """
-                @Composable
-                fun Something(modifier: Modifier) {
-                    Column(modifier = modifier) {
-                        Slot { modifier: Modifier ->
-                            val base = Modifier
-                            Row(modifier = base.then(modifier)) {}
-                        }
-                    }
-                }
-            """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
     }
 

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -442,6 +442,21 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when modifier is an argument to an unrelated dot then call`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Child(model = somePipeline.then(modifier))
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `passes when modifiers are reused for mutually exclusive branches`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -465,19 +465,44 @@ class ModifierReusedCheckTest {
     }
 
     @Test
-    fun `passes when modifier is an argument to an unrelated dot then call`() {
+    fun `passes when modifier is an argument to an uppercase-rooted unrelated dot then call`() {
         @Language("kotlin")
         val code =
             """
                 @Composable
                 fun Something(modifier: Modifier) {
                     Column(modifier = modifier) {
-                        Child(model = somePipeline.then(modifier))
                         Child(model = SomePipeline.then(modifier))
                     }
                 }
             """.trimIndent()
         modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
+    fun `errors when modifier is passed as an argument to a local-var-rooted then chain`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val base = Modifier.padding(8.dp)
+                    Row(modifier = base.then(modifier)) {}
+                    Column(modifier = modifier) {}
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 4,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+            LintViolation(
+                line = 5,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+        )
     }
 
     @Test

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -367,6 +367,36 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            Child(modifier = rootModifier, extra = modifier)
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 4,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+            LintViolation(
+                line = 6,
+                col = 13,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+        )
+    }
+
+    @Test
     fun `passes when modifier is used as an argument to a non-modifier factory function`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -337,6 +337,36 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when modifier alias is reused even when combined with a shadowed modifier in then`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = rootModifier.then(modifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 4,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+            LintViolation(
+                line = 6,
+                col = 13,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+        )
+    }
+
+    @Test
     fun `passes when modifier is used as an argument to a non-modifier factory function`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -367,6 +367,36 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when outer modifier alias is in then arg and shadowed modifier is chain receiver`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    val rootModifier = modifier
+                    Column(modifier = rootModifier) {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = modifier.then(rootModifier)) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 4,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+            LintViolation(
+                line = 6,
+                col = 13,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+        )
+    }
+
+    @Test
     fun `errors when outer modifier alias is passed alongside a shadowed modifier in a multi-arg call`() {
         @Language("kotlin")
         val code =

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -393,6 +393,48 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `errors when modifier is passed as an argument to Modifier dot then`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier = Modifier.then(modifier)) {
+                        Column(modifier = modifier) {}
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier = Modifier.fillMaxWidth().then(modifier)) {}
+                    Column(modifier = modifier) {}
+                }
+            """.trimIndent()
+
+        modifierRuleAssertThat(code).hasLintViolationsWithoutAutoCorrect(
+            LintViolation(
+                line = 3,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+            LintViolation(
+                line = 4,
+                col = 9,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+            LintViolation(
+                line = 9,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+            LintViolation(
+                line = 10,
+                col = 5,
+                detail = ModifierReused.ModifierShouldBeUsedOnceOnly,
+            ),
+        )
+    }
+
+    @Test
     fun `passes when the modifier parameter of a Composable is shadowed`() {
         @Language("kotlin")
         val code =
@@ -417,6 +459,12 @@ class ModifierReusedCheckTest {
                 fun Something(modifier: Modifier) {
                     Column(modifier) {
                         Bleh { modifier -> Potato(modifier) }
+                    }
+                }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Column(modifier = modifier) {
+                        Bleh { modifier: Modifier -> Row(modifier = Modifier.then(modifier)) }
                     }
                 }
             """.trimIndent()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -620,6 +620,15 @@ class ModifierReusedCheckTest {
                         }
                     }
                 }
+                @Composable
+                fun Something(modifier: Modifier) {
+                    Row(modifier) {
+                        Slot { (modifier, _) ->
+                            val local = modifier.padding(8.dp)
+                            Row(modifier = Modifier.then(local)) {}
+                        }
+                    }
+                }
             """.trimIndent()
 
         modifierRuleAssertThat(code).hasNoLintViolations()

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/ModifierReusedCheckTest.kt
@@ -695,6 +695,25 @@ class ModifierReusedCheckTest {
     }
 
     @Test
+    fun `passes when a shadowed then-chain in the same lambda block does not inflate the reuse count`() {
+        @Language("kotlin")
+        val code =
+            """
+                @Composable
+                fun Something(modifier: Modifier = Modifier) {
+                    val rootModifier = modifier
+                    Column {
+                        Slot { modifier: Modifier ->
+                            Row(modifier = Modifier.then(modifier)) {}
+                            Box(modifier = rootModifier) {}
+                        }
+                    }
+                }
+            """.trimIndent()
+        modifierRuleAssertThat(code).hasNoLintViolations()
+    }
+
+    @Test
     fun `passes when the modifier is followed by an early return`() {
         @Language("kotlin")
         val code =


### PR DESCRIPTION
Previously the ModifierReused rule missed cases where the modifier
parameter was passed as an argument inside a chain (e.g.
`Modifier.then(modifier)` or `Modifier.fillMaxWidth().then(modifier)`)
rather than as the chain's receiver. Only the root expression was
checked, which evaluates to `"Modifier"` (the type) instead of
`"modifier"` (the parameter).

- Add `hasModifierAsChainArgument` in `Modifiers.kt` to walk the entire
  dot-qualified chain and inspect each call's value arguments
- Update `parameterNamesUsedIn` in `KtCallExpressions.kt` with the same
  traversal so `isAnyShadowed` remains accurate for nested lambdas
- Add test cases for both detekt and ktlint covering error and shadowing
  edge cases