### PR TITLE
Ignore unsigned integer literals for autoboxing checks

### DIFF
--- a/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtConstantExpressions.kt
+++ b/rules/common/src/main/kotlin/io/nlopez/compose/core/util/KtConstantExpressions.kt
@@ -6,10 +6,10 @@ import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.psi.KtConstantExpression
 
 val KtConstantExpression.isInt: Boolean
-    get() = isIntegerConstant && !isLong
+    get() = isIntegerConstant && !isLong && !isUnsignedInteger
 
 val KtConstantExpression.isLong: Boolean
-    get() = isIntegerConstant && text.endsWith("L")
+    get() = isIntegerConstant && text.endsWith("L") && !isUnsignedInteger
 
 val KtConstantExpression.isDouble: Boolean
     get() = isFloatConstant && !isFloat
@@ -22,3 +22,6 @@ private val KtConstantExpression.isIntegerConstant: Boolean
 
 private val KtConstantExpression.isFloatConstant: Boolean
     get() = node.elementType == KtNodeTypes.FLOAT_CONSTANT
+
+private val KtConstantExpression.isUnsignedInteger: Boolean
+    get() = text.endsWith("U", ignoreCase = true) || text.endsWith("UL", ignoreCase = true)

--- a/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheckTest.kt
+++ b/rules/detekt/src/test/kotlin/io/nlopez/compose/rules/detekt/MutableStateAutoboxingCheckTest.kt
@@ -206,6 +206,10 @@ class MutableStateAutoboxingCheckTest {
             """
                 var a by mutableStateOf("")
                 var b by mutableStateOf(true)
+                var c by remember { mutableStateOf(0U) }
+                var d by mutableStateOf(0u)
+                var e by mutableStateOf(0UL)
+                var f by mutableStateOf(0uL)
                 fun bleh(c: String) {
                     var ccc by mutableStateOf(c)
                 }

--- a/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheckTest.kt
+++ b/rules/ktlint/src/test/kotlin/io/nlopez/compose/rules/ktlint/MutableStateAutoboxingCheckTest.kt
@@ -303,6 +303,10 @@ class MutableStateAutoboxingCheckTest {
             """
                 var a by mutableStateOf("")
                 var b by mutableStateOf(true)
+                var c by remember { mutableStateOf(0U) }
+                var d by mutableStateOf(0u)
+                var e by mutableStateOf(0UL)
+                var f by mutableStateOf(0uL)
                 fun bleh(c: String) {
                     var ccc by mutableStateOf(c)
                 }


### PR DESCRIPTION
Unsigned integer state has no primitive Compose state alternative, so treating
UInt and ULong literals as Int or Long produces incorrect autoboxing reports.

Fixes #676